### PR TITLE
Implement explicit null checks for loads/stores

### DIFF
--- a/Documentation/llilc-jit-eh.md
+++ b/Documentation/llilc-jit-eh.md
@@ -525,14 +525,14 @@ Once correct EH support is enabled and pushed back up to the master branch,
 EH-centric optimizations and support for other targets will follow.
 
 The current status is that the stub EH support is implemented with support
-for explicit throws but not implicit exceptions.
+for explicit throws and some but not all implicit exceptions.
 
 In summary, the plan/status is:
  1. [ ] Stub EH support
    - [x] Reader discards handlers
    - [x] Explicit throw becomes helper call
    - [ ] Implicit exceptions expanded to explicit test/throw sequences
-     - [ ] Null dereference
+     - [x] Null dereference
      - [ ] Divide by zero
      - [ ] Arithmetic overflow
      - [ ] Convert with overflow

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Add1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Add1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/And1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/And1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AndRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AndRef.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6896,11 +10184,19 @@ entry:
   store i32 addrspace(1)* %param1, i32 addrspace(1)** %arg1
   %0 = load i32, i32* %arg0
   %1 = load i32 addrspace(1)*, i32 addrspace(1)** %arg1
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = and i32 %0, %2
-  store i32 %3, i32* %arg0
-  %4 = load i32, i32* %arg0
-  ret i32 %4
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  %4 = and i32 %0, %3
+  store i32 %4, i32* %arg0
+  %5 = load i32, i32* %arg0
+  ret i32 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Args4.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Args4.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Args5.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Args5.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgAdd1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgAdd1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgAnd1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgAnd1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgOr1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgOr1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgSub1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgSub1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgXor1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgXor1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/BinaryRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/BinaryRMW.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6893,15 +10181,47 @@ entry:
   store i32 addrspace(1)* %param0, i32 addrspace(1)** %arg0
   store i32 %param1, i32* %arg1
   %0 = load i32 addrspace(1)*, i32 addrspace(1)** %arg0
-  %1 = load i32, i32 addrspace(1)* %0, align 8
-  %2 = load i32, i32* %arg1
-  %3 = add i32 %1, %2
-  store i32 %3, i32 addrspace(1)* %0, align 8
-  %4 = load i32 addrspace(1)*, i32 addrspace(1)** %arg0
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = or i32 %5, 2
-  store i32 %6, i32 addrspace(1)* %4, align 8
+  %NullCheck = icmp ne i32 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = load i32, i32 addrspace(1)* %0, align 8
+  %3 = load i32, i32* %arg1
+  %4 = add i32 %2, %3
+  %NullCheck2 = icmp ne i32 addrspace(1)* %0, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  store i32 %4, i32 addrspace(1)* %0, align 8
+  %6 = load i32 addrspace(1)*, i32 addrspace(1)** %arg0
+  %NullCheck4 = icmp ne i32 addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %5
+  %8 = load i32, i32 addrspace(1)* %6, align 8
+  %9 = or i32 %8, 2
+  %NullCheck6 = icmp ne i32 addrspace(1)* %6, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  store i32 %9, i32 addrspace(1)* %6, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Call1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Call1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6901,16 +10189,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 104
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 8
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 104
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7028,19 +10324,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7072,9 +10384,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7118,17 +10438,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7149,17 +10485,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7196,11 +10548,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7216,7 +10576,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7224,27 +10584,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7360,31 +10728,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7397,40 +10797,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7444,8 +10868,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7513,38 +10945,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7557,39 +11021,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7600,39 +11088,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7660,29 +11188,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7747,9 +11291,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7776,16 +11328,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7802,12 +11370,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7833,19 +11417,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7911,51 +11519,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7968,11 +11584,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7992,116 +11616,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8112,19 +11864,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8172,34 +11940,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8225,9 +12025,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8238,32 +12046,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8276,20 +12116,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8324,59 +12180,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8387,11 +12259,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8419,20 +12307,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8444,36 +12340,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8492,177 +12396,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8727,27 +12799,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8758,28 +12854,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8976,44 +13088,68 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 104
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 8
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 104
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, %System.String addrspace(1)* %8)
-  br label %18
+  %17 = add i64 %16, 8
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, %System.String addrspace(1)* %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9077,116 +13213,196 @@ entry:
 
 ; <label>:23                                      ; preds = %15
   %24 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
-  %26 = load i32, i32 addrspace(1)* %25
-  %27 = zext i32 %26 to i64
-  %28 = trunc i64 %27 to i32
-  %29 = load i32, i32* %arg2
-  %30 = sub i32 %28, %29
-  %31 = load i32, i32* %arg3
-  %32 = icmp sge i32 %30, %31
-  br i1 %32, label %37, label %33
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %24, null
+  br i1 %NullCheck, label %25, label %ThrowNullRef
 
-; <label>:33                                      ; preds = %23
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %35 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %34)
-  %36 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36, %System.String addrspace(1)* %35)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36) #0
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = trunc i64 %28 to i32
+  %30 = load i32, i32* %arg2
+  %31 = sub i32 %29, %30
+  %32 = load i32, i32* %arg3
+  %33 = icmp sge i32 %31, %32
+  br i1 %33, label %38, label %34
+
+; <label>:34                                      ; preds = %25
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %37, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %37) #0
   unreachable
 
-; <label>:37                                      ; preds = %23
-  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %38)
-  br label %89
+; <label>:38                                      ; preds = %25
+  %39 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %39)
+  br label %98
 
-; <label>:39                                      ; preds = %89
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %43, i32 0, i32 10
-  %45 = load i32, i32 addrspace(1)* %44, align 8
-  %46 = icmp ne i32 %42, %45
-  br i1 %46, label %49, label %47
+; <label>:40                                      ; preds = %98
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %41, null
+  br i1 %NullCheck4, label %42, label %ThrowNullRef3
 
-; <label>:47                                      ; preds = %39
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %48, i8 0, i8 0)
-  br label %49
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %45, null
+  br i1 %NullCheck6, label %46, label %ThrowNullRef5
 
-; <label>:49                                      ; preds = %39, %47
-  %50 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %51 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %50, i32 0, i32 10
-  %52 = load i32, i32 addrspace(1)* %51, align 8
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %45, i32 0, i32 10
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %49 = icmp ne i32 %44, %48
+  br i1 %49, label %52, label %50
+
+; <label>:50                                      ; preds = %46
+  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %51, i8 0, i8 0)
+  br label %52
+
+; <label>:52                                      ; preds = %46, %50
   %53 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %54 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 9
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = sub i32 %52, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc0
-  %58 = load i32, i32* %arg3
-  %59 = icmp sle i32 %57, %58
-  br i1 %59, label %62, label %60
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %53, null
+  br i1 %NullCheck8, label %54, label %ThrowNullRef7
 
-; <label>:60                                      ; preds = %49
-  %61 = load i32, i32* %arg3
+; <label>:54                                      ; preds = %52
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 10
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck10, label %58, label %ThrowNullRef9
+
+; <label>:58                                      ; preds = %54
+  %59 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 9
+  %60 = load i32, i32 addrspace(1)* %59, align 8
+  %61 = sub i32 %56, %60
   store i32 %61, i32* %loc0
-  br label %62
+  %62 = load i32, i32* %loc0
+  %63 = load i32, i32* %arg3
+  %64 = icmp sle i32 %62, %63
+  br i1 %64, label %67, label %65
 
-; <label>:62                                      ; preds = %49, %60
-  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %64 = load i32, i32* %arg2
-  %65 = mul i32 %64, 2
-  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %67 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 7
-  %68 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %70 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %69, i32 0, i32 9
-  %71 = load i32, i32 addrspace(1)* %70, align 8
-  %72 = mul i32 %71, 2
-  %73 = load i32, i32* %loc0
-  %74 = mul i32 %73, 2
-  %75 = bitcast %"System.Char[]" addrspace(1)* %63 to %System.Array addrspace(1)*
-  %76 = bitcast %"System.Char[]" addrspace(1)* %68 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %75, i32 %65, %System.Array addrspace(1)* %76, i32 %72, i32 %74)
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
+; <label>:65                                      ; preds = %58
+  %66 = load i32, i32* %arg3
+  store i32 %66, i32* %loc0
+  br label %67
+
+; <label>:67                                      ; preds = %58, %65
+  %68 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %69 = load i32, i32* %arg2
+  %70 = mul i32 %69, 2
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %71, null
+  br i1 %NullCheck12, label %72, label %ThrowNullRef11
+
+; <label>:72                                      ; preds = %67
+  %73 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 7
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %73, align 8
+  %75 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %75, null
+  br i1 %NullCheck14, label %76, label %ThrowNullRef13
+
+; <label>:76                                      ; preds = %72
+  %77 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %75, i32 0, i32 9
+  %78 = load i32, i32 addrspace(1)* %77, align 8
+  %79 = mul i32 %78, 2
   %80 = load i32, i32* %loc0
-  %81 = add i32 %79, %80
-  %82 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  store i32 %81, i32 addrspace(1)* %82
-  %83 = load i32, i32* %arg2
-  %84 = load i32, i32* %loc0
-  %85 = add i32 %83, %84
-  store i32 %85, i32* %arg2
-  %86 = load i32, i32* %arg3
-  %87 = load i32, i32* %loc0
-  %88 = sub i32 %86, %87
-  store i32 %88, i32* %arg3
-  br label %89
+  %81 = mul i32 %80, 2
+  %82 = bitcast %"System.Char[]" addrspace(1)* %68 to %System.Array addrspace(1)*
+  %83 = bitcast %"System.Char[]" addrspace(1)* %74 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %82, i32 %70, %System.Array addrspace(1)* %83, i32 %79, i32 %81)
+  %84 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck16, label %85, label %ThrowNullRef15
 
-; <label>:89                                      ; preds = %37, %62
-  %90 = load i32, i32* %arg3
-  %91 = icmp sgt i32 %90, 0
-  br i1 %91, label %39, label %92
+; <label>:85                                      ; preds = %76
+  %86 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = load i32, i32* %loc0
+  %89 = add i32 %87, %88
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck18, label %90, label %ThrowNullRef17
 
-; <label>:92                                      ; preds = %89
-  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %94 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 11
-  %95 = load i8, i8 addrspace(1)* %94, align 8
-  %96 = zext i8 %95 to i32
-  %97 = icmp eq i32 %96, 0
-  br i1 %97, label %100, label %98
+; <label>:90                                      ; preds = %85
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load i32, i32* %arg2
+  %93 = load i32, i32* %loc0
+  %94 = add i32 %92, %93
+  store i32 %94, i32* %arg2
+  %95 = load i32, i32* %arg3
+  %96 = load i32, i32* %loc0
+  %97 = sub i32 %95, %96
+  store i32 %97, i32* %arg3
+  br label %98
 
-; <label>:98                                      ; preds = %92
-  %99 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %99, i8 1, i8 0)
-  br label %100
+; <label>:98                                      ; preds = %38, %90
+  %99 = load i32, i32* %arg3
+  %100 = icmp sgt i32 %99, 0
+  br i1 %100, label %40, label %101
 
-; <label>:100                                     ; preds = %92, %98
+; <label>:101                                     ; preds = %98
+  %102 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %102, null
+  br i1 %NullCheck2, label %103, label %ThrowNullRef1
+
+; <label>:103                                     ; preds = %101
+  %104 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %102, i32 0, i32 11
+  %105 = load i8, i8 addrspace(1)* %104, align 8
+  %106 = zext i8 %105 to i32
+  %107 = icmp eq i32 %106, 0
+  br i1 %107, label %110, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %109, i8 1, i8 0)
+  br label %110
+
+; <label>:110                                     ; preds = %103, %108
   ret void
+
+ThrowNullRef:                                     ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
@@ -9314,30 +13530,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -9363,25 +13611,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -9441,38 +13697,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -9485,23 +13757,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -9513,27 +13793,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/CnsBool.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/CnsBool.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/CnsLng1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/CnsLng1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAdd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAdd.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6890,16 +10178,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 56
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 56
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7017,19 +10313,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7061,9 +10373,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7107,17 +10427,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7138,17 +10474,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7185,11 +10537,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7205,7 +10565,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7213,27 +10573,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7349,31 +10717,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7386,40 +10786,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7433,8 +10857,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7502,38 +10934,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7546,39 +11010,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7589,39 +11077,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7649,29 +11177,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7736,9 +11280,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7765,16 +11317,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7791,12 +11359,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7822,19 +11406,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7900,51 +11508,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7957,11 +11573,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7981,116 +11605,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8101,19 +11853,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8161,34 +11929,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8214,9 +12014,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8227,32 +12035,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8265,20 +12105,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8313,59 +12169,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8376,11 +12248,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8408,20 +12296,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8433,36 +12329,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,177 +12385,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8716,27 +12788,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8747,28 +12843,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8965,44 +13077,68 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load double, double* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 56
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load double, double* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, double %8)
-  br label %18
+  %17 = add i64 %16, 56
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9017,27 +13153,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9053,28 +13205,44 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Double::ToString using LLILCJit
@@ -9088,11 +13256,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %2 = load double, double addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne double addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load double, double addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9106,37 +13282,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9154,215 +13378,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9388,25 +14020,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9420,11 +14076,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9480,25 +14144,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9509,24 +14197,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9553,13 +14265,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9570,24 +14290,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9598,24 +14342,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9626,24 +14394,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9654,24 +14446,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9682,24 +14498,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9710,24 +14550,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9744,106 +14608,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9975,30 +14919,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10024,25 +15000,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10102,38 +15086,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10146,23 +15146,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10174,27 +15182,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10206,19 +15222,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10245,100 +15277,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAddConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAddConst.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6887,16 +10175,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 56
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 56
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7014,19 +10310,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7058,9 +10370,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7104,17 +10424,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7135,17 +10471,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7182,11 +10534,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7202,7 +10562,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7210,27 +10570,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7346,31 +10714,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7383,40 +10783,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7430,8 +10854,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7499,38 +10931,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7543,39 +11007,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7586,39 +11074,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7646,29 +11174,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7733,9 +11277,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7762,16 +11314,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7788,12 +11356,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7819,19 +11403,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7897,51 +11505,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7954,11 +11570,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7978,116 +11602,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8098,19 +11850,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8158,34 +11926,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8211,9 +12011,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8224,32 +12032,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8262,20 +12102,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8310,59 +12166,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8373,11 +12245,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8405,20 +12293,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8430,36 +12326,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8478,177 +12382,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8713,27 +12785,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8744,28 +12840,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8962,44 +13074,68 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load double, double* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 56
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load double, double* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, double %8)
-  br label %18
+  %17 = add i64 %16, 56
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9014,27 +13150,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9050,28 +13202,44 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Double::ToString using LLILCJit
@@ -9085,11 +13253,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %2 = load double, double addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne double addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load double, double addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9103,37 +13279,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9151,215 +13375,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9385,25 +14017,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9417,11 +14073,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9477,25 +14141,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9506,24 +14194,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9550,13 +14262,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9567,24 +14287,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9595,24 +14339,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9623,24 +14391,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9651,24 +14443,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9679,24 +14495,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9707,24 +14547,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9741,106 +14605,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9972,30 +14916,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10021,25 +14997,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10099,38 +15083,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10143,23 +15143,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10171,27 +15179,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10203,19 +15219,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10242,100 +15274,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblArea.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblArea.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6913,16 +10201,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 56
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 56
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7040,19 +10336,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7084,9 +10396,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7130,17 +10450,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7161,17 +10497,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7208,11 +10560,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7228,7 +10588,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7236,27 +10596,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7372,31 +10740,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7409,40 +10809,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7456,8 +10880,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7525,38 +10957,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7569,39 +11033,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7612,39 +11100,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7672,29 +11200,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7759,9 +11303,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7788,16 +11340,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7814,12 +11382,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7845,19 +11429,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7923,51 +11531,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7980,11 +11596,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -8004,116 +11628,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8124,19 +11876,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8184,34 +11952,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8237,9 +12037,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8250,32 +12058,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8288,20 +12128,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8336,59 +12192,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8399,11 +12271,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8431,20 +12319,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8456,36 +12352,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8504,177 +12408,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8739,27 +12811,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8770,28 +12866,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8988,44 +13100,68 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load double, double* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 56
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load double, double* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, double %8)
-  br label %18
+  %17 = add i64 %16, 56
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9040,27 +13176,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9076,28 +13228,44 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Double::ToString using LLILCJit
@@ -9111,11 +13279,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %2 = load double, double addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne double addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load double, double addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9129,37 +13305,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9177,215 +13401,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9411,25 +14043,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9443,11 +14099,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9503,25 +14167,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9532,24 +14220,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9576,13 +14288,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9593,24 +14313,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9621,24 +14365,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9649,24 +14417,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9677,24 +14469,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9705,24 +14521,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9733,24 +14573,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9767,106 +14631,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9998,30 +14942,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10047,25 +15023,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10125,38 +15109,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10169,23 +15169,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10197,27 +15205,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10229,19 +15245,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10268,100 +15300,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblArray.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6877,16 +10165,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 56
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 56
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7004,19 +10300,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7048,9 +10360,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7094,17 +10414,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7125,17 +10461,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7172,11 +10524,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7192,7 +10552,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7200,27 +10560,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7336,31 +10704,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7373,40 +10773,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7420,8 +10844,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7489,38 +10921,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7533,39 +10997,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7576,39 +11064,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7636,29 +11164,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7723,9 +11267,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7752,16 +11304,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7778,12 +11346,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7809,19 +11393,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7887,51 +11495,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7944,11 +11560,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7968,116 +11592,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8088,19 +11840,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8148,34 +11916,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8201,9 +12001,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8214,32 +12022,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8252,20 +12092,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8300,59 +12156,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8363,11 +12235,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8395,20 +12283,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8420,36 +12316,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8468,177 +12372,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8703,27 +12775,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8734,28 +12830,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8952,44 +13064,68 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load double, double* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 56
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load double, double* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, double %8)
-  br label %18
+  %17 = add i64 %16, 56
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9004,27 +13140,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9040,28 +13192,44 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Double::ToString using LLILCJit
@@ -9075,11 +13243,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %2 = load double, double addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne double addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load double, double addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9093,37 +13269,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9141,215 +13365,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9375,25 +14007,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9407,11 +14063,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9467,25 +14131,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9496,24 +14184,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9540,13 +14252,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9557,24 +14277,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9585,24 +14329,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9613,24 +14381,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9641,24 +14433,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9669,24 +14485,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9697,24 +14537,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9731,106 +14595,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9962,30 +14906,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10011,25 +14987,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10089,38 +15073,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10133,23 +15133,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10161,27 +15169,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10193,19 +15209,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10232,100 +15264,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg2.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6894,16 +10182,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 56
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 56
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7021,19 +10317,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7065,9 +10377,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7111,17 +10431,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7142,17 +10478,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7189,11 +10541,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7209,7 +10569,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7217,27 +10577,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7353,31 +10721,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7390,40 +10790,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7437,8 +10861,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7506,38 +10938,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7550,39 +11014,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7593,39 +11081,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7653,29 +11181,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7740,9 +11284,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7769,16 +11321,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7795,12 +11363,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7826,19 +11410,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7904,51 +11512,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7961,11 +11577,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7985,116 +11609,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8105,19 +11857,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8165,34 +11933,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8218,9 +12018,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8231,32 +12039,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8269,20 +12109,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8317,59 +12173,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8380,11 +12252,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8412,20 +12300,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8437,36 +12333,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8485,177 +12389,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8720,27 +12792,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8751,28 +12847,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8969,44 +13081,68 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load double, double* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 56
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load double, double* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, double %8)
-  br label %18
+  %17 = add i64 %16, 56
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9021,27 +13157,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9057,28 +13209,44 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Double::ToString using LLILCJit
@@ -9092,11 +13260,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %2 = load double, double addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne double addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load double, double addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9110,37 +13286,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9158,215 +13382,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9392,25 +14024,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9424,11 +14080,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9484,25 +14148,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9513,24 +14201,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9557,13 +14269,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9574,24 +14294,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9602,24 +14346,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9630,24 +14398,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9658,24 +14450,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9686,24 +14502,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9714,24 +14554,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9748,106 +14612,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9979,30 +14923,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10028,25 +15004,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10106,38 +15090,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10150,23 +15150,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10178,27 +15186,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10210,19 +15226,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10249,100 +15281,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg6.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg6.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6910,16 +10198,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 56
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 56
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7037,19 +10333,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7081,9 +10393,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7127,17 +10447,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7158,17 +10494,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7205,11 +10557,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7225,7 +10585,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7233,27 +10593,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7369,31 +10737,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7406,40 +10806,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7453,8 +10877,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7522,38 +10954,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7566,39 +11030,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7609,39 +11097,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7669,29 +11197,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7756,9 +11300,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7785,16 +11337,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7811,12 +11379,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7842,19 +11426,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7920,51 +11528,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7977,11 +11593,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -8001,116 +11625,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8121,19 +11873,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8181,34 +11949,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8234,9 +12034,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8247,32 +12055,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8285,20 +12125,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8333,59 +12189,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8396,11 +12268,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8428,20 +12316,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8453,36 +12349,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8501,177 +12405,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8736,27 +12808,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8767,28 +12863,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8985,44 +13097,68 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load double, double* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 56
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load double, double* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, double %8)
-  br label %18
+  %17 = add i64 %16, 56
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9037,27 +13173,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9073,28 +13225,44 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Double::ToString using LLILCJit
@@ -9108,11 +13276,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %2 = load double, double addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne double addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load double, double addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9126,37 +13302,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9174,215 +13398,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9408,25 +14040,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9440,11 +14096,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9500,25 +14164,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9529,24 +14217,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9573,13 +14285,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9590,24 +14310,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9618,24 +14362,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9646,24 +14414,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9674,24 +14466,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9702,24 +14518,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9730,24 +14570,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9764,106 +14628,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9995,30 +14939,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10044,25 +15020,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10122,38 +15106,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10166,23 +15166,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10194,27 +15202,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10226,19 +15242,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10265,100 +15297,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblCall1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblCall1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6907,16 +10195,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 56
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 56
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7034,19 +10330,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7078,9 +10390,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7124,17 +10444,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7155,17 +10491,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7202,11 +10554,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7222,7 +10582,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7230,27 +10590,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7366,31 +10734,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7403,40 +10803,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7450,8 +10874,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7519,38 +10951,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7563,39 +11027,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7606,39 +11094,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7666,29 +11194,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7753,9 +11297,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7782,16 +11334,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7808,12 +11376,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7839,19 +11423,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7917,51 +11525,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7974,11 +11590,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7998,116 +11622,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8118,19 +11870,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8178,34 +11946,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8231,9 +12031,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8244,32 +12052,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8282,20 +12122,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8330,59 +12186,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8393,11 +12265,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8425,20 +12313,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8450,36 +12346,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8498,177 +12402,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8733,27 +12805,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8764,28 +12860,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8982,44 +13094,68 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load double, double* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 56
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load double, double* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, double %8)
-  br label %18
+  %17 = add i64 %16, 56
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9034,27 +13170,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9070,28 +13222,44 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Double::ToString using LLILCJit
@@ -9105,11 +13273,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %2 = load double, double addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne double addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load double, double addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9123,37 +13299,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9171,215 +13395,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9405,25 +14037,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9437,11 +14093,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9497,25 +14161,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9526,24 +14214,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9570,13 +14282,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9587,24 +14307,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9615,24 +14359,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9643,24 +14411,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9671,24 +14463,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9699,24 +14515,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9727,24 +14567,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9761,106 +14625,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9992,30 +14936,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10041,25 +15017,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10119,38 +15103,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10163,23 +15163,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10191,27 +15199,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10223,19 +15239,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10262,100 +15294,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblCall2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblCall2.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6917,16 +10205,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 56
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 56
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7044,19 +10340,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7088,9 +10400,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7134,17 +10454,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7165,17 +10501,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7212,11 +10564,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7232,7 +10592,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7240,27 +10600,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7376,31 +10744,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7413,40 +10813,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7460,8 +10884,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7529,38 +10961,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7573,39 +11037,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7616,39 +11104,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7676,29 +11204,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7763,9 +11307,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7792,16 +11344,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7818,12 +11386,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7849,19 +11433,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7927,51 +11535,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7984,11 +11600,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -8008,116 +11632,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8128,19 +11880,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8188,34 +11956,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8241,9 +12041,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8254,32 +12062,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8292,20 +12132,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8340,59 +12196,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8403,11 +12275,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8435,20 +12323,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8460,36 +12356,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8508,177 +12412,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8743,27 +12815,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8774,28 +12870,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,44 +13104,68 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load double, double* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 56
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load double, double* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, double %8)
-  br label %18
+  %17 = add i64 %16, 56
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9044,27 +13180,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9080,28 +13232,44 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Double::ToString using LLILCJit
@@ -9115,11 +13283,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %2 = load double, double addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne double addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load double, double addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9133,37 +13309,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9181,215 +13405,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9415,25 +14047,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9447,11 +14103,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9507,25 +14171,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9536,24 +14224,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9580,13 +14292,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9597,24 +14317,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9625,24 +14369,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9653,24 +14421,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9681,24 +14473,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9709,24 +14525,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9737,24 +14577,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9771,106 +14635,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10002,30 +14946,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10051,25 +15027,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10129,38 +15113,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10173,23 +15173,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10201,27 +15209,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10233,19 +15249,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10272,100 +15304,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDist.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDist.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6912,16 +10200,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 56
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 56
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7039,19 +10335,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7083,9 +10395,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7129,17 +10449,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7160,17 +10496,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7207,11 +10559,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7227,7 +10587,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7235,27 +10595,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7371,31 +10739,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7408,40 +10808,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7455,8 +10879,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7524,38 +10956,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7568,39 +11032,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7611,39 +11099,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7671,29 +11199,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7758,9 +11302,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7787,16 +11339,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7813,12 +11381,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7844,19 +11428,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7922,51 +11530,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7979,11 +11595,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -8003,116 +11627,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8123,19 +11875,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8183,34 +11951,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8236,9 +12036,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8249,32 +12057,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8287,20 +12127,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8335,59 +12191,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8398,11 +12270,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8430,20 +12318,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8455,36 +12351,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8503,177 +12407,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8738,27 +12810,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8769,28 +12865,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8987,44 +13099,68 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load double, double* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 56
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load double, double* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, double %8)
-  br label %18
+  %17 = add i64 %16, 56
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9039,27 +13175,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9075,28 +13227,44 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Double::ToString using LLILCJit
@@ -9110,11 +13278,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %2 = load double, double addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne double addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load double, double addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9128,37 +13304,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9176,215 +13400,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9410,25 +14042,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9442,11 +14098,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9502,25 +14166,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9531,24 +14219,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9575,13 +14287,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9592,24 +14312,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9620,24 +14364,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9648,24 +14416,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9676,24 +14468,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9704,24 +14520,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9732,24 +14572,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9766,106 +14630,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9997,30 +14941,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10046,25 +15022,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10124,38 +15108,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10168,23 +15168,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10196,27 +15204,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10228,19 +15244,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10267,100 +15299,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDiv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDiv.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6890,16 +10178,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 56
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 56
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7017,19 +10313,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7061,9 +10373,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7107,17 +10427,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7138,17 +10474,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7185,11 +10537,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7205,7 +10565,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7213,27 +10573,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7349,31 +10717,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7386,40 +10786,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7433,8 +10857,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7502,38 +10934,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7546,39 +11010,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7589,39 +11077,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7649,29 +11177,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7736,9 +11280,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7765,16 +11317,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7791,12 +11359,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7822,19 +11406,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7900,51 +11508,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7957,11 +11573,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7981,116 +11605,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8101,19 +11853,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8161,34 +11929,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8214,9 +12014,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8227,32 +12035,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8265,20 +12105,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8313,59 +12169,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8376,11 +12248,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8408,20 +12296,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8433,36 +12329,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,177 +12385,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8716,27 +12788,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8747,28 +12843,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8965,44 +13077,68 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load double, double* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 56
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load double, double* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, double %8)
-  br label %18
+  %17 = add i64 %16, 56
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9017,27 +13153,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9053,28 +13205,44 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Double::ToString using LLILCJit
@@ -9088,11 +13256,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %2 = load double, double addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne double addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load double, double addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9106,37 +13282,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9154,215 +13378,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9388,25 +14020,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9420,11 +14076,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9480,25 +14144,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9509,24 +14197,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9553,13 +14265,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9570,24 +14290,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9598,24 +14342,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9626,24 +14394,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9654,24 +14446,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9682,24 +14498,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9710,24 +14550,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9744,106 +14608,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9975,30 +14919,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10024,25 +15000,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10102,38 +15086,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10146,23 +15146,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10174,27 +15182,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10206,19 +15222,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10245,100 +15277,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDivConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDivConst.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6887,16 +10175,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 56
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 56
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7014,19 +10310,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7058,9 +10370,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7104,17 +10424,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7135,17 +10471,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7182,11 +10534,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7202,7 +10562,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7210,27 +10570,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7346,31 +10714,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7383,40 +10783,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7430,8 +10854,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7499,38 +10931,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7543,39 +11007,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7586,39 +11074,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7646,29 +11174,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7733,9 +11277,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7762,16 +11314,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7788,12 +11356,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7819,19 +11403,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7897,51 +11505,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7954,11 +11570,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7978,116 +11602,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8098,19 +11850,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8158,34 +11926,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8211,9 +12011,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8224,32 +12032,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8262,20 +12102,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8310,59 +12166,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8373,11 +12245,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8405,20 +12293,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8430,36 +12326,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8478,177 +12382,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8713,27 +12785,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8744,28 +12840,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8962,44 +13074,68 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load double, double* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 56
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load double, double* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, double %8)
-  br label %18
+  %17 = add i64 %16, 56
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9014,27 +13150,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9050,28 +13202,44 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Double::ToString using LLILCJit
@@ -9085,11 +13253,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %2 = load double, double addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne double addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load double, double addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9103,37 +13279,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9151,215 +13375,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9385,25 +14017,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9417,11 +14073,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9477,25 +14141,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9506,24 +14194,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9550,13 +14262,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9567,24 +14287,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9595,24 +14339,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9623,24 +14391,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9651,24 +14443,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9679,24 +14495,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9707,24 +14547,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9741,106 +14605,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9972,30 +14916,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10021,25 +14997,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10099,38 +15083,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10143,23 +15143,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10171,27 +15179,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10203,19 +15219,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10242,100 +15274,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblFillArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblFillArray.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6879,16 +10167,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 56
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 56
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7006,19 +10302,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7050,9 +10362,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7096,17 +10416,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7127,17 +10463,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7174,11 +10526,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7194,7 +10554,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7202,27 +10562,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7338,31 +10706,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7375,40 +10775,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7422,8 +10846,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7491,38 +10923,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7535,39 +10999,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7578,39 +11066,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7638,29 +11166,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7725,9 +11269,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7754,16 +11306,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7780,12 +11348,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7811,19 +11395,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7889,51 +11497,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7946,11 +11562,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7970,116 +11594,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8090,19 +11842,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8150,34 +11918,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8203,9 +12003,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8216,32 +12024,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8254,20 +12094,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8302,59 +12158,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8365,11 +12237,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8397,20 +12285,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8422,36 +12318,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8470,177 +12374,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8705,27 +12777,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8736,28 +12832,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8954,44 +13066,68 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load double, double* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 56
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load double, double* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, double %8)
-  br label %18
+  %17 = add i64 %16, 56
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9006,27 +13142,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9042,28 +13194,44 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Double::ToString using LLILCJit
@@ -9077,11 +13245,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %2 = load double, double addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne double addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load double, double addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9095,37 +13271,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9143,215 +13367,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9377,25 +14009,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9409,11 +14065,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9469,25 +14133,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9498,24 +14186,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9542,13 +14254,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9559,24 +14279,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9587,24 +14331,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9615,24 +14383,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9643,24 +14435,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9671,24 +14487,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9699,24 +14539,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9733,106 +14597,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9964,30 +14908,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10013,25 +14989,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10091,38 +15075,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10135,23 +15135,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10163,27 +15171,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10195,19 +15211,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10234,100 +15266,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblMul.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblMul.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6890,16 +10178,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 56
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 56
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7017,19 +10313,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7061,9 +10373,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7107,17 +10427,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7138,17 +10474,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7185,11 +10537,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7205,7 +10565,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7213,27 +10573,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7349,31 +10717,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7386,40 +10786,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7433,8 +10857,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7502,38 +10934,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7546,39 +11010,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7589,39 +11077,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7649,29 +11177,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7736,9 +11280,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7765,16 +11317,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7791,12 +11359,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7822,19 +11406,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7900,51 +11508,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7957,11 +11573,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7981,116 +11605,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8101,19 +11853,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8161,34 +11929,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8214,9 +12014,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8227,32 +12035,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8265,20 +12105,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8313,59 +12169,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8376,11 +12248,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8408,20 +12296,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8433,36 +12329,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,177 +12385,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8716,27 +12788,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8747,28 +12843,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8965,44 +13077,68 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load double, double* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 56
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load double, double* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, double %8)
-  br label %18
+  %17 = add i64 %16, 56
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9017,27 +13153,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9053,28 +13205,44 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Double::ToString using LLILCJit
@@ -9088,11 +13256,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %2 = load double, double addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne double addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load double, double addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9106,37 +13282,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9154,215 +13378,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9388,25 +14020,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9420,11 +14076,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9480,25 +14144,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9509,24 +14197,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9553,13 +14265,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9570,24 +14290,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9598,24 +14342,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9626,24 +14394,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9654,24 +14446,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9682,24 +14498,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9710,24 +14550,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9744,106 +14608,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9975,30 +14919,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10024,25 +15000,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10102,38 +15086,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10146,23 +15146,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10174,27 +15182,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10206,19 +15222,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10245,100 +15277,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblMulConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblMulConst.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6889,16 +10177,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 56
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 56
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7016,19 +10312,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7060,9 +10372,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7106,17 +10426,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7137,17 +10473,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7184,11 +10536,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7204,7 +10564,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7212,27 +10572,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7348,31 +10716,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7385,40 +10785,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7432,8 +10856,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7501,38 +10933,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7545,39 +11009,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7588,39 +11076,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7648,29 +11176,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7735,9 +11279,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7764,16 +11316,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7790,12 +11358,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7821,19 +11405,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7899,51 +11507,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7956,11 +11572,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7980,116 +11604,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8100,19 +11852,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8160,34 +11928,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8213,9 +12013,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8226,32 +12034,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8264,20 +12104,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8312,59 +12168,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8375,11 +12247,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8407,20 +12295,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8432,36 +12328,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8480,177 +12384,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8715,27 +12787,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8746,28 +12842,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8964,44 +13076,68 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load double, double* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 56
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load double, double* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, double %8)
-  br label %18
+  %17 = add i64 %16, 56
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9016,27 +13152,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9052,28 +13204,44 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Double::ToString using LLILCJit
@@ -9087,11 +13255,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %2 = load double, double addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne double addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load double, double addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9105,37 +13281,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9153,215 +13377,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9387,25 +14019,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9419,11 +14075,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9479,25 +14143,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9508,24 +14196,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9552,13 +14264,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9569,24 +14289,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9597,24 +14341,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9625,24 +14393,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9653,24 +14445,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9681,24 +14497,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9709,24 +14549,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9743,106 +14607,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9974,30 +14918,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10023,25 +14999,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10101,38 +15085,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10145,23 +15145,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10173,27 +15181,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10205,19 +15221,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10244,100 +15276,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblNeg.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6887,16 +10175,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 56
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 56
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7014,19 +10310,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7058,9 +10370,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7104,17 +10424,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7135,17 +10471,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7182,11 +10534,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7202,7 +10562,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7210,27 +10570,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7346,31 +10714,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7383,40 +10783,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7430,8 +10854,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7499,38 +10931,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7543,39 +11007,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7586,39 +11074,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7646,29 +11174,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7733,9 +11277,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7762,16 +11314,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7788,12 +11356,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7819,19 +11403,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7897,51 +11505,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7954,11 +11570,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7978,116 +11602,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8098,19 +11850,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8158,34 +11926,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8211,9 +12011,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8224,32 +12032,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8262,20 +12102,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8310,59 +12166,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8373,11 +12245,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8405,20 +12293,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8430,36 +12326,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8478,177 +12382,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8713,27 +12785,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8744,28 +12840,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8962,44 +13074,68 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load double, double* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 56
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load double, double* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, double %8)
-  br label %18
+  %17 = add i64 %16, 56
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9014,27 +13150,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9050,28 +13202,44 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Double::ToString using LLILCJit
@@ -9085,11 +13253,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %2 = load double, double addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne double addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load double, double addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9103,37 +13279,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9151,215 +13375,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9385,25 +14017,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9417,11 +14073,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9477,25 +14141,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9506,24 +14194,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9550,13 +14262,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9567,24 +14287,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9595,24 +14339,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9623,24 +14391,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9651,24 +14443,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9679,24 +14495,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9707,24 +14547,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9741,106 +14605,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9972,30 +14916,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10021,25 +14997,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10099,38 +15083,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10143,23 +15143,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10171,27 +15179,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10203,19 +15219,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10242,100 +15274,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblRem.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblRem.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6890,16 +10178,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 56
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 56
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7017,19 +10313,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7061,9 +10373,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7107,17 +10427,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7138,17 +10474,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7185,11 +10537,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7205,7 +10565,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7213,27 +10573,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7349,31 +10717,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7386,40 +10786,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7433,8 +10857,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7502,38 +10934,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7546,39 +11010,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7589,39 +11077,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7649,29 +11177,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7736,9 +11280,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7765,16 +11317,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7791,12 +11359,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7822,19 +11406,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7900,51 +11508,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7957,11 +11573,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7981,116 +11605,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8101,19 +11853,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8161,34 +11929,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8214,9 +12014,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8227,32 +12035,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8265,20 +12105,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8313,59 +12169,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8376,11 +12248,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8408,20 +12296,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8433,36 +12329,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,177 +12385,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8716,27 +12788,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8747,28 +12843,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8965,44 +13077,68 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load double, double* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 56
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load double, double* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, double %8)
-  br label %18
+  %17 = add i64 %16, 56
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9017,27 +13153,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9053,28 +13205,44 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Double::ToString using LLILCJit
@@ -9088,11 +13256,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %2 = load double, double addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne double addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load double, double addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9106,37 +13282,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9154,215 +13378,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9388,25 +14020,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9420,11 +14076,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9480,25 +14144,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9509,24 +14197,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9553,13 +14265,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9570,24 +14290,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9598,24 +14342,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9626,24 +14394,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9654,24 +14446,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9682,24 +14498,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9710,24 +14550,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9744,106 +14608,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9975,30 +14919,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10024,25 +15000,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10102,38 +15086,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10146,23 +15146,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10174,27 +15182,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10206,19 +15222,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10245,100 +15277,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblRoots.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblRoots.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6913,39 +10201,63 @@ entry:
 ; <label>:17                                      ; preds = %11, %14
   %18 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
   %19 = bitcast %System.Object addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 0
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %28 = call %System.String addrspace(1)* %27(%System.Object addrspace(1)* %18)
-  %29 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %30 = bitcast %System.Object addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 0
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %39 = call %System.String addrspace(1)* %38(%System.Object addrspace(1)* %29)
-  %40 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
-  %41 = bitcast %System.Object addrspace(1)* %40 to i64 addrspace(1)*
-  %42 = load i64, i64 addrspace(1)* %41
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = add i64 %45, 0
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
+
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %29 = call %System.String addrspace(1)* %28(%System.Object addrspace(1)* %18)
+  %30 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %31 = bitcast %System.Object addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %20
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 0
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %41 = call %System.String addrspace(1)* %40(%System.Object addrspace(1)* %30)
+  %42 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  %43 = bitcast %System.Object addrspace(1)* %42 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %43, null
+  br i1 %NullCheck4, label %44, label %ThrowNullRef3
+
+; <label>:44                                      ; preds = %32
+  %45 = load i64, i64 addrspace(1)* %43
+  %46 = add i64 %45, 64
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
-  %49 = inttoptr i64 %48 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %50 = call %System.String addrspace(1)* %49(%System.Object addrspace(1)* %40)
-  %51 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %28, %System.String addrspace(1)* %39, %System.String addrspace(1)* %50)
-  ret %System.String addrspace(1)* %51
+  %49 = add i64 %48, 0
+  %50 = inttoptr i64 %49 to i64*
+  %51 = load i64, i64* %50
+  %52 = inttoptr i64 %51 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %53 = call %System.String addrspace(1)* %52(%System.Object addrspace(1)* %42)
+  %54 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %41, %System.String addrspace(1)* %53)
+  ret %System.String addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Double::ToString using LLILCJit
@@ -6957,10 +10269,18 @@ entry:
   store %System.Double addrspace(1)* %param0, %System.Double addrspace(1)** %this
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %2 = load double, double addrspace(1)* %1, align 8
-  %3 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* ()*)()
-  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %3)
-  ret %System.String addrspace(1)* %4
+  %NullCheck = icmp ne double addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load double, double addrspace(1)* %1, align 8
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* ()*)()
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::get_CurrentInfo using LLILCJit
@@ -7153,37 +10473,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -7201,215 +10569,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -7435,25 +11211,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -7467,11 +11267,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -7527,25 +11335,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -7556,24 +11388,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -7600,13 +11456,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -7617,24 +11481,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -7645,24 +11533,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -7673,24 +11585,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -7701,24 +11637,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -7729,24 +11689,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -7757,24 +11741,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::ToString using LLILCJit
@@ -7851,41 +11859,89 @@ entry:
 
 ; <label>:25                                      ; preds = %20, %23
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
-  %28 = load i32, i32 addrspace(1)* %27
-  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %30 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
-  %31 = load i32, i32 addrspace(1)* %30
-  %32 = add i32 %28, %31
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 1
-  %35 = load i32, i32 addrspace(1)* %34
-  %36 = add i32 %32, %35
-  store i32 %36, i32* %loc0
-  %37 = load i32, i32* %loc0
-  %38 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %37)
-  store %System.String addrspace(1)* %38, %System.String addrspace(1)** %loc1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %39, i32 0, %System.String addrspace(1)* %40)
-  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %43 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
-  %44 = load i32, i32 addrspace(1)* %43
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, i32 %44, %System.String addrspace(1)* %45)
-  %46 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %48 = getelementptr inbounds %System.String, %System.String addrspace(1)* %47, i32 0, i32 1
-  %49 = load i32, i32 addrspace(1)* %48
-  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %51 = getelementptr inbounds %System.String, %System.String addrspace(1)* %50, i32 0, i32 1
-  %52 = load i32, i32 addrspace(1)* %51
-  %53 = add i32 %49, %52
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %46, i32 %53, %System.String addrspace(1)* %54)
-  %55 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %55
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %27, label %ThrowNullRef
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck2, label %31, label %ThrowNullRef1
+
+; <label>:31                                      ; preds = %27
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = add i32 %29, %33
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %35, null
+  br i1 %NullCheck4, label %36, label %ThrowNullRef3
+
+; <label>:36                                      ; preds = %31
+  %37 = getelementptr inbounds %System.String, %System.String addrspace(1)* %35, i32 0, i32 1
+  %38 = load i32, i32 addrspace(1)* %37
+  %39 = add i32 %34, %38
+  store i32 %39, i32* %loc0
+  %40 = load i32, i32* %loc0
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %40)
+  store %System.String addrspace(1)* %41, %System.String addrspace(1)** %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %42, i32 0, %System.String addrspace(1)* %43)
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %45, null
+  br i1 %NullCheck6, label %46, label %ThrowNullRef5
+
+; <label>:46                                      ; preds = %36
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %44, i32 %48, %System.String addrspace(1)* %49)
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck8, label %52, label %ThrowNullRef7
+
+; <label>:52                                      ; preds = %46
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %55, null
+  br i1 %NullCheck10, label %56, label %ThrowNullRef9
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %55, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = add i32 %54, %58
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %50, i32 %59, %System.String addrspace(1)* %60)
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %61
+
+ThrowNullRef:                                     ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
@@ -7898,16 +11954,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 104
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 8
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 104
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -8025,19 +12089,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -8069,9 +12149,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -8115,17 +12203,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -8146,17 +12250,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -8193,11 +12313,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -8213,7 +12341,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -8221,27 +12349,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -8357,31 +12493,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -8394,40 +12562,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8441,8 +12633,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -8510,38 +12710,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -8554,39 +12786,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -8597,39 +12853,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -8657,29 +12953,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -8744,9 +13056,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -8773,16 +13093,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -8799,12 +13135,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -8830,19 +13182,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -8908,51 +13284,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -8965,11 +13349,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -8989,116 +13381,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -9109,19 +13629,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -9169,34 +13705,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9222,9 +13790,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -9235,32 +13811,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -9273,20 +13881,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -9321,59 +13945,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -9384,11 +14024,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -9416,20 +14072,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -9441,36 +14105,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9489,177 +14161,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -9724,27 +14564,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -9755,28 +14619,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9796,44 +14676,68 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 104
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 8
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 104
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, %System.String addrspace(1)* %8)
-  br label %18
+  %17 = add i64 %16, 8
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, %System.String addrspace(1)* %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9897,116 +14801,196 @@ entry:
 
 ; <label>:23                                      ; preds = %15
   %24 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
-  %26 = load i32, i32 addrspace(1)* %25
-  %27 = zext i32 %26 to i64
-  %28 = trunc i64 %27 to i32
-  %29 = load i32, i32* %arg2
-  %30 = sub i32 %28, %29
-  %31 = load i32, i32* %arg3
-  %32 = icmp sge i32 %30, %31
-  br i1 %32, label %37, label %33
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %24, null
+  br i1 %NullCheck, label %25, label %ThrowNullRef
 
-; <label>:33                                      ; preds = %23
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %35 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %34)
-  %36 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36, %System.String addrspace(1)* %35)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36) #0
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = trunc i64 %28 to i32
+  %30 = load i32, i32* %arg2
+  %31 = sub i32 %29, %30
+  %32 = load i32, i32* %arg3
+  %33 = icmp sge i32 %31, %32
+  br i1 %33, label %38, label %34
+
+; <label>:34                                      ; preds = %25
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %37, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %37) #0
   unreachable
 
-; <label>:37                                      ; preds = %23
-  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %38)
-  br label %89
+; <label>:38                                      ; preds = %25
+  %39 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %39)
+  br label %98
 
-; <label>:39                                      ; preds = %89
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %43, i32 0, i32 10
-  %45 = load i32, i32 addrspace(1)* %44, align 8
-  %46 = icmp ne i32 %42, %45
-  br i1 %46, label %49, label %47
+; <label>:40                                      ; preds = %98
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %41, null
+  br i1 %NullCheck4, label %42, label %ThrowNullRef3
 
-; <label>:47                                      ; preds = %39
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %48, i8 0, i8 0)
-  br label %49
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %45, null
+  br i1 %NullCheck6, label %46, label %ThrowNullRef5
 
-; <label>:49                                      ; preds = %39, %47
-  %50 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %51 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %50, i32 0, i32 10
-  %52 = load i32, i32 addrspace(1)* %51, align 8
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %45, i32 0, i32 10
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %49 = icmp ne i32 %44, %48
+  br i1 %49, label %52, label %50
+
+; <label>:50                                      ; preds = %46
+  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %51, i8 0, i8 0)
+  br label %52
+
+; <label>:52                                      ; preds = %46, %50
   %53 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %54 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 9
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = sub i32 %52, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc0
-  %58 = load i32, i32* %arg3
-  %59 = icmp sle i32 %57, %58
-  br i1 %59, label %62, label %60
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %53, null
+  br i1 %NullCheck8, label %54, label %ThrowNullRef7
 
-; <label>:60                                      ; preds = %49
-  %61 = load i32, i32* %arg3
+; <label>:54                                      ; preds = %52
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 10
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck10, label %58, label %ThrowNullRef9
+
+; <label>:58                                      ; preds = %54
+  %59 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 9
+  %60 = load i32, i32 addrspace(1)* %59, align 8
+  %61 = sub i32 %56, %60
   store i32 %61, i32* %loc0
-  br label %62
+  %62 = load i32, i32* %loc0
+  %63 = load i32, i32* %arg3
+  %64 = icmp sle i32 %62, %63
+  br i1 %64, label %67, label %65
 
-; <label>:62                                      ; preds = %49, %60
-  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %64 = load i32, i32* %arg2
-  %65 = mul i32 %64, 2
-  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %67 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 7
-  %68 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %70 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %69, i32 0, i32 9
-  %71 = load i32, i32 addrspace(1)* %70, align 8
-  %72 = mul i32 %71, 2
-  %73 = load i32, i32* %loc0
-  %74 = mul i32 %73, 2
-  %75 = bitcast %"System.Char[]" addrspace(1)* %63 to %System.Array addrspace(1)*
-  %76 = bitcast %"System.Char[]" addrspace(1)* %68 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %75, i32 %65, %System.Array addrspace(1)* %76, i32 %72, i32 %74)
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
+; <label>:65                                      ; preds = %58
+  %66 = load i32, i32* %arg3
+  store i32 %66, i32* %loc0
+  br label %67
+
+; <label>:67                                      ; preds = %58, %65
+  %68 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %69 = load i32, i32* %arg2
+  %70 = mul i32 %69, 2
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %71, null
+  br i1 %NullCheck12, label %72, label %ThrowNullRef11
+
+; <label>:72                                      ; preds = %67
+  %73 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 7
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %73, align 8
+  %75 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %75, null
+  br i1 %NullCheck14, label %76, label %ThrowNullRef13
+
+; <label>:76                                      ; preds = %72
+  %77 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %75, i32 0, i32 9
+  %78 = load i32, i32 addrspace(1)* %77, align 8
+  %79 = mul i32 %78, 2
   %80 = load i32, i32* %loc0
-  %81 = add i32 %79, %80
-  %82 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  store i32 %81, i32 addrspace(1)* %82
-  %83 = load i32, i32* %arg2
-  %84 = load i32, i32* %loc0
-  %85 = add i32 %83, %84
-  store i32 %85, i32* %arg2
-  %86 = load i32, i32* %arg3
-  %87 = load i32, i32* %loc0
-  %88 = sub i32 %86, %87
-  store i32 %88, i32* %arg3
-  br label %89
+  %81 = mul i32 %80, 2
+  %82 = bitcast %"System.Char[]" addrspace(1)* %68 to %System.Array addrspace(1)*
+  %83 = bitcast %"System.Char[]" addrspace(1)* %74 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %82, i32 %70, %System.Array addrspace(1)* %83, i32 %79, i32 %81)
+  %84 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck16, label %85, label %ThrowNullRef15
 
-; <label>:89                                      ; preds = %37, %62
-  %90 = load i32, i32* %arg3
-  %91 = icmp sgt i32 %90, 0
-  br i1 %91, label %39, label %92
+; <label>:85                                      ; preds = %76
+  %86 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = load i32, i32* %loc0
+  %89 = add i32 %87, %88
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck18, label %90, label %ThrowNullRef17
 
-; <label>:92                                      ; preds = %89
-  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %94 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 11
-  %95 = load i8, i8 addrspace(1)* %94, align 8
-  %96 = zext i8 %95 to i32
-  %97 = icmp eq i32 %96, 0
-  br i1 %97, label %100, label %98
+; <label>:90                                      ; preds = %85
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load i32, i32* %arg2
+  %93 = load i32, i32* %loc0
+  %94 = add i32 %92, %93
+  store i32 %94, i32* %arg2
+  %95 = load i32, i32* %arg3
+  %96 = load i32, i32* %loc0
+  %97 = sub i32 %95, %96
+  store i32 %97, i32* %arg3
+  br label %98
 
-; <label>:98                                      ; preds = %92
-  %99 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %99, i8 1, i8 0)
-  br label %100
+; <label>:98                                      ; preds = %38, %90
+  %99 = load i32, i32* %arg3
+  %100 = icmp sgt i32 %99, 0
+  br i1 %100, label %40, label %101
 
-; <label>:100                                     ; preds = %92, %98
+; <label>:101                                     ; preds = %98
+  %102 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %102, null
+  br i1 %NullCheck2, label %103, label %ThrowNullRef1
+
+; <label>:103                                     ; preds = %101
+  %104 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %102, i32 0, i32 11
+  %105 = load i8, i8 addrspace(1)* %104, align 8
+  %106 = zext i8 %105 to i32
+  %107 = icmp eq i32 %106, 0
+  br i1 %107, label %110, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %109, i8 1, i8 0)
+  br label %110
+
+; <label>:110                                     ; preds = %103, %108
   ret void
+
+ThrowNullRef:                                     ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
@@ -10134,30 +15118,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10183,25 +15199,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10261,38 +15285,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10305,23 +15345,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10333,27 +15381,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblSub.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblSub.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6890,16 +10178,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 56
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 56
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7017,19 +10313,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7061,9 +10373,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7107,17 +10427,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7138,17 +10474,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7185,11 +10537,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7205,7 +10565,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7213,27 +10573,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7349,31 +10717,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7386,40 +10786,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7433,8 +10857,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7502,38 +10934,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7546,39 +11010,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7589,39 +11077,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7649,29 +11177,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7736,9 +11280,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7765,16 +11317,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7791,12 +11359,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7822,19 +11406,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7900,51 +11508,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7957,11 +11573,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7981,116 +11605,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8101,19 +11853,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8161,34 +11929,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8214,9 +12014,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8227,32 +12035,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8265,20 +12105,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8313,59 +12169,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8376,11 +12248,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8408,20 +12296,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8433,36 +12329,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,177 +12385,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8716,27 +12788,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8747,28 +12843,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8965,44 +13077,68 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load double, double* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 56
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load double, double* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, double %8)
-  br label %18
+  %17 = add i64 %16, 56
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9017,27 +13153,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9053,28 +13205,44 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Double::ToString using LLILCJit
@@ -9088,11 +13256,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %2 = load double, double addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne double addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load double, double addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9106,37 +13282,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9154,215 +13378,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9388,25 +14020,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9420,11 +14076,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9480,25 +14144,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9509,24 +14197,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9553,13 +14265,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9570,24 +14290,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9598,24 +14342,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9626,24 +14394,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9654,24 +14446,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9682,24 +14498,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9710,24 +14550,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9744,106 +14608,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9975,30 +14919,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10024,25 +15000,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10102,38 +15086,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10146,23 +15146,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10174,27 +15182,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10206,19 +15222,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10245,100 +15277,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblSubConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblSubConst.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6887,16 +10175,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 56
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 56
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7014,19 +10310,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7058,9 +10370,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7104,17 +10424,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7135,17 +10471,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7182,11 +10534,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7202,7 +10562,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7210,27 +10570,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7346,31 +10714,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7383,40 +10783,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7430,8 +10854,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7499,38 +10931,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7543,39 +11007,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7586,39 +11074,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7646,29 +11174,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7733,9 +11277,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7762,16 +11314,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7788,12 +11356,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7819,19 +11403,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7897,51 +11505,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7954,11 +11570,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7978,116 +11602,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8098,19 +11850,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8158,34 +11926,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8211,9 +12011,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8224,32 +12032,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8262,20 +12102,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8310,59 +12166,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8373,11 +12245,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8405,20 +12293,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8430,36 +12326,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8478,177 +12382,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8713,27 +12785,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8744,28 +12840,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8962,44 +13074,68 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load double, double* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 56
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load double, double* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, double %8)
-  br label %18
+  %17 = add i64 %16, 56
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9014,27 +13150,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9050,28 +13202,44 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Double::ToString using LLILCJit
@@ -9085,11 +13253,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %2 = load double, double addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne double addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load double, double addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9103,37 +13279,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9151,215 +13375,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9385,25 +14017,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9417,11 +14073,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9477,25 +14141,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9506,24 +14194,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9550,13 +14262,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9567,24 +14287,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9595,24 +14339,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9623,24 +14391,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9651,24 +14443,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9679,24 +14495,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9707,24 +14547,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9741,106 +14605,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9972,30 +14916,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10021,25 +14997,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10099,38 +15083,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10143,23 +15143,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10171,27 +15179,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10203,19 +15219,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10242,100 +15274,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblVar.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblVar.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6893,16 +10181,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 56
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 56
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7020,19 +10316,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7064,9 +10376,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7110,17 +10430,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7141,17 +10477,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7188,11 +10540,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7208,7 +10568,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7216,27 +10576,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7352,31 +10720,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7389,40 +10789,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7436,8 +10860,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7505,38 +10937,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7549,39 +11013,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7592,39 +11080,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7652,29 +11180,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7739,9 +11283,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7768,16 +11320,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7794,12 +11362,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7825,19 +11409,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7903,51 +11511,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7960,11 +11576,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7984,116 +11608,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8104,19 +11856,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8164,34 +11932,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8217,9 +12017,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8230,32 +12038,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8268,20 +12108,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8316,59 +12172,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8379,11 +12251,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8411,20 +12299,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8436,36 +12332,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8484,177 +12388,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8719,27 +12791,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8750,28 +12846,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8968,44 +13080,68 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load double, double* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 56
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load double, double* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, double %8)
-  br label %18
+  %17 = add i64 %16, 56
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9020,27 +13156,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9056,28 +13208,44 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Double::ToString using LLILCJit
@@ -9091,11 +13259,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %2 = load double, double addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne double addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load double, double addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9109,37 +13285,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9157,215 +13381,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9391,25 +14023,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9423,11 +14079,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9483,25 +14147,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9512,24 +14200,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9556,13 +14268,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9573,24 +14293,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9601,24 +14345,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9629,24 +14397,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9657,24 +14449,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9685,24 +14501,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9713,24 +14553,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9747,106 +14611,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9978,30 +14922,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10027,25 +15003,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10105,38 +15089,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10149,23 +15149,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10177,27 +15185,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10209,19 +15225,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10248,100 +15280,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Eq1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Eq1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAdd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAdd.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6890,16 +10178,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 48
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 48
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7017,19 +10313,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7061,9 +10373,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7107,17 +10427,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7138,17 +10474,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7185,11 +10537,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7205,7 +10565,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7213,27 +10573,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7349,31 +10717,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7386,40 +10786,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7433,8 +10857,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7502,38 +10934,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7546,39 +11010,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7589,39 +11077,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7649,29 +11177,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7736,9 +11280,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7765,16 +11317,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7791,12 +11359,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7822,19 +11406,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7900,51 +11508,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7957,11 +11573,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7981,116 +11605,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8101,19 +11853,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8161,34 +11929,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8214,9 +12014,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8227,32 +12035,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8265,20 +12105,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8313,59 +12169,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8376,11 +12248,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8408,20 +12296,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8433,36 +12329,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,177 +12385,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8716,27 +12788,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8747,28 +12843,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8965,44 +13077,68 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load float, float* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 48
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load float, float* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, float %8)
-  br label %18
+  %17 = add i64 %16, 48
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9017,27 +13153,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9053,28 +13205,44 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Single::ToString using LLILCJit
@@ -9088,11 +13256,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %2 = load float, float addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne float addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load float, float addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9106,37 +13282,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9154,215 +13378,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9388,25 +14020,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9420,11 +14076,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9480,25 +14144,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9509,24 +14197,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9553,13 +14265,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9570,24 +14290,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9598,24 +14342,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9626,24 +14394,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9654,24 +14446,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9682,24 +14498,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9710,24 +14550,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9744,106 +14608,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9975,30 +14919,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10024,25 +15000,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10102,38 +15086,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10146,23 +15146,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10174,27 +15182,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10206,19 +15222,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10245,100 +15277,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAddConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAddConst.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6887,16 +10175,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 48
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 48
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7014,19 +10310,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7058,9 +10370,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7104,17 +10424,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7135,17 +10471,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7182,11 +10534,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7202,7 +10562,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7210,27 +10570,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7346,31 +10714,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7383,40 +10783,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7430,8 +10854,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7499,38 +10931,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7543,39 +11007,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7586,39 +11074,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7646,29 +11174,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7733,9 +11277,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7762,16 +11314,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7788,12 +11356,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7819,19 +11403,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7897,51 +11505,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7954,11 +11570,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7978,116 +11602,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8098,19 +11850,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8158,34 +11926,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8211,9 +12011,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8224,32 +12032,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8262,20 +12102,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8310,59 +12166,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8373,11 +12245,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8405,20 +12293,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8430,36 +12326,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8478,177 +12382,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8713,27 +12785,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8744,28 +12840,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8962,44 +13074,68 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load float, float* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 48
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load float, float* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, float %8)
-  br label %18
+  %17 = add i64 %16, 48
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9014,27 +13150,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9050,28 +13202,44 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Single::ToString using LLILCJit
@@ -9085,11 +13253,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %2 = load float, float addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne float addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load float, float addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9103,37 +13279,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9151,215 +13375,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9385,25 +14017,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9417,11 +14073,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9477,25 +14141,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9506,24 +14194,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9550,13 +14262,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9567,24 +14287,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9595,24 +14339,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9623,24 +14391,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9651,24 +14443,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9679,24 +14495,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9707,24 +14547,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9741,106 +14605,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9972,30 +14916,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10021,25 +14997,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10099,38 +15083,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10143,23 +15143,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10171,27 +15179,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10203,19 +15219,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10242,100 +15274,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPArea.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPArea.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6913,16 +10201,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 48
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 48
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7040,19 +10336,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7084,9 +10396,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7130,17 +10450,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7161,17 +10497,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7208,11 +10560,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7228,7 +10588,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7236,27 +10596,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7372,31 +10740,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7409,40 +10809,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7456,8 +10880,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7525,38 +10957,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7569,39 +11033,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7612,39 +11100,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7672,29 +11200,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7759,9 +11303,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7788,16 +11340,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7814,12 +11382,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7845,19 +11429,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7923,51 +11531,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7980,11 +11596,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -8004,116 +11628,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8124,19 +11876,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8184,34 +11952,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8237,9 +12037,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8250,32 +12058,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8288,20 +12128,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8336,59 +12192,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8399,11 +12271,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8431,20 +12319,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8456,36 +12352,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8504,177 +12408,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8739,27 +12811,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8770,28 +12866,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8988,44 +13100,68 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load float, float* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 48
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load float, float* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, float %8)
-  br label %18
+  %17 = add i64 %16, 48
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9040,27 +13176,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9076,28 +13228,44 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Single::ToString using LLILCJit
@@ -9111,11 +13279,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %2 = load float, float addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne float addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load float, float addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9129,37 +13305,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9177,215 +13401,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9411,25 +14043,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9443,11 +14099,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9503,25 +14167,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9532,24 +14220,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9576,13 +14288,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9593,24 +14313,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9621,24 +14365,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9649,24 +14417,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9677,24 +14469,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9705,24 +14521,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9733,24 +14573,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9767,106 +14631,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9998,30 +14942,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10047,25 +15023,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10125,38 +15109,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10169,23 +15169,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10197,27 +15205,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10229,19 +15245,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10268,100 +15300,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPArray.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6877,16 +10165,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 48
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 48
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7004,19 +10300,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7048,9 +10360,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7094,17 +10414,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7125,17 +10461,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7172,11 +10524,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7192,7 +10552,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7200,27 +10560,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7336,31 +10704,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7373,40 +10773,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7420,8 +10844,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7489,38 +10921,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7533,39 +10997,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7576,39 +11064,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7636,29 +11164,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7723,9 +11267,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7752,16 +11304,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7778,12 +11346,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7809,19 +11393,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7887,51 +11495,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7944,11 +11560,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7968,116 +11592,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8088,19 +11840,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8148,34 +11916,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8201,9 +12001,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8214,32 +12022,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8252,20 +12092,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8300,59 +12156,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8363,11 +12235,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8395,20 +12283,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8420,36 +12316,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8468,177 +12372,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8703,27 +12775,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8734,28 +12830,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8952,44 +13064,68 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load float, float* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 48
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load float, float* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, float %8)
-  br label %18
+  %17 = add i64 %16, 48
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9004,27 +13140,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9040,28 +13192,44 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Single::ToString using LLILCJit
@@ -9075,11 +13243,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %2 = load float, float addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne float addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load float, float addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9093,37 +13269,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9141,215 +13365,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9375,25 +14007,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9407,11 +14063,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9467,25 +14131,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9496,24 +14184,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9540,13 +14252,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9557,24 +14277,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9585,24 +14329,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9613,24 +14381,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9641,24 +14433,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9669,24 +14485,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9697,24 +14537,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9731,106 +14595,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9962,30 +14906,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10011,25 +14987,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10089,38 +15073,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10133,23 +15133,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10161,27 +15169,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10193,19 +15209,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10232,100 +15264,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg2.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6894,16 +10182,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 48
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 48
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7021,19 +10317,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7065,9 +10377,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7111,17 +10431,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7142,17 +10478,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7189,11 +10541,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7209,7 +10569,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7217,27 +10577,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7353,31 +10721,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7390,40 +10790,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7437,8 +10861,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7506,38 +10938,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7550,39 +11014,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7593,39 +11081,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7653,29 +11181,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7740,9 +11284,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7769,16 +11321,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7795,12 +11363,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7826,19 +11410,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7904,51 +11512,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7961,11 +11577,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7985,116 +11609,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8105,19 +11857,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8165,34 +11933,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8218,9 +12018,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8231,32 +12039,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8269,20 +12109,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8317,59 +12173,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8380,11 +12252,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8412,20 +12300,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8437,36 +12333,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8485,177 +12389,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8720,27 +12792,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8751,28 +12847,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8969,44 +13081,68 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load float, float* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 48
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load float, float* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, float %8)
-  br label %18
+  %17 = add i64 %16, 48
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9021,27 +13157,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9057,28 +13209,44 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Single::ToString using LLILCJit
@@ -9092,11 +13260,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %2 = load float, float addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne float addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load float, float addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9110,37 +13286,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9158,215 +13382,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9392,25 +14024,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9424,11 +14080,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9484,25 +14148,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9513,24 +14201,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9557,13 +14269,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9574,24 +14294,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9602,24 +14346,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9630,24 +14398,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9658,24 +14450,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9686,24 +14502,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9714,24 +14554,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9748,106 +14612,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9979,30 +14923,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10028,25 +15004,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10106,38 +15090,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10150,23 +15150,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10178,27 +15186,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10210,19 +15226,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10249,100 +15281,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg6.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg6.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6910,16 +10198,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 48
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 48
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7037,19 +10333,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7081,9 +10393,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7127,17 +10447,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7158,17 +10494,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7205,11 +10557,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7225,7 +10585,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7233,27 +10593,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7369,31 +10737,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7406,40 +10806,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7453,8 +10877,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7522,38 +10954,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7566,39 +11030,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7609,39 +11097,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7669,29 +11197,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7756,9 +11300,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7785,16 +11337,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7811,12 +11379,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7842,19 +11426,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7920,51 +11528,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7977,11 +11593,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -8001,116 +11625,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8121,19 +11873,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8181,34 +11949,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8234,9 +12034,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8247,32 +12055,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8285,20 +12125,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8333,59 +12189,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8396,11 +12268,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8428,20 +12316,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8453,36 +12349,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8501,177 +12405,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8736,27 +12808,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8767,28 +12863,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8985,44 +13097,68 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load float, float* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 48
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load float, float* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, float %8)
-  br label %18
+  %17 = add i64 %16, 48
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9037,27 +13173,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9073,28 +13225,44 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Single::ToString using LLILCJit
@@ -9108,11 +13276,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %2 = load float, float addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne float addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load float, float addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9126,37 +13302,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9174,215 +13398,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9408,25 +14040,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9440,11 +14096,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9500,25 +14164,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9529,24 +14217,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9573,13 +14285,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9590,24 +14310,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9618,24 +14362,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9646,24 +14414,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9674,24 +14466,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9702,24 +14518,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9730,24 +14570,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9764,106 +14628,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9995,30 +14939,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10044,25 +15020,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10122,38 +15106,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10166,23 +15166,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10194,27 +15202,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10226,19 +15242,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10265,100 +15297,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPCall1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPCall1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6907,16 +10195,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 48
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 48
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7034,19 +10330,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7078,9 +10390,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7124,17 +10444,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7155,17 +10491,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7202,11 +10554,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7222,7 +10582,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7230,27 +10590,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7366,31 +10734,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7403,40 +10803,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7450,8 +10874,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7519,38 +10951,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7563,39 +11027,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7606,39 +11094,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7666,29 +11194,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7753,9 +11297,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7782,16 +11334,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7808,12 +11376,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7839,19 +11423,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7917,51 +11525,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7974,11 +11590,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7998,116 +11622,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8118,19 +11870,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8178,34 +11946,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8231,9 +12031,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8244,32 +12052,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8282,20 +12122,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8330,59 +12186,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8393,11 +12265,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8425,20 +12313,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8450,36 +12346,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8498,177 +12402,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8733,27 +12805,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8764,28 +12860,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8982,44 +13094,68 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load float, float* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 48
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load float, float* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, float %8)
-  br label %18
+  %17 = add i64 %16, 48
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9034,27 +13170,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9070,28 +13222,44 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Single::ToString using LLILCJit
@@ -9105,11 +13273,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %2 = load float, float addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne float addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load float, float addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9123,37 +13299,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9171,215 +13395,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9405,25 +14037,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9437,11 +14093,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9497,25 +14161,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9526,24 +14214,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9570,13 +14282,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9587,24 +14307,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9615,24 +14359,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9643,24 +14411,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9671,24 +14463,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9699,24 +14515,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9727,24 +14567,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9761,106 +14625,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9992,30 +14936,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10041,25 +15017,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10119,38 +15103,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10163,23 +15163,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10191,27 +15199,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10223,19 +15239,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10262,100 +15294,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPCall2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPCall2.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6917,16 +10205,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 48
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 48
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7044,19 +10340,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7088,9 +10400,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7134,17 +10454,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7165,17 +10501,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7212,11 +10564,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7232,7 +10592,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7240,27 +10600,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7376,31 +10744,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7413,40 +10813,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7460,8 +10884,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7529,38 +10961,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7573,39 +11037,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7616,39 +11104,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7676,29 +11204,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7763,9 +11307,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7792,16 +11344,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7818,12 +11386,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7849,19 +11433,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7927,51 +11535,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7984,11 +11600,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -8008,116 +11632,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8128,19 +11880,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8188,34 +11956,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8241,9 +12041,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8254,32 +12062,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8292,20 +12132,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8340,59 +12196,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8403,11 +12275,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8435,20 +12323,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8460,36 +12356,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8508,177 +12412,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8743,27 +12815,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8774,28 +12870,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8992,44 +13104,68 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load float, float* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 48
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load float, float* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, float %8)
-  br label %18
+  %17 = add i64 %16, 48
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9044,27 +13180,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9080,28 +13232,44 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Single::ToString using LLILCJit
@@ -9115,11 +13283,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %2 = load float, float addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne float addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load float, float addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9133,37 +13309,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9181,215 +13405,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9415,25 +14047,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9447,11 +14103,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9507,25 +14171,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9536,24 +14224,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9580,13 +14292,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9597,24 +14317,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9625,24 +14369,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9653,24 +14421,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9681,24 +14473,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9709,24 +14525,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9737,24 +14577,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9771,106 +14635,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10002,30 +14946,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10051,25 +15027,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10129,38 +15113,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10173,23 +15173,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10201,27 +15209,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10233,19 +15249,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10272,100 +15304,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvDbl2Lng.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvDbl2Lng.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6938,16 +10226,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i64, i64* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i64)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i64)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7065,19 +10361,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7109,9 +10421,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7155,17 +10475,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7186,17 +10522,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7233,11 +10585,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7253,7 +10613,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7261,27 +10621,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7397,31 +10765,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7434,40 +10834,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7481,8 +10905,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7550,38 +10982,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7594,39 +11058,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7637,39 +11125,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7697,29 +11225,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7784,9 +11328,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7813,16 +11365,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7839,12 +11407,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7870,19 +11454,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7948,51 +11556,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -8005,11 +11621,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -8029,116 +11653,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8149,19 +11901,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8209,34 +11977,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8262,9 +12062,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8275,32 +12083,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8313,20 +12153,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8361,59 +12217,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8424,11 +12296,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8456,20 +12344,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8481,36 +12377,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8529,177 +12433,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8764,27 +12836,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8795,28 +12891,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9013,44 +13125,68 @@ entry:
   store i64 %param1, i64* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load i64, i64* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 32
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load i64, i64* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, i64)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, i64 %8)
-  br label %18
+  %17 = add i64 %16, 32
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, i64)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, i64 %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9065,27 +13201,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i64, i64* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 16
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i64)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 16
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i64)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9101,28 +13253,44 @@ entry:
   %1 = addrspacecast i64* %arg1 to i64 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast i64 addrspace(1)* %1 to %System.Int64 addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int64 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int64 addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast i64 addrspace(1)* %1 to %System.Int64 addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int64 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int64 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Int64::ToString using LLILCJit
@@ -9136,11 +13304,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Int64 addrspace(1)*, %System.Int64 addrspace(1)** %this
   %1 = bitcast %System.Int64 addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i64, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i64 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i64, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i64 %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9154,37 +13330,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9202,215 +13426,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9436,25 +14068,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9468,11 +14124,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9528,25 +14192,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9557,24 +14245,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9601,13 +14313,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9618,24 +14338,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9646,24 +14390,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9674,24 +14442,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9702,24 +14494,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9730,24 +14546,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9758,24 +14598,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9792,106 +14656,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10023,30 +14967,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10072,25 +15048,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10150,38 +15134,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10194,23 +15194,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10222,27 +15230,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10254,19 +15270,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10293,100 +15325,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method BringUpTest::FPConvDbl2Lng using LLILCJit
@@ -10411,16 +15523,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i64, i64* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i64)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i64)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
@@ -10436,44 +15556,68 @@ entry:
   store i64 %param1, i64* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load i64, i64* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 40
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load i64, i64* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, i64)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, i64 %8)
-  br label %18
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, i64)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, i64 %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10488,27 +15632,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i64, i64* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 24
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i64)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 24
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i64)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -10524,28 +15684,44 @@ entry:
   %1 = addrspacecast i64* %arg1 to i64 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast i64 addrspace(1)* %1 to %System.UInt64 addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.UInt64 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.UInt64 addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast i64 addrspace(1)* %1 to %System.UInt64 addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.UInt64 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.UInt64 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UInt64::ToString using LLILCJit
@@ -10559,11 +15735,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.UInt64 addrspace(1)*, %System.UInt64 addrspace(1)** %this
   %1 = bitcast %System.UInt64 addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i64, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i64 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i64, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i64 %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2F.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2F.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6887,16 +10175,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 56
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 56
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7014,19 +10310,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7058,9 +10370,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7104,17 +10424,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7135,17 +10471,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7182,11 +10534,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7202,7 +10562,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7210,27 +10570,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7346,31 +10714,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7383,40 +10783,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7430,8 +10854,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7499,38 +10931,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7543,39 +11007,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7586,39 +11074,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7646,29 +11174,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7733,9 +11277,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7762,16 +11314,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7788,12 +11356,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7819,19 +11403,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7897,51 +11505,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7954,11 +11570,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7978,116 +11602,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8098,19 +11850,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8158,34 +11926,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8211,9 +12011,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8224,32 +12032,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8262,20 +12102,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8310,59 +12166,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8373,11 +12245,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8405,20 +12293,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8430,36 +12326,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8478,177 +12382,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8713,27 +12785,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8744,28 +12840,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8962,44 +13074,68 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load double, double* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 56
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load double, double* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, double %8)
-  br label %18
+  %17 = add i64 %16, 56
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9014,27 +13150,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9050,28 +13202,44 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Double::ToString using LLILCJit
@@ -9085,11 +13253,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %2 = load double, double addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne double addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load double, double addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9103,37 +13279,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9151,215 +13375,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9385,25 +14017,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9417,11 +14073,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9477,25 +14141,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9506,24 +14194,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9550,13 +14262,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9567,24 +14287,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9595,24 +14339,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9623,24 +14391,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9651,24 +14443,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9679,24 +14495,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9707,24 +14547,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9741,106 +14605,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9972,30 +14916,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10021,25 +14997,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10099,38 +15083,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10143,23 +15143,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10171,27 +15179,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10203,19 +15219,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10242,100 +15274,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method BringUpTest::FPConvF2F using LLILCJit
@@ -10360,16 +15472,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 48
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 48
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
@@ -10385,44 +15505,68 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load float, float* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 48
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load float, float* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, float %8)
-  br label %18
+  %17 = add i64 %16, 48
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10437,27 +15581,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -10473,28 +15633,44 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Single::ToString using LLILCJit
@@ -10508,11 +15684,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %2 = load float, float addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne float addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load float, float addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2I.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2I.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6942,16 +10230,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i32, i32* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 16
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 16
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7069,19 +10365,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7113,9 +10425,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7159,17 +10479,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7190,17 +10526,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7237,11 +10589,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7257,7 +10617,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7265,27 +10625,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7401,31 +10769,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7438,40 +10838,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7485,8 +10909,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7554,38 +10986,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7598,39 +11062,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7641,39 +11129,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7701,29 +11229,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7788,9 +11332,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7817,16 +11369,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7843,12 +11411,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7874,19 +11458,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7952,51 +11560,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -8009,11 +11625,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -8033,116 +11657,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8153,19 +11905,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8213,34 +11981,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8266,9 +12066,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8279,32 +12087,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8317,20 +12157,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8365,59 +12221,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8428,11 +12300,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8460,20 +12348,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8485,36 +12381,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8533,177 +12437,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8768,27 +12840,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8799,28 +12895,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9017,44 +13129,68 @@ entry:
   store i32 %param1, i32* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load i32, i32* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 16
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load i32, i32* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, i32)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, i32 %8)
-  br label %18
+  %17 = add i64 %16, 16
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, i32 %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9069,27 +13205,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i32, i32* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 0
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 0
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9105,28 +13257,44 @@ entry:
   %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int32 addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int32 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Int32::ToString using LLILCJit
@@ -9140,11 +13308,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9158,37 +13334,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9206,215 +13430,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9440,25 +14072,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9472,11 +14128,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9532,25 +14196,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9561,24 +14249,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9605,13 +14317,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9622,24 +14342,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9650,24 +14394,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9678,24 +14446,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9706,24 +14498,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9734,24 +14550,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9762,24 +14602,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9796,106 +14660,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10027,30 +14971,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10076,25 +15052,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10154,38 +15138,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10198,23 +15198,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10226,27 +15234,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10258,19 +15274,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10297,100 +15329,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method BringUpTest::FPConvF2I using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2Lng.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2Lng.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6938,16 +10226,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i64, i64* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i64)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i64)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7065,19 +10361,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7109,9 +10421,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7155,17 +10475,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7186,17 +10522,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7233,11 +10585,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7253,7 +10613,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7261,27 +10621,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7397,31 +10765,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7434,40 +10834,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7481,8 +10905,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7550,38 +10982,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7594,39 +11058,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7637,39 +11125,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7697,29 +11225,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7784,9 +11328,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7813,16 +11365,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7839,12 +11407,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7870,19 +11454,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7948,51 +11556,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -8005,11 +11621,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -8029,116 +11653,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8149,19 +11901,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8209,34 +11977,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8262,9 +12062,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8275,32 +12083,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8313,20 +12153,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8361,59 +12217,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8424,11 +12296,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8456,20 +12344,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8481,36 +12377,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8529,177 +12433,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8764,27 +12836,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8795,28 +12891,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9013,44 +13125,68 @@ entry:
   store i64 %param1, i64* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load i64, i64* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 32
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load i64, i64* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, i64)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, i64 %8)
-  br label %18
+  %17 = add i64 %16, 32
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, i64)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, i64 %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9065,27 +13201,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i64, i64* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 16
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i64)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 16
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i64)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9101,28 +13253,44 @@ entry:
   %1 = addrspacecast i64* %arg1 to i64 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast i64 addrspace(1)* %1 to %System.Int64 addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int64 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int64 addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast i64 addrspace(1)* %1 to %System.Int64 addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int64 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int64 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Int64::ToString using LLILCJit
@@ -9136,11 +13304,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Int64 addrspace(1)*, %System.Int64 addrspace(1)** %this
   %1 = bitcast %System.Int64 addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i64, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i64 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i64, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i64 %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9154,37 +13330,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9202,215 +13426,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9436,25 +14068,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9468,11 +14124,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9528,25 +14192,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9557,24 +14245,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9601,13 +14313,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9618,24 +14338,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9646,24 +14390,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9674,24 +14442,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9702,24 +14494,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9730,24 +14546,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9758,24 +14598,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9792,106 +14656,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10023,30 +14967,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10072,25 +15048,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10150,38 +15134,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10194,23 +15194,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10222,27 +15230,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10254,19 +15270,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10293,100 +15325,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method BringUpTest::FPConvF2Lng using LLILCJit
@@ -10411,16 +15523,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i64, i64* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i64)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i64)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
@@ -10436,44 +15556,68 @@ entry:
   store i64 %param1, i64* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load i64, i64* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 40
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load i64, i64* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, i64)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, i64 %8)
-  br label %18
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, i64)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, i64 %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10488,27 +15632,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i64, i64* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 24
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i64)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 24
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i64)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -10524,28 +15684,44 @@ entry:
   %1 = addrspacecast i64* %arg1 to i64 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast i64 addrspace(1)* %1 to %System.UInt64 addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.UInt64 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.UInt64 addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast i64 addrspace(1)* %1 to %System.UInt64 addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.UInt64 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.UInt64 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UInt64::ToString using LLILCJit
@@ -10559,11 +15735,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.UInt64 addrspace(1)*, %System.UInt64 addrspace(1)** %this
   %1 = bitcast %System.UInt64 addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i64, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i64 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i64, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i64 %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvI2F.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvI2F.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6887,16 +10175,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 48
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 48
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7014,19 +10310,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7058,9 +10370,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7104,17 +10424,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7135,17 +10471,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7182,11 +10534,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7202,7 +10562,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7210,27 +10570,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7346,31 +10714,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7383,40 +10783,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7430,8 +10854,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7499,38 +10931,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7543,39 +11007,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7586,39 +11074,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7646,29 +11174,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7733,9 +11277,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7762,16 +11314,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7788,12 +11356,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7819,19 +11403,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7897,51 +11505,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7954,11 +11570,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7978,116 +11602,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8098,19 +11850,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8158,34 +11926,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8211,9 +12011,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8224,32 +12032,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8262,20 +12102,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8310,59 +12166,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8373,11 +12245,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8405,20 +12293,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8430,36 +12326,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8478,177 +12382,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8713,27 +12785,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8744,28 +12840,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8962,44 +13074,68 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load float, float* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 48
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load float, float* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, float %8)
-  br label %18
+  %17 = add i64 %16, 48
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9014,27 +13150,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9050,28 +13202,44 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Single::ToString using LLILCJit
@@ -9085,11 +13253,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %2 = load float, float addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne float addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load float, float addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9103,37 +13279,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9151,215 +13375,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9385,25 +14017,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9417,11 +14073,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9477,25 +14141,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9506,24 +14194,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9550,13 +14262,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9567,24 +14287,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9595,24 +14339,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9623,24 +14391,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9651,24 +14443,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9679,24 +14495,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9707,24 +14547,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9741,106 +14605,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9972,30 +14916,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10021,25 +14997,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10099,38 +15083,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10143,23 +15143,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10171,27 +15179,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10203,19 +15219,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10242,100 +15274,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method BringUpTest::FPConvI2F using LLILCJit
@@ -10360,16 +15472,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 56
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 56
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
@@ -10385,44 +15505,68 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load double, double* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 56
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load double, double* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, double %8)
-  br label %18
+  %17 = add i64 %16, 56
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10437,27 +15581,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -10473,28 +15633,44 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Double::ToString using LLILCJit
@@ -10508,11 +15684,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %2 = load double, double addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne double addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load double, double addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method BringUpTest::FPConvI2F using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDist.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDist.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6877,16 +10165,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 48
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 48
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7004,19 +10300,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7048,9 +10360,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7094,17 +10414,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7125,17 +10461,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7172,11 +10524,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7192,7 +10552,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7200,27 +10560,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7336,31 +10704,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7373,40 +10773,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7420,8 +10844,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7489,38 +10921,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7533,39 +10997,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7576,39 +11064,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7636,29 +11164,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7723,9 +11267,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7752,16 +11304,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7778,12 +11346,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7809,19 +11393,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7887,51 +11495,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7944,11 +11560,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7968,116 +11592,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8088,19 +11840,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8148,34 +11916,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8201,9 +12001,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8214,32 +12022,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8252,20 +12092,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8300,59 +12156,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8363,11 +12235,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8395,20 +12283,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8420,36 +12316,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8468,177 +12372,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8703,27 +12775,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8734,28 +12830,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8952,44 +13064,68 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load float, float* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 48
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load float, float* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, float %8)
-  br label %18
+  %17 = add i64 %16, 48
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9004,27 +13140,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9040,28 +13192,44 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Single::ToString using LLILCJit
@@ -9075,11 +13243,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %2 = load float, float addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne float addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load float, float addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9093,37 +13269,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9141,215 +13365,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9375,25 +14007,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9407,11 +14063,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9467,25 +14131,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9496,24 +14184,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9540,13 +14252,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9557,24 +14277,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9585,24 +14329,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9613,24 +14381,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9641,24 +14433,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9669,24 +14485,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9697,24 +14537,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9731,106 +14595,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9962,30 +14906,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10011,25 +14987,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10089,38 +15073,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10133,23 +15133,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10161,27 +15169,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10193,19 +15209,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10232,100 +15264,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDiv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDiv.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6890,16 +10178,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 48
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 48
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7017,19 +10313,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7061,9 +10373,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7107,17 +10427,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7138,17 +10474,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7185,11 +10537,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7205,7 +10565,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7213,27 +10573,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7349,31 +10717,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7386,40 +10786,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7433,8 +10857,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7502,38 +10934,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7546,39 +11010,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7589,39 +11077,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7649,29 +11177,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7736,9 +11280,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7765,16 +11317,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7791,12 +11359,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7822,19 +11406,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7900,51 +11508,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7957,11 +11573,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7981,116 +11605,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8101,19 +11853,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8161,34 +11929,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8214,9 +12014,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8227,32 +12035,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8265,20 +12105,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8313,59 +12169,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8376,11 +12248,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8408,20 +12296,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8433,36 +12329,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,177 +12385,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8716,27 +12788,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8747,28 +12843,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8965,44 +13077,68 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load float, float* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 48
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load float, float* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, float %8)
-  br label %18
+  %17 = add i64 %16, 48
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9017,27 +13153,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9053,28 +13205,44 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Single::ToString using LLILCJit
@@ -9088,11 +13256,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %2 = load float, float addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne float addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load float, float addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9106,37 +13282,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9154,215 +13378,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9388,25 +14020,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9420,11 +14076,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9480,25 +14144,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9509,24 +14197,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9553,13 +14265,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9570,24 +14290,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9598,24 +14342,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9626,24 +14394,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9654,24 +14446,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9682,24 +14498,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9710,24 +14550,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9744,106 +14608,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9975,30 +14919,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10024,25 +15000,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10102,38 +15086,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10146,23 +15146,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10174,27 +15182,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10206,19 +15222,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10245,100 +15277,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDivConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDivConst.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6887,16 +10175,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 48
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 48
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7014,19 +10310,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7058,9 +10370,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7104,17 +10424,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7135,17 +10471,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7182,11 +10534,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7202,7 +10562,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7210,27 +10570,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7346,31 +10714,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7383,40 +10783,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7430,8 +10854,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7499,38 +10931,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7543,39 +11007,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7586,39 +11074,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7646,29 +11174,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7733,9 +11277,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7762,16 +11314,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7788,12 +11356,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7819,19 +11403,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7897,51 +11505,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7954,11 +11570,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7978,116 +11602,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8098,19 +11850,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8158,34 +11926,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8211,9 +12011,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8224,32 +12032,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8262,20 +12102,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8310,59 +12166,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8373,11 +12245,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8405,20 +12293,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8430,36 +12326,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8478,177 +12382,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8713,27 +12785,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8744,28 +12840,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8962,44 +13074,68 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load float, float* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 48
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load float, float* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, float %8)
-  br label %18
+  %17 = add i64 %16, 48
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9014,27 +13150,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9050,28 +13202,44 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Single::ToString using LLILCJit
@@ -9085,11 +13253,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %2 = load float, float addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne float addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load float, float addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9103,37 +13279,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9151,215 +13375,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9385,25 +14017,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9417,11 +14073,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9477,25 +14141,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9506,24 +14194,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9550,13 +14262,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9567,24 +14287,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9595,24 +14339,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9623,24 +14391,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9651,24 +14443,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9679,24 +14495,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9707,24 +14547,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9741,106 +14605,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9972,30 +14916,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10021,25 +14997,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10099,38 +15083,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10143,23 +15143,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10171,27 +15179,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10203,19 +15219,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10242,100 +15274,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPError.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPError.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6894,16 +10182,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 48
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 48
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7021,19 +10317,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7065,9 +10377,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7111,17 +10431,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7142,17 +10478,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7189,11 +10541,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7209,7 +10569,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7217,27 +10577,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7353,31 +10721,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7390,40 +10790,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7437,8 +10861,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7506,38 +10938,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7550,39 +11014,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7593,39 +11081,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7653,29 +11181,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7740,9 +11284,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7769,16 +11321,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7795,12 +11363,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7826,19 +11410,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7904,51 +11512,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7961,11 +11577,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7985,116 +11609,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8105,19 +11857,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8165,34 +11933,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8218,9 +12018,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8231,32 +12039,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8269,20 +12109,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8317,59 +12173,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8380,11 +12252,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8412,20 +12300,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8437,36 +12333,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8485,177 +12389,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8720,27 +12792,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8751,28 +12847,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8969,44 +13081,68 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load float, float* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 48
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load float, float* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, float %8)
-  br label %18
+  %17 = add i64 %16, 48
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9021,27 +13157,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9057,28 +13209,44 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Single::ToString using LLILCJit
@@ -9092,11 +13260,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %2 = load float, float addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne float addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load float, float addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9110,37 +13286,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9158,215 +13382,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9392,25 +14024,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9424,11 +14080,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9484,25 +14148,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9513,24 +14201,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9557,13 +14269,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9574,24 +14294,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9602,24 +14346,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9630,24 +14398,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9658,24 +14450,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9686,24 +14502,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9714,24 +14554,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9748,106 +14612,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9979,30 +14923,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10028,25 +15004,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10106,38 +15090,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10150,23 +15150,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10178,27 +15186,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10210,19 +15226,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10249,100 +15281,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPFillArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPFillArray.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6879,16 +10167,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 48
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 48
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7006,19 +10302,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7050,9 +10362,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7096,17 +10416,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7127,17 +10463,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7174,11 +10526,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7194,7 +10554,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7202,27 +10562,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7338,31 +10706,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7375,40 +10775,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7422,8 +10846,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7491,38 +10923,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7535,39 +10999,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7578,39 +11066,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7638,29 +11166,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7725,9 +11269,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7754,16 +11306,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7780,12 +11348,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7811,19 +11395,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7889,51 +11497,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7946,11 +11562,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7970,116 +11594,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8090,19 +11842,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8150,34 +11918,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8203,9 +12003,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8216,32 +12024,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8254,20 +12094,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8302,59 +12158,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8365,11 +12237,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8397,20 +12285,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8422,36 +12318,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8470,177 +12374,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8705,27 +12777,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8736,28 +12832,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8954,44 +13066,68 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load float, float* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 48
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load float, float* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, float %8)
-  br label %18
+  %17 = add i64 %16, 48
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9006,27 +13142,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9042,28 +13194,44 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Single::ToString using LLILCJit
@@ -9077,11 +13245,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %2 = load float, float addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne float addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load float, float addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9095,37 +13271,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9143,215 +13367,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9377,25 +14009,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9409,11 +14065,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9469,25 +14133,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9498,24 +14186,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9542,13 +14254,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9559,24 +14279,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9587,24 +14331,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9615,24 +14383,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9643,24 +14435,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9671,24 +14487,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9699,24 +14539,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9733,106 +14597,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9964,30 +14908,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10013,25 +14989,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10091,38 +15075,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10135,23 +15135,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10163,27 +15171,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10195,19 +15211,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10234,100 +15266,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMath.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMath.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6879,16 +10167,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 56
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 56
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7006,19 +10302,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7050,9 +10362,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7096,17 +10416,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7127,17 +10463,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7174,11 +10526,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7194,7 +10554,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7202,27 +10562,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7338,31 +10706,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7375,40 +10775,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7422,8 +10846,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7491,38 +10923,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7535,39 +10999,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7578,39 +11066,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7638,29 +11166,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7725,9 +11269,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7754,16 +11306,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7780,12 +11348,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7811,19 +11395,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7889,51 +11497,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7946,11 +11562,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7970,116 +11594,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8090,19 +11842,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8150,34 +11918,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8203,9 +12003,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8216,32 +12024,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8254,20 +12094,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8302,59 +12158,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8365,11 +12237,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8397,20 +12285,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8422,36 +12318,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8470,177 +12374,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8705,27 +12777,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8736,28 +12832,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8954,44 +13066,68 @@ entry:
   store double %param1, double* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load double, double* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 56
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load double, double* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, double %8)
-  br label %18
+  %17 = add i64 %16, 56
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9006,27 +13142,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9042,28 +13194,44 @@ entry:
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Double::ToString using LLILCJit
@@ -9077,11 +13245,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
   %1 = bitcast %System.Double addrspace(1)* %0 to double addrspace(1)*
-  %2 = load double, double addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne double addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load double, double addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9095,37 +13271,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9143,215 +13367,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9377,25 +14009,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9409,11 +14065,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9469,25 +14133,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9498,24 +14186,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9542,13 +14254,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9559,24 +14279,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9587,24 +14331,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9615,24 +14383,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9643,24 +14435,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9671,24 +14487,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9699,24 +14539,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9733,106 +14597,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9964,30 +14908,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10013,25 +14989,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10091,38 +15075,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10135,23 +15135,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10163,27 +15171,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10195,19 +15211,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10234,100 +15266,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMul.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMul.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6890,16 +10178,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 48
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 48
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7017,19 +10313,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7061,9 +10373,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7107,17 +10427,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7138,17 +10474,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7185,11 +10537,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7205,7 +10565,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7213,27 +10573,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7349,31 +10717,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7386,40 +10786,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7433,8 +10857,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7502,38 +10934,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7546,39 +11010,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7589,39 +11077,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7649,29 +11177,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7736,9 +11280,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7765,16 +11317,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7791,12 +11359,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7822,19 +11406,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7900,51 +11508,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7957,11 +11573,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7981,116 +11605,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8101,19 +11853,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8161,34 +11929,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8214,9 +12014,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8227,32 +12035,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8265,20 +12105,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8313,59 +12169,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8376,11 +12248,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8408,20 +12296,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8433,36 +12329,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,177 +12385,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8716,27 +12788,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8747,28 +12843,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8965,44 +13077,68 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load float, float* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 48
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load float, float* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, float %8)
-  br label %18
+  %17 = add i64 %16, 48
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9017,27 +13153,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9053,28 +13205,44 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Single::ToString using LLILCJit
@@ -9088,11 +13256,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %2 = load float, float addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne float addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load float, float addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9106,37 +13282,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9154,215 +13378,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9388,25 +14020,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9420,11 +14076,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9480,25 +14144,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9509,24 +14197,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9553,13 +14265,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9570,24 +14290,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9598,24 +14342,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9626,24 +14394,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9654,24 +14446,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9682,24 +14498,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9710,24 +14550,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9744,106 +14608,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9975,30 +14919,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10024,25 +15000,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10102,38 +15086,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10146,23 +15146,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10174,27 +15182,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10206,19 +15222,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10245,100 +15277,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMulConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMulConst.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6889,16 +10177,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 48
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 48
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7016,19 +10312,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7060,9 +10372,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7106,17 +10426,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7137,17 +10473,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7184,11 +10536,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7204,7 +10564,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7212,27 +10572,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7348,31 +10716,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7385,40 +10785,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7432,8 +10856,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7501,38 +10933,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7545,39 +11009,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7588,39 +11076,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7648,29 +11176,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7735,9 +11279,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7764,16 +11316,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7790,12 +11358,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7821,19 +11405,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7899,51 +11507,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7956,11 +11572,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7980,116 +11604,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8100,19 +11852,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8160,34 +11928,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8213,9 +12013,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8226,32 +12034,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8264,20 +12104,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8312,59 +12168,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8375,11 +12247,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8407,20 +12295,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8432,36 +12328,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8480,177 +12384,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8715,27 +12787,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8746,28 +12842,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8964,44 +13076,68 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load float, float* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 48
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load float, float* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, float %8)
-  br label %18
+  %17 = add i64 %16, 48
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9016,27 +13152,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9052,28 +13204,44 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Single::ToString using LLILCJit
@@ -9087,11 +13255,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %2 = load float, float addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne float addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load float, float addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9105,37 +13281,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9153,215 +13377,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9387,25 +14019,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9419,11 +14075,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9479,25 +14143,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9508,24 +14196,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9552,13 +14264,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9569,24 +14289,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9597,24 +14341,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9625,24 +14393,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9653,24 +14445,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9681,24 +14497,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9709,24 +14549,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9743,106 +14607,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9974,30 +14918,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10023,25 +14999,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10101,38 +15085,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10145,23 +15145,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10173,27 +15181,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10205,19 +15221,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10244,100 +15276,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPNeg.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6887,16 +10175,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 48
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 48
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7014,19 +10310,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7058,9 +10370,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7104,17 +10424,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7135,17 +10471,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7182,11 +10534,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7202,7 +10562,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7210,27 +10570,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7346,31 +10714,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7383,40 +10783,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7430,8 +10854,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7499,38 +10931,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7543,39 +11007,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7586,39 +11074,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7646,29 +11174,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7733,9 +11277,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7762,16 +11314,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7788,12 +11356,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7819,19 +11403,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7897,51 +11505,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7954,11 +11570,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7978,116 +11602,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8098,19 +11850,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8158,34 +11926,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8211,9 +12011,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8224,32 +12032,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8262,20 +12102,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8310,59 +12166,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8373,11 +12245,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8405,20 +12293,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8430,36 +12326,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8478,177 +12382,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8713,27 +12785,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8744,28 +12840,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8962,44 +13074,68 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load float, float* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 48
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load float, float* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, float %8)
-  br label %18
+  %17 = add i64 %16, 48
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9014,27 +13150,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9050,28 +13202,44 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Single::ToString using LLILCJit
@@ -9085,11 +13253,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %2 = load float, float addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne float addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load float, float addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9103,37 +13279,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9151,215 +13375,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9385,25 +14017,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9417,11 +14073,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9477,25 +14141,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9506,24 +14194,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9550,13 +14262,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9567,24 +14287,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9595,24 +14339,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9623,24 +14391,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9651,24 +14443,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9679,24 +14495,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9707,24 +14547,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9741,106 +14605,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9972,30 +14916,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10021,25 +14997,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10099,38 +15083,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10143,23 +15143,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10171,27 +15179,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10203,19 +15219,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10242,100 +15274,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPRem.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPRem.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6890,16 +10178,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 48
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 48
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7017,19 +10313,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7061,9 +10373,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7107,17 +10427,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7138,17 +10474,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7185,11 +10537,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7205,7 +10565,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7213,27 +10573,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7349,31 +10717,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7386,40 +10786,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7433,8 +10857,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7502,38 +10934,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7546,39 +11010,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7589,39 +11077,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7649,29 +11177,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7736,9 +11280,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7765,16 +11317,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7791,12 +11359,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7822,19 +11406,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7900,51 +11508,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7957,11 +11573,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7981,116 +11605,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8101,19 +11853,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8161,34 +11929,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8214,9 +12014,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8227,32 +12035,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8265,20 +12105,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8313,59 +12169,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8376,11 +12248,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8408,20 +12296,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8433,36 +12329,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,177 +12385,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8716,27 +12788,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8747,28 +12843,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8965,44 +13077,68 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load float, float* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 48
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load float, float* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, float %8)
-  br label %18
+  %17 = add i64 %16, 48
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9017,27 +13153,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9053,28 +13205,44 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Single::ToString using LLILCJit
@@ -9088,11 +13256,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %2 = load float, float addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne float addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load float, float addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9106,37 +13282,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9154,215 +13378,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9388,25 +14020,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9420,11 +14076,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9480,25 +14144,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9509,24 +14197,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9553,13 +14265,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9570,24 +14290,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9598,24 +14342,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9626,24 +14394,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9654,24 +14446,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9682,24 +14498,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9710,24 +14550,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9744,106 +14608,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9975,30 +14919,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10024,25 +15000,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10102,38 +15086,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10146,23 +15146,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10174,27 +15182,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10206,19 +15222,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10245,100 +15277,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPRoots.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPRoots.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6877,16 +10165,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 48
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 48
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7004,19 +10300,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7048,9 +10360,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7094,17 +10414,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7125,17 +10461,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7172,11 +10524,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7192,7 +10552,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7200,27 +10560,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7336,31 +10704,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7373,40 +10773,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7420,8 +10844,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7489,38 +10921,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7533,39 +10997,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7576,39 +11064,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7636,29 +11164,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7723,9 +11267,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7752,16 +11304,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7778,12 +11346,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7809,19 +11393,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7887,51 +11495,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7944,11 +11560,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7968,116 +11592,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8088,19 +11840,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8148,34 +11916,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8201,9 +12001,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8214,32 +12022,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8252,20 +12092,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8300,59 +12156,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8363,11 +12235,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8395,20 +12283,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8420,36 +12316,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8468,177 +12372,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8703,27 +12775,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8734,28 +12830,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8952,44 +13064,68 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load float, float* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 48
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load float, float* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, float %8)
-  br label %18
+  %17 = add i64 %16, 48
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9004,27 +13140,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9040,28 +13192,44 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Single::ToString using LLILCJit
@@ -9075,11 +13243,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %2 = load float, float addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne float addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load float, float addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9093,37 +13269,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9141,215 +13365,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9375,25 +14007,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9407,11 +14063,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9467,25 +14131,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9496,24 +14184,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9540,13 +14252,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9557,24 +14277,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9585,24 +14329,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9613,24 +14381,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9641,24 +14433,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9669,24 +14485,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9697,24 +14537,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9731,106 +14595,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9962,30 +14906,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10011,25 +14987,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10089,38 +15073,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10133,23 +15133,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10161,27 +15169,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10193,19 +15209,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10232,100 +15264,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -10374,39 +15486,63 @@ entry:
 ; <label>:17                                      ; preds = %11, %14
   %18 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
   %19 = bitcast %System.Object addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 0
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %28 = call %System.String addrspace(1)* %27(%System.Object addrspace(1)* %18)
-  %29 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %30 = bitcast %System.Object addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 0
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %39 = call %System.String addrspace(1)* %38(%System.Object addrspace(1)* %29)
-  %40 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
-  %41 = bitcast %System.Object addrspace(1)* %40 to i64 addrspace(1)*
-  %42 = load i64, i64 addrspace(1)* %41
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = add i64 %45, 0
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
+
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %29 = call %System.String addrspace(1)* %28(%System.Object addrspace(1)* %18)
+  %30 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %31 = bitcast %System.Object addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %20
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 0
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %41 = call %System.String addrspace(1)* %40(%System.Object addrspace(1)* %30)
+  %42 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  %43 = bitcast %System.Object addrspace(1)* %42 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %43, null
+  br i1 %NullCheck4, label %44, label %ThrowNullRef3
+
+; <label>:44                                      ; preds = %32
+  %45 = load i64, i64 addrspace(1)* %43
+  %46 = add i64 %45, 64
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
-  %49 = inttoptr i64 %48 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %50 = call %System.String addrspace(1)* %49(%System.Object addrspace(1)* %40)
-  %51 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %28, %System.String addrspace(1)* %39, %System.String addrspace(1)* %50)
-  ret %System.String addrspace(1)* %51
+  %49 = add i64 %48, 0
+  %50 = inttoptr i64 %49 to i64*
+  %51 = load i64, i64* %50
+  %52 = inttoptr i64 %51 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %53 = call %System.String addrspace(1)* %52(%System.Object addrspace(1)* %42)
+  %54 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %41, %System.String addrspace(1)* %53)
+  ret %System.String addrspace(1)* %54
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Single::ToString using LLILCJit
@@ -10418,10 +15554,18 @@ entry:
   store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %2 = load float, float addrspace(1)* %1, align 8
-  %3 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* ()*)()
-  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %3)
-  ret %System.String addrspace(1)* %4
+  %NullCheck = icmp ne float addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load float, float addrspace(1)* %1, align 8
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* ()*)()
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::get_CurrentInfo using LLILCJit
@@ -10500,41 +15644,89 @@ entry:
 
 ; <label>:25                                      ; preds = %20, %23
   %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
-  %28 = load i32, i32 addrspace(1)* %27
-  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %30 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
-  %31 = load i32, i32 addrspace(1)* %30
-  %32 = add i32 %28, %31
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 1
-  %35 = load i32, i32 addrspace(1)* %34
-  %36 = add i32 %32, %35
-  store i32 %36, i32* %loc0
-  %37 = load i32, i32* %loc0
-  %38 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %37)
-  store %System.String addrspace(1)* %38, %System.String addrspace(1)** %loc1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %39, i32 0, %System.String addrspace(1)* %40)
-  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %43 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
-  %44 = load i32, i32 addrspace(1)* %43
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, i32 %44, %System.String addrspace(1)* %45)
-  %46 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %47 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %48 = getelementptr inbounds %System.String, %System.String addrspace(1)* %47, i32 0, i32 1
-  %49 = load i32, i32 addrspace(1)* %48
-  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %51 = getelementptr inbounds %System.String, %System.String addrspace(1)* %50, i32 0, i32 1
-  %52 = load i32, i32 addrspace(1)* %51
-  %53 = add i32 %49, %52
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %46, i32 %53, %System.String addrspace(1)* %54)
-  %55 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %55
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %27, label %ThrowNullRef
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck2, label %31, label %ThrowNullRef1
+
+; <label>:31                                      ; preds = %27
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = add i32 %29, %33
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %35, null
+  br i1 %NullCheck4, label %36, label %ThrowNullRef3
+
+; <label>:36                                      ; preds = %31
+  %37 = getelementptr inbounds %System.String, %System.String addrspace(1)* %35, i32 0, i32 1
+  %38 = load i32, i32 addrspace(1)* %37
+  %39 = add i32 %34, %38
+  store i32 %39, i32* %loc0
+  %40 = load i32, i32* %loc0
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %40)
+  store %System.String addrspace(1)* %41, %System.String addrspace(1)** %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %42, i32 0, %System.String addrspace(1)* %43)
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %45, null
+  br i1 %NullCheck6, label %46, label %ThrowNullRef5
+
+; <label>:46                                      ; preds = %36
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 1
+  %48 = load i32, i32 addrspace(1)* %47
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %44, i32 %48, %System.String addrspace(1)* %49)
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck8, label %52, label %ThrowNullRef7
+
+; <label>:52                                      ; preds = %46
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %55, null
+  br i1 %NullCheck10, label %56, label %ThrowNullRef9
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %55, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = add i32 %54, %58
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %50, i32 %59, %System.String addrspace(1)* %60)
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %61
+
+ThrowNullRef:                                     ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
@@ -10547,16 +15739,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 104
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 8
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 104
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
@@ -10572,44 +15772,68 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 104
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 8
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 104
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, %System.String addrspace(1)* %8)
-  br label %18
+  %17 = add i64 %16, 8
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, %System.String addrspace(1)* %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10671,116 +15895,196 @@ entry:
 
 ; <label>:23                                      ; preds = %15
   %24 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
-  %26 = load i32, i32 addrspace(1)* %25
-  %27 = zext i32 %26 to i64
-  %28 = trunc i64 %27 to i32
-  %29 = load i32, i32* %arg2
-  %30 = sub i32 %28, %29
-  %31 = load i32, i32* %arg3
-  %32 = icmp sge i32 %30, %31
-  br i1 %32, label %37, label %33
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %24, null
+  br i1 %NullCheck, label %25, label %ThrowNullRef
 
-; <label>:33                                      ; preds = %23
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %35 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %34)
-  %36 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36, %System.String addrspace(1)* %35)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36) #0
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = trunc i64 %28 to i32
+  %30 = load i32, i32* %arg2
+  %31 = sub i32 %29, %30
+  %32 = load i32, i32* %arg3
+  %33 = icmp sge i32 %31, %32
+  br i1 %33, label %38, label %34
+
+; <label>:34                                      ; preds = %25
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %37, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %37) #0
   unreachable
 
-; <label>:37                                      ; preds = %23
-  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %38)
-  br label %89
+; <label>:38                                      ; preds = %25
+  %39 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %39)
+  br label %98
 
-; <label>:39                                      ; preds = %89
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %43, i32 0, i32 10
-  %45 = load i32, i32 addrspace(1)* %44, align 8
-  %46 = icmp ne i32 %42, %45
-  br i1 %46, label %49, label %47
+; <label>:40                                      ; preds = %98
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %41, null
+  br i1 %NullCheck4, label %42, label %ThrowNullRef3
 
-; <label>:47                                      ; preds = %39
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %48, i8 0, i8 0)
-  br label %49
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %45, null
+  br i1 %NullCheck6, label %46, label %ThrowNullRef5
 
-; <label>:49                                      ; preds = %39, %47
-  %50 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %51 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %50, i32 0, i32 10
-  %52 = load i32, i32 addrspace(1)* %51, align 8
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %45, i32 0, i32 10
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %49 = icmp ne i32 %44, %48
+  br i1 %49, label %52, label %50
+
+; <label>:50                                      ; preds = %46
+  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %51, i8 0, i8 0)
+  br label %52
+
+; <label>:52                                      ; preds = %46, %50
   %53 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %54 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 9
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = sub i32 %52, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc0
-  %58 = load i32, i32* %arg3
-  %59 = icmp sle i32 %57, %58
-  br i1 %59, label %62, label %60
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %53, null
+  br i1 %NullCheck8, label %54, label %ThrowNullRef7
 
-; <label>:60                                      ; preds = %49
-  %61 = load i32, i32* %arg3
+; <label>:54                                      ; preds = %52
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 10
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck10, label %58, label %ThrowNullRef9
+
+; <label>:58                                      ; preds = %54
+  %59 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 9
+  %60 = load i32, i32 addrspace(1)* %59, align 8
+  %61 = sub i32 %56, %60
   store i32 %61, i32* %loc0
-  br label %62
+  %62 = load i32, i32* %loc0
+  %63 = load i32, i32* %arg3
+  %64 = icmp sle i32 %62, %63
+  br i1 %64, label %67, label %65
 
-; <label>:62                                      ; preds = %49, %60
-  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %64 = load i32, i32* %arg2
-  %65 = mul i32 %64, 2
-  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %67 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 7
-  %68 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %70 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %69, i32 0, i32 9
-  %71 = load i32, i32 addrspace(1)* %70, align 8
-  %72 = mul i32 %71, 2
-  %73 = load i32, i32* %loc0
-  %74 = mul i32 %73, 2
-  %75 = bitcast %"System.Char[]" addrspace(1)* %63 to %System.Array addrspace(1)*
-  %76 = bitcast %"System.Char[]" addrspace(1)* %68 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %75, i32 %65, %System.Array addrspace(1)* %76, i32 %72, i32 %74)
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
+; <label>:65                                      ; preds = %58
+  %66 = load i32, i32* %arg3
+  store i32 %66, i32* %loc0
+  br label %67
+
+; <label>:67                                      ; preds = %58, %65
+  %68 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %69 = load i32, i32* %arg2
+  %70 = mul i32 %69, 2
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %71, null
+  br i1 %NullCheck12, label %72, label %ThrowNullRef11
+
+; <label>:72                                      ; preds = %67
+  %73 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 7
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %73, align 8
+  %75 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %75, null
+  br i1 %NullCheck14, label %76, label %ThrowNullRef13
+
+; <label>:76                                      ; preds = %72
+  %77 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %75, i32 0, i32 9
+  %78 = load i32, i32 addrspace(1)* %77, align 8
+  %79 = mul i32 %78, 2
   %80 = load i32, i32* %loc0
-  %81 = add i32 %79, %80
-  %82 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  store i32 %81, i32 addrspace(1)* %82
-  %83 = load i32, i32* %arg2
-  %84 = load i32, i32* %loc0
-  %85 = add i32 %83, %84
-  store i32 %85, i32* %arg2
-  %86 = load i32, i32* %arg3
-  %87 = load i32, i32* %loc0
-  %88 = sub i32 %86, %87
-  store i32 %88, i32* %arg3
-  br label %89
+  %81 = mul i32 %80, 2
+  %82 = bitcast %"System.Char[]" addrspace(1)* %68 to %System.Array addrspace(1)*
+  %83 = bitcast %"System.Char[]" addrspace(1)* %74 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %82, i32 %70, %System.Array addrspace(1)* %83, i32 %79, i32 %81)
+  %84 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck16, label %85, label %ThrowNullRef15
 
-; <label>:89                                      ; preds = %37, %62
-  %90 = load i32, i32* %arg3
-  %91 = icmp sgt i32 %90, 0
-  br i1 %91, label %39, label %92
+; <label>:85                                      ; preds = %76
+  %86 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = load i32, i32* %loc0
+  %89 = add i32 %87, %88
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck18, label %90, label %ThrowNullRef17
 
-; <label>:92                                      ; preds = %89
-  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %94 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 11
-  %95 = load i8, i8 addrspace(1)* %94, align 8
-  %96 = zext i8 %95 to i32
-  %97 = icmp eq i32 %96, 0
-  br i1 %97, label %100, label %98
+; <label>:90                                      ; preds = %85
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load i32, i32* %arg2
+  %93 = load i32, i32* %loc0
+  %94 = add i32 %92, %93
+  store i32 %94, i32* %arg2
+  %95 = load i32, i32* %arg3
+  %96 = load i32, i32* %loc0
+  %97 = sub i32 %95, %96
+  store i32 %97, i32* %arg3
+  br label %98
 
-; <label>:98                                      ; preds = %92
-  %99 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %99, i8 1, i8 0)
-  br label %100
+; <label>:98                                      ; preds = %38, %90
+  %99 = load i32, i32* %arg3
+  %100 = icmp sgt i32 %99, 0
+  br i1 %100, label %40, label %101
 
-; <label>:100                                     ; preds = %92, %98
+; <label>:101                                     ; preds = %98
+  %102 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %102, null
+  br i1 %NullCheck2, label %103, label %ThrowNullRef1
+
+; <label>:103                                     ; preds = %101
+  %104 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %102, i32 0, i32 11
+  %105 = load i8, i8 addrspace(1)* %104, align 8
+  %106 = zext i8 %105 to i32
+  %107 = icmp eq i32 %106, 0
+  br i1 %107, label %110, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %109, i8 1, i8 0)
+  br label %110
+
+; <label>:110                                     ; preds = %103, %108
   ret void
+
+ThrowNullRef:                                     ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSmall.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSmall.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6905,16 +10193,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 48
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 48
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7032,19 +10328,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7076,9 +10388,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7122,17 +10442,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7153,17 +10489,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7200,11 +10552,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7220,7 +10580,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7228,27 +10588,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7364,31 +10732,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7401,40 +10801,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7448,8 +10872,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7517,38 +10949,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7561,39 +11025,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7604,39 +11092,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7664,29 +11192,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7751,9 +11295,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7780,16 +11332,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7806,12 +11374,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7837,19 +11421,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7915,51 +11523,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7972,11 +11588,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7996,116 +11620,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8116,19 +11868,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8176,34 +11944,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8229,9 +12029,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8242,32 +12050,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8280,20 +12120,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8328,59 +12184,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8391,11 +12263,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8423,20 +12311,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8448,36 +12344,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8496,177 +12400,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8731,27 +12803,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8762,28 +12858,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8980,44 +13092,68 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load float, float* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 48
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load float, float* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, float %8)
-  br label %18
+  %17 = add i64 %16, 48
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9032,27 +13168,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9068,28 +13220,44 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Single::ToString using LLILCJit
@@ -9103,11 +13271,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %2 = load float, float addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne float addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load float, float addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9121,37 +13297,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9169,215 +13393,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9403,25 +14035,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9435,11 +14091,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9495,25 +14159,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9524,24 +14212,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9568,13 +14280,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9585,24 +14305,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9613,24 +14357,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9641,24 +14409,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9669,24 +14461,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9697,24 +14513,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9725,24 +14565,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9759,106 +14623,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9990,30 +14934,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10039,25 +15015,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10117,38 +15101,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10161,23 +15161,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10189,27 +15197,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10221,19 +15237,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10260,100 +15292,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSub.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSub.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6890,16 +10178,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 48
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 48
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7017,19 +10313,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7061,9 +10373,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7107,17 +10427,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7138,17 +10474,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7185,11 +10537,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7205,7 +10565,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7213,27 +10573,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7349,31 +10717,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7386,40 +10786,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7433,8 +10857,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7502,38 +10934,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7546,39 +11010,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7589,39 +11077,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7649,29 +11177,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7736,9 +11280,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7765,16 +11317,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7791,12 +11359,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7822,19 +11406,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7900,51 +11508,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7957,11 +11573,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7981,116 +11605,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8101,19 +11853,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8161,34 +11929,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8214,9 +12014,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8227,32 +12035,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8265,20 +12105,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8313,59 +12169,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8376,11 +12248,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8408,20 +12296,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8433,36 +12329,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8481,177 +12385,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8716,27 +12788,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8747,28 +12843,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8965,44 +13077,68 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load float, float* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 48
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load float, float* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, float %8)
-  br label %18
+  %17 = add i64 %16, 48
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9017,27 +13153,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9053,28 +13205,44 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Single::ToString using LLILCJit
@@ -9088,11 +13256,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %2 = load float, float addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne float addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load float, float addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9106,37 +13282,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9154,215 +13378,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9388,25 +14020,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9420,11 +14076,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9480,25 +14144,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9509,24 +14197,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9553,13 +14265,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9570,24 +14290,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9598,24 +14342,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9626,24 +14394,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9654,24 +14446,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9682,24 +14498,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9710,24 +14550,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9744,106 +14608,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9975,30 +14919,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10024,25 +15000,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10102,38 +15086,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10146,23 +15146,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10174,27 +15182,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10206,19 +15222,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10245,100 +15277,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSubConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSubConst.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6887,16 +10175,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 48
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 48
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7014,19 +10310,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7058,9 +10370,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7104,17 +10424,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7135,17 +10471,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7182,11 +10534,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7202,7 +10562,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7210,27 +10570,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7346,31 +10714,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7383,40 +10783,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7430,8 +10854,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7499,38 +10931,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7543,39 +11007,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7586,39 +11074,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7646,29 +11174,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7733,9 +11277,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7762,16 +11314,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7788,12 +11356,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7819,19 +11403,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7897,51 +11505,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7954,11 +11570,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7978,116 +11602,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8098,19 +11850,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8158,34 +11926,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8211,9 +12011,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8224,32 +12032,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8262,20 +12102,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8310,59 +12166,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8373,11 +12245,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8405,20 +12293,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8430,36 +12326,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8478,177 +12382,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8713,27 +12785,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8744,28 +12840,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8962,44 +13074,68 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load float, float* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 48
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load float, float* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, float %8)
-  br label %18
+  %17 = add i64 %16, 48
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9014,27 +13150,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9050,28 +13202,44 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Single::ToString using LLILCJit
@@ -9085,11 +13253,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %2 = load float, float addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne float addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load float, float addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9103,37 +13279,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9151,215 +13375,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9385,25 +14017,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9417,11 +14073,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9477,25 +14141,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9506,24 +14194,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9550,13 +14262,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9567,24 +14287,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9595,24 +14339,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9623,24 +14391,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9651,24 +14443,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9679,24 +14495,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9707,24 +14547,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9741,106 +14605,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9972,30 +14916,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10021,25 +14997,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10099,38 +15083,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10143,23 +15143,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10171,27 +15179,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10203,19 +15219,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10242,100 +15274,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPVar.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPVar.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6893,16 +10181,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 48
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 48
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7020,19 +10316,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7064,9 +10376,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7110,17 +10430,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7141,17 +10477,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7188,11 +10540,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7208,7 +10568,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7216,27 +10576,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7352,31 +10720,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7389,40 +10789,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7436,8 +10860,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7505,38 +10937,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7549,39 +11013,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7592,39 +11080,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7652,29 +11180,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7739,9 +11283,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7768,16 +11320,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7794,12 +11362,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7825,19 +11409,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7903,51 +11511,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7960,11 +11576,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7984,116 +11608,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8104,19 +11856,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8164,34 +11932,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8217,9 +12017,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8230,32 +12038,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8268,20 +12108,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8316,59 +12172,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8379,11 +12251,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8411,20 +12299,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8436,36 +12332,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8484,177 +12388,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8719,27 +12791,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8750,28 +12846,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8968,44 +13080,68 @@ entry:
   store float %param1, float* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load float, float* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 48
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load float, float* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, float %8)
-  br label %18
+  %17 = add i64 %16, 48
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9020,27 +13156,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9056,28 +13208,44 @@ entry:
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Single::ToString using LLILCJit
@@ -9091,11 +13259,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
   %1 = bitcast %System.Single addrspace(1)* %0 to float addrspace(1)*
-  %2 = load float, float addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne float addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load float, float addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9109,37 +13285,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9157,215 +13381,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9391,25 +14023,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9423,11 +14079,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9483,25 +14147,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9512,24 +14200,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9556,13 +14268,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9573,24 +14293,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9601,24 +14345,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9629,24 +14397,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9657,24 +14449,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9685,24 +14501,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9713,24 +14553,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9747,106 +14611,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9978,30 +14922,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10027,25 +15003,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10105,38 +15089,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10149,23 +15149,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10177,27 +15185,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10209,19 +15225,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10248,100 +15280,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FactorialRec.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FactorialRec.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6924,16 +10212,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i32, i32* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 16
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 16
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7051,19 +10347,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7095,9 +10407,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7141,17 +10461,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7172,17 +10508,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7219,11 +10571,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7239,7 +10599,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7247,27 +10607,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7383,31 +10751,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7420,40 +10820,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7467,8 +10891,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7536,38 +10968,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7580,39 +11044,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7623,39 +11111,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7683,29 +11211,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7770,9 +11314,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7799,16 +11351,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7825,12 +11393,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7856,19 +11440,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7934,51 +11542,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7991,11 +11607,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -8015,116 +11639,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8135,19 +11887,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8195,34 +11963,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8248,9 +12048,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8261,32 +12069,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8299,20 +12139,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8347,59 +12203,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8410,11 +12282,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8442,20 +12330,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8467,36 +12363,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8515,177 +12419,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8750,27 +12822,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8781,28 +12877,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8999,44 +13111,68 @@ entry:
   store i32 %param1, i32* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load i32, i32* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 16
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load i32, i32* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, i32)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, i32 %8)
-  br label %18
+  %17 = add i64 %16, 16
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, i32 %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9051,27 +13187,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i32, i32* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 0
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 0
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9087,28 +13239,44 @@ entry:
   %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int32 addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int32 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Int32::ToString using LLILCJit
@@ -9122,11 +13290,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9140,37 +13316,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9188,215 +13412,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9422,25 +14054,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9454,11 +14110,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9514,25 +14178,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9543,24 +14231,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9587,13 +14299,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9604,24 +14324,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9632,24 +14376,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9660,24 +14428,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9688,24 +14480,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9716,24 +14532,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9744,24 +14584,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9778,106 +14642,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10009,30 +14953,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10058,25 +15034,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10136,38 +15120,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10180,23 +15180,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10208,27 +15216,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10240,19 +15256,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10279,100 +15311,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FibLoop.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FibLoop.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FiboRec.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FiboRec.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Gcd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Gcd.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6938,10 +10226,18 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* ()*)()
-  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %3)
-  ret %System.String addrspace(1)* %4
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* ()*)()
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::get_CurrentInfo using LLILCJit
@@ -7134,37 +10430,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -7182,215 +10526,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -7416,25 +11168,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -7448,11 +11224,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -7508,25 +11292,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -7537,24 +11345,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -7581,13 +11413,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -7598,24 +11438,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -7626,24 +11490,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -7654,24 +11542,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -7682,24 +11594,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -7710,24 +11646,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -7738,24 +11698,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::ConcatArray using LLILCJit
@@ -7770,16 +11754,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 104
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 8
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 104
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7897,19 +11889,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7941,9 +11949,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7987,17 +12003,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -8018,17 +12050,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -8065,11 +12113,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -8085,7 +12141,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -8093,27 +12149,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -8229,31 +12293,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -8266,40 +12362,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8313,8 +12433,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -8382,38 +12510,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -8426,39 +12586,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -8469,39 +12653,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -8529,29 +12753,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -8616,9 +12856,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -8645,16 +12893,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -8671,12 +12935,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -8702,19 +12982,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -8780,51 +13084,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -8837,11 +13149,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -8861,116 +13181,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8981,19 +13429,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -9041,34 +13505,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9094,9 +13590,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -9107,32 +13611,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -9145,20 +13681,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -9193,59 +13745,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -9256,11 +13824,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -9288,20 +13872,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -9313,36 +13905,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9361,177 +13961,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -9596,27 +14364,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -9627,28 +14419,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9668,44 +14476,68 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 104
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 8
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 104
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, %System.String addrspace(1)* %8)
-  br label %18
+  %17 = add i64 %16, 8
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, %System.String addrspace(1)* %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9769,116 +14601,196 @@ entry:
 
 ; <label>:23                                      ; preds = %15
   %24 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
-  %26 = load i32, i32 addrspace(1)* %25
-  %27 = zext i32 %26 to i64
-  %28 = trunc i64 %27 to i32
-  %29 = load i32, i32* %arg2
-  %30 = sub i32 %28, %29
-  %31 = load i32, i32* %arg3
-  %32 = icmp sge i32 %30, %31
-  br i1 %32, label %37, label %33
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %24, null
+  br i1 %NullCheck, label %25, label %ThrowNullRef
 
-; <label>:33                                      ; preds = %23
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %35 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %34)
-  %36 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36, %System.String addrspace(1)* %35)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36) #0
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = trunc i64 %28 to i32
+  %30 = load i32, i32* %arg2
+  %31 = sub i32 %29, %30
+  %32 = load i32, i32* %arg3
+  %33 = icmp sge i32 %31, %32
+  br i1 %33, label %38, label %34
+
+; <label>:34                                      ; preds = %25
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %37, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %37) #0
   unreachable
 
-; <label>:37                                      ; preds = %23
-  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %38)
-  br label %89
+; <label>:38                                      ; preds = %25
+  %39 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %39)
+  br label %98
 
-; <label>:39                                      ; preds = %89
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %43, i32 0, i32 10
-  %45 = load i32, i32 addrspace(1)* %44, align 8
-  %46 = icmp ne i32 %42, %45
-  br i1 %46, label %49, label %47
+; <label>:40                                      ; preds = %98
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %41, null
+  br i1 %NullCheck4, label %42, label %ThrowNullRef3
 
-; <label>:47                                      ; preds = %39
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %48, i8 0, i8 0)
-  br label %49
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %45, null
+  br i1 %NullCheck6, label %46, label %ThrowNullRef5
 
-; <label>:49                                      ; preds = %39, %47
-  %50 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %51 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %50, i32 0, i32 10
-  %52 = load i32, i32 addrspace(1)* %51, align 8
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %45, i32 0, i32 10
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %49 = icmp ne i32 %44, %48
+  br i1 %49, label %52, label %50
+
+; <label>:50                                      ; preds = %46
+  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %51, i8 0, i8 0)
+  br label %52
+
+; <label>:52                                      ; preds = %46, %50
   %53 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %54 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 9
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = sub i32 %52, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc0
-  %58 = load i32, i32* %arg3
-  %59 = icmp sle i32 %57, %58
-  br i1 %59, label %62, label %60
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %53, null
+  br i1 %NullCheck8, label %54, label %ThrowNullRef7
 
-; <label>:60                                      ; preds = %49
-  %61 = load i32, i32* %arg3
+; <label>:54                                      ; preds = %52
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 10
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck10, label %58, label %ThrowNullRef9
+
+; <label>:58                                      ; preds = %54
+  %59 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 9
+  %60 = load i32, i32 addrspace(1)* %59, align 8
+  %61 = sub i32 %56, %60
   store i32 %61, i32* %loc0
-  br label %62
+  %62 = load i32, i32* %loc0
+  %63 = load i32, i32* %arg3
+  %64 = icmp sle i32 %62, %63
+  br i1 %64, label %67, label %65
 
-; <label>:62                                      ; preds = %49, %60
-  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %64 = load i32, i32* %arg2
-  %65 = mul i32 %64, 2
-  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %67 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 7
-  %68 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %70 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %69, i32 0, i32 9
-  %71 = load i32, i32 addrspace(1)* %70, align 8
-  %72 = mul i32 %71, 2
-  %73 = load i32, i32* %loc0
-  %74 = mul i32 %73, 2
-  %75 = bitcast %"System.Char[]" addrspace(1)* %63 to %System.Array addrspace(1)*
-  %76 = bitcast %"System.Char[]" addrspace(1)* %68 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %75, i32 %65, %System.Array addrspace(1)* %76, i32 %72, i32 %74)
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
+; <label>:65                                      ; preds = %58
+  %66 = load i32, i32* %arg3
+  store i32 %66, i32* %loc0
+  br label %67
+
+; <label>:67                                      ; preds = %58, %65
+  %68 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %69 = load i32, i32* %arg2
+  %70 = mul i32 %69, 2
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %71, null
+  br i1 %NullCheck12, label %72, label %ThrowNullRef11
+
+; <label>:72                                      ; preds = %67
+  %73 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 7
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %73, align 8
+  %75 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %75, null
+  br i1 %NullCheck14, label %76, label %ThrowNullRef13
+
+; <label>:76                                      ; preds = %72
+  %77 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %75, i32 0, i32 9
+  %78 = load i32, i32 addrspace(1)* %77, align 8
+  %79 = mul i32 %78, 2
   %80 = load i32, i32* %loc0
-  %81 = add i32 %79, %80
-  %82 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  store i32 %81, i32 addrspace(1)* %82
-  %83 = load i32, i32* %arg2
-  %84 = load i32, i32* %loc0
-  %85 = add i32 %83, %84
-  store i32 %85, i32* %arg2
-  %86 = load i32, i32* %arg3
-  %87 = load i32, i32* %loc0
-  %88 = sub i32 %86, %87
-  store i32 %88, i32* %arg3
-  br label %89
+  %81 = mul i32 %80, 2
+  %82 = bitcast %"System.Char[]" addrspace(1)* %68 to %System.Array addrspace(1)*
+  %83 = bitcast %"System.Char[]" addrspace(1)* %74 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %82, i32 %70, %System.Array addrspace(1)* %83, i32 %79, i32 %81)
+  %84 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck16, label %85, label %ThrowNullRef15
 
-; <label>:89                                      ; preds = %37, %62
-  %90 = load i32, i32* %arg3
-  %91 = icmp sgt i32 %90, 0
-  br i1 %91, label %39, label %92
+; <label>:85                                      ; preds = %76
+  %86 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = load i32, i32* %loc0
+  %89 = add i32 %87, %88
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck18, label %90, label %ThrowNullRef17
 
-; <label>:92                                      ; preds = %89
-  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %94 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 11
-  %95 = load i8, i8 addrspace(1)* %94, align 8
-  %96 = zext i8 %95 to i32
-  %97 = icmp eq i32 %96, 0
-  br i1 %97, label %100, label %98
+; <label>:90                                      ; preds = %85
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load i32, i32* %arg2
+  %93 = load i32, i32* %loc0
+  %94 = add i32 %92, %93
+  store i32 %94, i32* %arg2
+  %95 = load i32, i32* %arg3
+  %96 = load i32, i32* %loc0
+  %97 = sub i32 %95, %96
+  store i32 %97, i32* %arg3
+  br label %98
 
-; <label>:98                                      ; preds = %92
-  %99 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %99, i8 1, i8 0)
-  br label %100
+; <label>:98                                      ; preds = %38, %90
+  %99 = load i32, i32* %arg3
+  %100 = icmp sgt i32 %99, 0
+  br i1 %100, label %40, label %101
 
-; <label>:100                                     ; preds = %92, %98
+; <label>:101                                     ; preds = %98
+  %102 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %102, null
+  br i1 %NullCheck2, label %103, label %ThrowNullRef1
+
+; <label>:103                                     ; preds = %101
+  %104 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %102, i32 0, i32 11
+  %105 = load i8, i8 addrspace(1)* %104, align 8
+  %106 = zext i8 %105 to i32
+  %107 = icmp eq i32 %106, 0
+  br i1 %107, label %110, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %109, i8 1, i8 0)
+  br label %110
+
+; <label>:110                                     ; preds = %103, %108
   ret void
+
+ThrowNullRef:                                     ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
@@ -10006,30 +14918,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10055,25 +14999,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10133,38 +15085,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10177,23 +15145,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10205,27 +15181,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -10261,28 +15245,44 @@ entry:
 ; <label>:11                                      ; preds = %5, %8
   %12 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
   %13 = bitcast %System.Object addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 0
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = inttoptr i64 %20 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %22 = call %System.String addrspace(1)* %21(%System.Object addrspace(1)* %12)
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %24 = bitcast %System.Object addrspace(1)* %23 to i64 addrspace(1)*
-  %25 = load i64, i64 addrspace(1)* %24
-  %26 = add i64 %25, 64
-  %27 = inttoptr i64 %26 to i64*
-  %28 = load i64, i64* %27
-  %29 = add i64 %28, 0
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
-  %32 = inttoptr i64 %31 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %33 = call %System.String addrspace(1)* %32(%System.Object addrspace(1)* %23)
-  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %33)
-  ret %System.String addrspace(1)* %34
+  %NullCheck = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 0
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %23 = call %System.String addrspace(1)* %22(%System.Object addrspace(1)* %12)
+  %24 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %25 = bitcast %System.Object addrspace(1)* %24 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %25, null
+  br i1 %NullCheck2, label %26, label %ThrowNullRef1
+
+; <label>:26                                      ; preds = %14
+  %27 = load i64, i64 addrspace(1)* %25
+  %28 = add i64 %27, 64
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 0
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %35 = call %System.String addrspace(1)* %34(%System.Object addrspace(1)* %24)
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %35)
+  ret %System.String addrspace(1)* %36
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ge1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ge1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Gt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Gt1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ind1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ind1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6891,8 +10179,16 @@ entry:
   %arg0 = alloca i32 addrspace(1)*
   store i32 addrspace(1)* %param0, i32 addrspace(1)** %arg0
   %0 = load i32 addrspace(1)*, i32 addrspace(1)** %arg0
+  %NullCheck = icmp ne i32 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
   store i32 1, i32 addrspace(1)* %0, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/InitObj.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/InitObj.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6889,35 +10177,75 @@ entry:
   %0 = addrspacecast %MyClass* %loc0 to %MyClass addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%MyClass addrspace(1)*, i32, i32)*)(%MyClass addrspace(1)* %0, i32 0, i32 12)
   %1 = addrspacecast %MyClass* %loc0 to %MyClass addrspace(1)*
-  %2 = getelementptr inbounds %MyClass, %MyClass addrspace(1)* %1, i32 0, i32 0
-  %3 = load i32, i32 addrspace(1)* %2, align 8
-  %4 = addrspacecast %MyClass* %loc0 to %MyClass addrspace(1)*
-  %5 = getelementptr inbounds %MyClass, %MyClass addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp ne i32 %3, %6
-  br i1 %7, label %23, label %8
+  %NullCheck = icmp ne %MyClass addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = addrspacecast %MyClass* %loc0 to %MyClass addrspace(1)*
-  %10 = getelementptr inbounds %MyClass, %MyClass addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = addrspacecast %MyClass* %loc0 to %MyClass addrspace(1)*
-  %13 = getelementptr inbounds %MyClass, %MyClass addrspace(1)* %12, i32 0, i32 2
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %MyClass, %MyClass addrspace(1)* %1, i32 0, i32 0
+  %4 = load i32, i32 addrspace(1)* %3, align 8
+  %5 = addrspacecast %MyClass* %loc0 to %MyClass addrspace(1)*
+  %NullCheck2 = icmp ne %MyClass addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %MyClass, %MyClass addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %28, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = addrspacecast %MyClass* %loc0 to %MyClass addrspace(1)*
+  %NullCheck4 = icmp ne %MyClass addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %MyClass, %MyClass addrspace(1)* %11, i32 0, i32 1
   %14 = load i32, i32 addrspace(1)* %13, align 8
-  %15 = icmp ne i32 %11, %14
-  br i1 %15, label %23, label %16
+  %15 = addrspacecast %MyClass* %loc0 to %MyClass addrspace(1)*
+  %NullCheck6 = icmp ne %MyClass addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:16                                      ; preds = %8
-  %17 = addrspacecast %MyClass* %loc0 to %MyClass addrspace(1)*
-  %18 = getelementptr inbounds %MyClass, %MyClass addrspace(1)* %17, i32 0, i32 2
-  %19 = load i32, i32 addrspace(1)* %18, align 8
-  %20 = icmp eq i32 %19, 0
-  %21 = sext i1 %20 to i32
-  %22 = trunc i32 %21 to i8
-  ret i8 %22
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %MyClass, %MyClass addrspace(1)* %15, i32 0, i32 2
+  %18 = load i32, i32 addrspace(1)* %17, align 8
+  %19 = icmp ne i32 %14, %18
+  br i1 %19, label %28, label %20
 
-; <label>:23                                      ; preds = %entry, %8
+; <label>:20                                      ; preds = %16
+  %21 = addrspacecast %MyClass* %loc0 to %MyClass addrspace(1)*
+  %NullCheck8 = icmp ne %MyClass addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %MyClass, %MyClass addrspace(1)* %21, i32 0, i32 2
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = icmp eq i32 %24, 0
+  %26 = sext i1 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+; <label>:28                                      ; preds = %6, %16
   ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/InstanceCalls.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/InstanceCalls.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6881,13 +10169,29 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %MiscMethods addrspace(1)*, %MiscMethods addrspace(1)** %this
   %3 = load i32, i32* %arg1
-  %4 = getelementptr inbounds %MiscMethods, %MiscMethods addrspace(1)* %2, i32 0, i32 1
-  store i32 %3, i32 addrspace(1)* %4
-  %5 = load %MiscMethods addrspace(1)*, %MiscMethods addrspace(1)** %this
-  %6 = load i32, i32* %arg2
-  %7 = getelementptr inbounds %MiscMethods, %MiscMethods addrspace(1)* %5, i32 0, i32 2
-  store i32 %6, i32 addrspace(1)* %7
+  %NullCheck = icmp ne %MiscMethods addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %MiscMethods, %MiscMethods addrspace(1)* %2, i32 0, i32 1
+  store i32 %3, i32 addrspace(1)* %5
+  %6 = load %MiscMethods addrspace(1)*, %MiscMethods addrspace(1)** %this
+  %7 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %MiscMethods addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %MiscMethods, %MiscMethods addrspace(1)* %6, i32 0, i32 2
+  store i32 %7, i32 addrspace(1)* %9
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method MiscMethods::InstanceCalls using LLILCJit
@@ -6900,28 +10204,60 @@ entry:
   store %MiscMethods addrspace(1)* %param0, %MiscMethods addrspace(1)** %this
   store %MiscMethods addrspace(1)* %param1, %MiscMethods addrspace(1)** %arg1
   %0 = load %MiscMethods addrspace(1)*, %MiscMethods addrspace(1)** %this
-  %1 = getelementptr inbounds %MiscMethods, %MiscMethods addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %MiscMethods addrspace(1)*, %MiscMethods addrspace(1)** %arg1
-  %4 = getelementptr inbounds %MiscMethods, %MiscMethods addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp ne i32 %2, %5
-  br i1 %6, label %17, label %7
+  %NullCheck = icmp ne %MiscMethods addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %MiscMethods addrspace(1)*, %MiscMethods addrspace(1)** %this
-  %9 = getelementptr inbounds %MiscMethods, %MiscMethods addrspace(1)* %8, i32 0, i32 2
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %MiscMethods addrspace(1)*, %MiscMethods addrspace(1)** %arg1
-  %12 = getelementptr inbounds %MiscMethods, %MiscMethods addrspace(1)* %11, i32 0, i32 2
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %MiscMethods, %MiscMethods addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %MiscMethods addrspace(1)*, %MiscMethods addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %MiscMethods addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %MiscMethods, %MiscMethods addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp ne i32 %3, %7
+  br i1 %8, label %21, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = load %MiscMethods addrspace(1)*, %MiscMethods addrspace(1)** %this
+  %NullCheck4 = icmp ne %MiscMethods addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %MiscMethods, %MiscMethods addrspace(1)* %10, i32 0, i32 2
   %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp eq i32 %10, %13
-  %15 = sext i1 %14 to i32
-  %16 = trunc i32 %15 to i8
-  ret i8 %16
+  %14 = load %MiscMethods addrspace(1)*, %MiscMethods addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %MiscMethods addrspace(1)* %14, null
+  br i1 %NullCheck6, label %15, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %entry
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %MiscMethods, %MiscMethods addrspace(1)* %14, i32 0, i32 2
+  %17 = load i32, i32 addrspace(1)* %16, align 8
+  %18 = icmp eq i32 %13, %17
+  %19 = sext i1 %18 to i32
+  %20 = trunc i32 %19 to i8
+  ret i8 %20
+
+; <label>:21                                      ; preds = %5
   ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method BringUpTest::InstanceCalls using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/IntArraySum.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/IntArraySum.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/IntConv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/IntConv.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6973,16 +10261,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i64, i64* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 32
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i64)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i64)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7100,19 +10396,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7144,9 +10456,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7190,17 +10510,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7221,17 +10557,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7268,11 +10620,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7288,7 +10648,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7296,27 +10656,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7432,31 +10800,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7469,40 +10869,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7516,8 +10940,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7585,38 +11017,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7629,39 +11093,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7672,39 +11160,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7732,29 +11260,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7819,9 +11363,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7848,16 +11400,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7874,12 +11442,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7905,19 +11489,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7983,51 +11591,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -8040,11 +11656,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -8064,116 +11688,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8184,19 +11936,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8244,34 +12012,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8297,9 +12097,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8310,32 +12118,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8348,20 +12188,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8396,59 +12252,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8459,11 +12331,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8491,20 +12379,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8516,36 +12412,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8564,177 +12468,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8799,27 +12871,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8830,28 +12926,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9048,44 +13160,68 @@ entry:
   store i64 %param1, i64* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load i64, i64* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 32
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load i64, i64* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, i64)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, i64 %8)
-  br label %18
+  %17 = add i64 %16, 32
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, i64)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, i64 %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9100,27 +13236,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i64, i64* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 16
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i64)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 16
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i64)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9136,28 +13288,44 @@ entry:
   %1 = addrspacecast i64* %arg1 to i64 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast i64 addrspace(1)* %1 to %System.Int64 addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int64 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int64 addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast i64 addrspace(1)* %1 to %System.Int64 addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int64 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int64 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Int64::ToString using LLILCJit
@@ -9171,11 +13339,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Int64 addrspace(1)*, %System.Int64 addrspace(1)** %this
   %1 = bitcast %System.Int64 addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i64, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i64 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i64, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i64 %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9189,37 +13365,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9237,215 +13461,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9471,25 +14103,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9503,11 +14159,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9563,25 +14227,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9592,24 +14280,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9636,13 +14348,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9653,24 +14373,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9681,24 +14425,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9709,24 +14477,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9737,24 +14529,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9765,24 +14581,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9793,24 +14633,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9827,106 +14691,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10058,30 +15002,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10107,25 +15083,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10185,38 +15169,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10229,23 +15229,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10257,27 +15265,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10289,19 +15305,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10328,100 +15360,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method BringUpTest::IntConv using LLILCJit
@@ -10458,16 +15570,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i32, i32* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 16
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 16
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
@@ -10483,44 +15603,68 @@ entry:
   store i32 %param1, i32* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load i32, i32* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 16
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load i32, i32* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, i32)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, i32 %8)
-  br label %18
+  %17 = add i64 %16, 16
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, i32 %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10535,27 +15679,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i32, i32* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 0
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 0
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -10571,28 +15731,44 @@ entry:
   %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int32 addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int32 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Int32::ToString using LLILCJit
@@ -10606,11 +15782,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method BringUpTest::IntConv using LLILCJit
@@ -10662,16 +15846,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i32, i32* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 24
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 24
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
@@ -10687,44 +15879,68 @@ entry:
   store i32 %param1, i32* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load i32, i32* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 24
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load i32, i32* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, i32)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, i32 %8)
-  br label %18
+  %17 = add i64 %16, 24
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, i32 %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10739,27 +15955,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i32, i32* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 8
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -10775,28 +16007,44 @@ entry:
   %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast i32 addrspace(1)* %1 to %System.UInt32 addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.UInt32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.UInt32 addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast i32 addrspace(1)* %1 to %System.UInt32 addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.UInt32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.UInt32 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UInt32::ToString using LLILCJit
@@ -10810,11 +16058,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.UInt32 addrspace(1)*, %System.UInt32 addrspace(1)** %this
   %1 = bitcast %System.UInt32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrue1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrue1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqDbl.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqFP.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqInt1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeDbl.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeFP.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeInt1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtDbl.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtFP.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtInt1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeDbl.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeFP.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeInt1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtDbl.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtFP.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtInt1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeDbl.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeFP.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeInt1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Jmp1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Jmp1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Le1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Le1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LeftShift.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LeftShift.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LngConv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LngConv.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7025,9 +10313,17 @@ entry:
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
   %1 = load i64, i64* %arg1
   %2 = inttoptr i64 %1 to i16*
-  %3 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %2, i16* addrspace(1)* %3
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %2, i16* addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method IntPtr::op_Explicit using LLILCJit
@@ -7042,16 +10338,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i32, i32* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 24
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 24
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7169,19 +10473,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7213,9 +10533,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7259,17 +10587,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7290,17 +10634,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7337,11 +10697,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7357,7 +10725,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7365,27 +10733,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7501,31 +10877,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7538,40 +10946,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7585,8 +11017,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7654,38 +11094,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7698,39 +11170,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7741,39 +11237,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7801,29 +11337,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7888,9 +11440,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7917,16 +11477,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7943,12 +11519,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7974,19 +11566,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -8052,51 +11668,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -8109,11 +11733,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -8133,116 +11765,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8253,19 +12013,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8313,34 +12089,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8366,9 +12174,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8379,32 +12195,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8417,20 +12265,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8465,59 +12329,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8528,11 +12408,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8560,20 +12456,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8585,36 +12489,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8633,177 +12545,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8868,27 +12948,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8899,28 +13003,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9117,44 +13237,68 @@ entry:
   store i32 %param1, i32* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load i32, i32* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 24
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load i32, i32* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, i32)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, i32 %8)
-  br label %18
+  %17 = add i64 %16, 24
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, i32 %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9169,27 +13313,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i32, i32* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 8
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9205,28 +13365,44 @@ entry:
   %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast i32 addrspace(1)* %1 to %System.UInt32 addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.UInt32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.UInt32 addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast i32 addrspace(1)* %1 to %System.UInt32 addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.UInt32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.UInt32 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UInt32::ToString using LLILCJit
@@ -9240,11 +13416,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.UInt32 addrspace(1)*, %System.UInt32 addrspace(1)** %this
   %1 = bitcast %System.UInt32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9258,37 +13442,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9306,215 +13538,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9540,25 +14180,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9572,11 +14236,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9632,25 +14304,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -9661,24 +14357,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -9705,13 +14425,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -9722,24 +14450,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -9750,24 +14502,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -9778,24 +14554,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -9806,24 +14606,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -9834,24 +14658,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -9862,24 +14710,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -9896,106 +14768,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10127,30 +15079,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10176,25 +15160,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10254,38 +15246,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10298,23 +15306,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10326,27 +15342,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10358,19 +15382,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10397,100 +15437,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method BringUpTest::LngConv using LLILCJit
@@ -10507,9 +15627,17 @@ entry:
   %1 = load i64, i64* %arg0
   %2 = trunc i64 %1 to i32
   store i32 %2, i32* %loc0
+  %NullCheck = icmp ne i32 addrspace(1)* %0, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
   store i32 %2, i32 addrspace(1)* %0, align 8
-  %3 = load i32, i32* %loc0
-  ret i32 %3
+  %4 = load i32, i32* %loc0
+  ret i32 %4
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
@@ -10522,16 +15650,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i32, i32* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 16
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 16
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
@@ -10547,44 +15683,68 @@ entry:
   store i32 %param1, i32* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load i32, i32* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 16
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load i32, i32* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, i32)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, i32 %8)
-  br label %18
+  %17 = add i64 %16, 16
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, i32 %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10599,27 +15759,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i32, i32* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 0
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 0
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -10635,28 +15811,44 @@ entry:
   %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int32 addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int32 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Int32::ToString using LLILCJit
@@ -10670,11 +15862,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method BringUpTest::LngConv using LLILCJit
@@ -10691,9 +15891,17 @@ entry:
   %1 = load i64, i64* %arg0
   %2 = trunc i64 %1 to i32
   store i32 %2, i32* %loc0
+  %NullCheck = icmp ne i32 addrspace(1)* %0, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
   store i32 %2, i32 addrspace(1)* %0, align 8
-  %3 = load i32, i32* %loc0
-  ret i32 %3
+  %4 = load i32, i32* %loc0
+  ret i32 %4
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method BringUpTest::LngConv using LLILCJit
@@ -10713,11 +15921,19 @@ entry:
   %4 = trunc i32 %3 to i16
   store i16 %4, i16* %loc0
   %5 = trunc i32 %3 to i16
+  %NullCheck = icmp ne i16 addrspace(1)* %0, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
   store i16 %5, i16 addrspace(1)* %0, align 8
-  %6 = load i16, i16* %loc0
-  %7 = sext i16 %6 to i32
-  %8 = trunc i32 %7 to i16
-  ret i16 %8
+  %7 = load i16, i16* %loc0
+  %8 = sext i16 %7 to i32
+  %9 = trunc i32 %8 to i16
+  ret i16 %9
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method BringUpTest::LngConv using LLILCJit
@@ -10737,11 +15953,19 @@ entry:
   %4 = trunc i32 %3 to i16
   store i16 %4, i16* %loc0
   %5 = trunc i32 %3 to i16
+  %NullCheck = icmp ne i16 addrspace(1)* %0, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
   store i16 %5, i16 addrspace(1)* %0, align 8
-  %6 = load i16, i16* %loc0
-  %7 = zext i16 %6 to i32
-  %8 = trunc i32 %7 to i16
-  ret i16 %8
+  %7 = load i16, i16* %loc0
+  %8 = zext i16 %7 to i32
+  %9 = trunc i32 %8 to i16
+  ret i16 %9
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method BringUpTest::LngConv using LLILCJit
@@ -10761,11 +15985,19 @@ entry:
   %4 = trunc i32 %3 to i8
   store i8 %4, i8* %loc0
   %5 = trunc i32 %3 to i8
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
   store i8 %5, i8 addrspace(1)* %0, align 8
-  %6 = load i8, i8* %loc0
-  %7 = sext i8 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %7 = load i8, i8* %loc0
+  %8 = sext i8 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method BringUpTest::LngConv using LLILCJit
@@ -10785,11 +16017,19 @@ entry:
   %4 = trunc i32 %3 to i8
   store i8 %4, i8* %loc0
   %5 = trunc i32 %3 to i8
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
   store i8 %5, i8 addrspace(1)* %0, align 8
-  %6 = load i8, i8* %loc0
-  %7 = zext i8 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %7 = load i8, i8* %loc0
+  %8 = zext i8 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LongArgsAndReturn.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LongArgsAndReturn.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Lt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Lt1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ne1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ne1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NegRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NegRMW.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6892,10 +10180,26 @@ entry:
   store i32 addrspace(1)* %param0, i32 addrspace(1)** %arg0
   %0 = load i32 addrspace(1)*, i32 addrspace(1)** %arg0
   %1 = load i32 addrspace(1)*, i32 addrspace(1)** %arg0
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = sub i32 0, %2
-  store i32 %3, i32 addrspace(1)* %0, align 8
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  %4 = sub i32 0, %3
+  %NullCheck2 = icmp ne i32 addrspace(1)* %0, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %2
+  store i32 %4, i32 addrspace(1)* %0, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NestedCall.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NestedCall.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NotAndNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NotAndNeg.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NotRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NotRMW.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6892,10 +10180,26 @@ entry:
   store i32 addrspace(1)* %param0, i32 addrspace(1)** %arg0
   %0 = load i32 addrspace(1)*, i32 addrspace(1)** %arg0
   %1 = load i32 addrspace(1)*, i32 addrspace(1)** %arg0
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = xor i32 %2, -1
-  store i32 %3, i32 addrspace(1)* %0, align 8
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  %4 = xor i32 %3, -1
+  %NullCheck2 = icmp ne i32 addrspace(1)* %0, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %2
+  store i32 %4, i32 addrspace(1)* %0, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/ObjAlloc.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/ObjAlloc.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6937,13 +10225,29 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %Point addrspace(1)*, %Point addrspace(1)** %this
   %3 = load i32, i32* %arg1
-  %4 = getelementptr inbounds %Point, %Point addrspace(1)* %2, i32 0, i32 1
-  store i32 %3, i32 addrspace(1)* %4
-  %5 = load %Point addrspace(1)*, %Point addrspace(1)** %this
-  %6 = load i32, i32* %arg2
-  %7 = getelementptr inbounds %Point, %Point addrspace(1)* %5, i32 0, i32 2
-  store i32 %6, i32 addrspace(1)* %7
+  %NullCheck = icmp ne %Point addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %Point, %Point addrspace(1)* %2, i32 0, i32 1
+  store i32 %3, i32 addrspace(1)* %5
+  %6 = load %Point addrspace(1)*, %Point addrspace(1)** %this
+  %7 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %Point addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %Point, %Point addrspace(1)* %6, i32 0, i32 2
+  store i32 %7, i32 addrspace(1)* %9
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Point::DistanceSquared using LLILCJit
@@ -6956,37 +10260,101 @@ entry:
   store %Point addrspace(1)* %param0, %Point addrspace(1)** %this
   store %Point addrspace(1)* %param1, %Point addrspace(1)** %arg1
   %0 = load %Point addrspace(1)*, %Point addrspace(1)** %this
-  %1 = getelementptr inbounds %Point, %Point addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %Point addrspace(1)*, %Point addrspace(1)** %arg1
-  %4 = getelementptr inbounds %Point, %Point addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  %7 = load %Point addrspace(1)*, %Point addrspace(1)** %this
-  %8 = getelementptr inbounds %Point, %Point addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8, align 8
-  %10 = load %Point addrspace(1)*, %Point addrspace(1)** %arg1
-  %11 = getelementptr inbounds %Point, %Point addrspace(1)* %10, i32 0, i32 1
+  %NullCheck = icmp ne %Point addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %Point, %Point addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %Point addrspace(1)*, %Point addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %Point addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %Point, %Point addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  %9 = load %Point addrspace(1)*, %Point addrspace(1)** %this
+  %NullCheck4 = icmp ne %Point addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %Point, %Point addrspace(1)* %9, i32 0, i32 1
   %12 = load i32, i32 addrspace(1)* %11, align 8
-  %13 = sub i32 %9, %12
-  %14 = mul i32 %6, %13
-  %15 = load %Point addrspace(1)*, %Point addrspace(1)** %this
-  %16 = getelementptr inbounds %Point, %Point addrspace(1)* %15, i32 0, i32 2
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = load %Point addrspace(1)*, %Point addrspace(1)** %arg1
-  %19 = getelementptr inbounds %Point, %Point addrspace(1)* %18, i32 0, i32 2
-  %20 = load i32, i32 addrspace(1)* %19, align 8
-  %21 = sub i32 %17, %20
-  %22 = load %Point addrspace(1)*, %Point addrspace(1)** %this
-  %23 = getelementptr inbounds %Point, %Point addrspace(1)* %22, i32 0, i32 2
-  %24 = load i32, i32 addrspace(1)* %23, align 8
-  %25 = load %Point addrspace(1)*, %Point addrspace(1)** %arg1
-  %26 = getelementptr inbounds %Point, %Point addrspace(1)* %25, i32 0, i32 2
-  %27 = load i32, i32 addrspace(1)* %26, align 8
-  %28 = sub i32 %24, %27
-  %29 = mul i32 %21, %28
-  %30 = add i32 %14, %29
-  ret i32 %30
+  %13 = load %Point addrspace(1)*, %Point addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %Point addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %Point, %Point addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = sub i32 %12, %16
+  %18 = mul i32 %8, %17
+  %19 = load %Point addrspace(1)*, %Point addrspace(1)** %this
+  %NullCheck8 = icmp ne %Point addrspace(1)* %19, null
+  br i1 %NullCheck8, label %20, label %ThrowNullRef7
+
+; <label>:20                                      ; preds = %14
+  %21 = getelementptr inbounds %Point, %Point addrspace(1)* %19, i32 0, i32 2
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = load %Point addrspace(1)*, %Point addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %Point addrspace(1)* %23, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %Point, %Point addrspace(1)* %23, i32 0, i32 2
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  %28 = load %Point addrspace(1)*, %Point addrspace(1)** %this
+  %NullCheck12 = icmp ne %Point addrspace(1)* %28, null
+  br i1 %NullCheck12, label %29, label %ThrowNullRef11
+
+; <label>:29                                      ; preds = %24
+  %30 = getelementptr inbounds %Point, %Point addrspace(1)* %28, i32 0, i32 2
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = load %Point addrspace(1)*, %Point addrspace(1)** %arg1
+  %NullCheck14 = icmp ne %Point addrspace(1)* %32, null
+  br i1 %NullCheck14, label %33, label %ThrowNullRef13
+
+; <label>:33                                      ; preds = %29
+  %34 = getelementptr inbounds %Point, %Point addrspace(1)* %32, i32 0, i32 2
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %31, %35
+  %37 = mul i32 %27, %36
+  %38 = add i32 %18, %37
+  ret i32 %38
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/OpMembersOfStructLocal.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/OpMembersOfStructLocal.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6899,663 +10187,1455 @@ entry:
   %0 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%Point addrspace(1)*, i32, i32, i32)*)(%Point addrspace(1)* %0, i32 10, i32 20, i32 30)
   %1 = addrspacecast %Point* %loc1 to %Point addrspace(1)*
-  %2 = getelementptr inbounds %Point, %Point addrspace(1)* %1, i32 0, i32 0
-  store i32 0, i32 addrspace(1)* %2
-  %3 = addrspacecast %Point* %loc1 to %Point addrspace(1)*
-  %4 = getelementptr inbounds %Point, %Point addrspace(1)* %3, i32 0, i32 1
-  store i32 0, i32 addrspace(1)* %4
-  %5 = addrspacecast %Point* %loc1 to %Point addrspace(1)*
-  %6 = getelementptr inbounds %Point, %Point addrspace(1)* %5, i32 0, i32 2
+  %NullCheck = icmp ne %Point addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %Point, %Point addrspace(1)* %1, i32 0, i32 0
+  store i32 0, i32 addrspace(1)* %3
+  %4 = addrspacecast %Point* %loc1 to %Point addrspace(1)*
+  %NullCheck2 = icmp ne %Point addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %Point, %Point addrspace(1)* %4, i32 0, i32 1
   store i32 0, i32 addrspace(1)* %6
-  %7 = addrspacecast %Point* %loc2 to %Point addrspace(1)*
-  %8 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %9 = getelementptr inbounds %Point, %Point addrspace(1)* %8, i32 0, i32 0
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = add i32 %10, 5
-  %12 = getelementptr inbounds %Point, %Point addrspace(1)* %7, i32 0, i32 0
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = addrspacecast %Point* %loc2 to %Point addrspace(1)*
-  %14 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %15 = getelementptr inbounds %Point, %Point addrspace(1)* %14, i32 0, i32 1
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = addrspacecast %Point* %loc1 to %Point addrspace(1)*
-  %18 = getelementptr inbounds %Point, %Point addrspace(1)* %17, i32 0, i32 1
-  %19 = load i32, i32 addrspace(1)* %18, align 8
-  %20 = add i32 %16, %19
-  %21 = getelementptr inbounds %Point, %Point addrspace(1)* %13, i32 0, i32 1
-  store i32 %20, i32 addrspace(1)* %21
-  %22 = addrspacecast %Point* %loc2 to %Point addrspace(1)*
-  %23 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %24 = getelementptr inbounds %Point, %Point addrspace(1)* %23, i32 0, i32 2
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = addrspacecast %Point* %loc1 to %Point addrspace(1)*
-  %27 = getelementptr inbounds %Point, %Point addrspace(1)* %26, i32 0, i32 2
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = mul i32 %25, %28
-  %30 = getelementptr inbounds %Point, %Point addrspace(1)* %22, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = addrspacecast %Point* %loc2 to %Point addrspace(1)*
-  %32 = getelementptr inbounds %Point, %Point addrspace(1)* %31, i32 0, i32 0
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = icmp ne i32 %33, 15
-  br i1 %34, label %46, label %35
+  %7 = addrspacecast %Point* %loc1 to %Point addrspace(1)*
+  %NullCheck4 = icmp ne %Point addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
 
-; <label>:35                                      ; preds = %entry
-  %36 = addrspacecast %Point* %loc2 to %Point addrspace(1)*
-  %37 = getelementptr inbounds %Point, %Point addrspace(1)* %36, i32 0, i32 1
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %Point, %Point addrspace(1)* %7, i32 0, i32 2
+  store i32 0, i32 addrspace(1)* %9
+  %10 = addrspacecast %Point* %loc2 to %Point addrspace(1)*
+  %11 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
+  %NullCheck6 = icmp ne %Point addrspace(1)* %11, null
+  br i1 %NullCheck6, label %12, label %ThrowNullRef5
+
+; <label>:12                                      ; preds = %8
+  %13 = getelementptr inbounds %Point, %Point addrspace(1)* %11, i32 0, i32 0
+  %14 = load i32, i32 addrspace(1)* %13, align 8
+  %15 = add i32 %14, 5
+  %NullCheck8 = icmp ne %Point addrspace(1)* %10, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %Point, %Point addrspace(1)* %10, i32 0, i32 0
+  store i32 %15, i32 addrspace(1)* %17
+  %18 = addrspacecast %Point* %loc2 to %Point addrspace(1)*
+  %19 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
+  %NullCheck10 = icmp ne %Point addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %16
+  %21 = getelementptr inbounds %Point, %Point addrspace(1)* %19, i32 0, i32 1
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = addrspacecast %Point* %loc1 to %Point addrspace(1)*
+  %NullCheck12 = icmp ne %Point addrspace(1)* %23, null
+  br i1 %NullCheck12, label %24, label %ThrowNullRef11
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %Point, %Point addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = add i32 %22, %26
+  %NullCheck14 = icmp ne %Point addrspace(1)* %18, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %Point, %Point addrspace(1)* %18, i32 0, i32 1
+  store i32 %27, i32 addrspace(1)* %29
+  %30 = addrspacecast %Point* %loc2 to %Point addrspace(1)*
+  %31 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
+  %NullCheck16 = icmp ne %Point addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %Point, %Point addrspace(1)* %31, i32 0, i32 2
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = addrspacecast %Point* %loc1 to %Point addrspace(1)*
+  %NullCheck18 = icmp ne %Point addrspace(1)* %35, null
+  br i1 %NullCheck18, label %36, label %ThrowNullRef17
+
+; <label>:36                                      ; preds = %32
+  %37 = getelementptr inbounds %Point, %Point addrspace(1)* %35, i32 0, i32 2
   %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = icmp ne i32 %38, 20
-  br i1 %39, label %46, label %40
+  %39 = mul i32 %34, %38
+  %NullCheck20 = icmp ne %Point addrspace(1)* %30, null
+  br i1 %NullCheck20, label %40, label %ThrowNullRef19
 
-; <label>:40                                      ; preds = %35
-  %41 = addrspacecast %Point* %loc2 to %Point addrspace(1)*
-  %42 = getelementptr inbounds %Point, %Point addrspace(1)* %41, i32 0, i32 2
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = icmp eq i32 %43, 0
-  %45 = sext i1 %44 to i32
-  br label %47
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %Point, %Point addrspace(1)* %30, i32 0, i32 2
+  store i32 %39, i32 addrspace(1)* %41
+  %42 = addrspacecast %Point* %loc2 to %Point addrspace(1)*
+  %NullCheck22 = icmp ne %Point addrspace(1)* %42, null
+  br i1 %NullCheck22, label %43, label %ThrowNullRef21
 
-; <label>:46                                      ; preds = %entry, %35
-  br label %47
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %Point, %Point addrspace(1)* %42, i32 0, i32 0
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = icmp ne i32 %45, 15
+  br i1 %46, label %60, label %47
 
-; <label>:47                                      ; preds = %40, %46
-  %48 = phi i32 [ %45, %40 ], [ 0, %46 ]
-  %49 = trunc i32 %48 to i8
-  store i8 %49, i8* %loc3
-  %50 = load i8, i8* %loc3
-  %51 = zext i8 %50 to i32
-  %52 = icmp ne i32 %51, 0
-  br i1 %52, label %54, label %53
+; <label>:47                                      ; preds = %43
+  %48 = addrspacecast %Point* %loc2 to %Point addrspace(1)*
+  %NullCheck24 = icmp ne %Point addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %47
-  ret i32 -1
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %Point, %Point addrspace(1)* %48, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = icmp ne i32 %51, 20
+  br i1 %52, label %60, label %53
 
-; <label>:54                                      ; preds = %47
-  %55 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %56 = getelementptr inbounds %Point, %Point addrspace(1)* %55, i32 0, i32 0
+; <label>:53                                      ; preds = %49
+  %54 = addrspacecast %Point* %loc2 to %Point addrspace(1)*
+  %NullCheck26 = icmp ne %Point addrspace(1)* %54, null
+  br i1 %NullCheck26, label %55, label %ThrowNullRef25
+
+; <label>:55                                      ; preds = %53
+  %56 = getelementptr inbounds %Point, %Point addrspace(1)* %54, i32 0, i32 2
   %57 = load i32, i32 addrspace(1)* %56, align 8
-  %58 = addrspacecast %Point* %loc1 to %Point addrspace(1)*
-  %59 = getelementptr inbounds %Point, %Point addrspace(1)* %58, i32 0, i32 0
-  %60 = load i32, i32 addrspace(1)* %59, align 8
-  %61 = add i32 %57, %60
-  store i32 %61, i32* %loc4
-  %62 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %63 = getelementptr inbounds %Point, %Point addrspace(1)* %62, i32 0, i32 1
-  %64 = load i32, i32 addrspace(1)* %63, align 8
-  %65 = addrspacecast %Point* %loc1 to %Point addrspace(1)*
-  %66 = getelementptr inbounds %Point, %Point addrspace(1)* %65, i32 0, i32 1
-  %67 = load i32, i32 addrspace(1)* %66, align 8
-  %68 = mul i32 %64, %67
-  store i32 %68, i32* %loc5
+  %58 = icmp eq i32 %57, 0
+  %59 = sext i1 %58 to i32
+  br label %61
+
+; <label>:60                                      ; preds = %43, %49
+  br label %61
+
+; <label>:61                                      ; preds = %55, %60
+  %62 = phi i32 [ %59, %55 ], [ 0, %60 ]
+  %63 = trunc i32 %62 to i8
+  store i8 %63, i8* %loc3
+  %64 = load i8, i8* %loc3
+  %65 = zext i8 %64 to i32
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %68, label %67
+
+; <label>:67                                      ; preds = %61
+  ret i32 -1
+
+; <label>:68                                      ; preds = %61
   %69 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %70 = getelementptr inbounds %Point, %Point addrspace(1)* %69, i32 0, i32 2
-  %71 = load i32, i32 addrspace(1)* %70, align 8
-  store i32 %71, i32* %loc6
-  %72 = load i32, i32* %loc4
-  %73 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %74 = getelementptr inbounds %Point, %Point addrspace(1)* %73, i32 0, i32 0
-  %75 = load i32, i32 addrspace(1)* %74, align 8
-  %76 = icmp ne i32 %72, %75
-  br i1 %76, label %84, label %77
+  %NullCheck28 = icmp ne %Point addrspace(1)* %69, null
+  br i1 %NullCheck28, label %70, label %ThrowNullRef27
 
-; <label>:77                                      ; preds = %54
-  %78 = load i32, i32* %loc5
-  %79 = addrspacecast %Point* %loc1 to %Point addrspace(1)*
-  %80 = getelementptr inbounds %Point, %Point addrspace(1)* %79, i32 0, i32 1
+; <label>:70                                      ; preds = %68
+  %71 = getelementptr inbounds %Point, %Point addrspace(1)* %69, i32 0, i32 0
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %73 = addrspacecast %Point* %loc1 to %Point addrspace(1)*
+  %NullCheck30 = icmp ne %Point addrspace(1)* %73, null
+  br i1 %NullCheck30, label %74, label %ThrowNullRef29
+
+; <label>:74                                      ; preds = %70
+  %75 = getelementptr inbounds %Point, %Point addrspace(1)* %73, i32 0, i32 0
+  %76 = load i32, i32 addrspace(1)* %75, align 8
+  %77 = add i32 %72, %76
+  store i32 %77, i32* %loc4
+  %78 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
+  %NullCheck32 = icmp ne %Point addrspace(1)* %78, null
+  br i1 %NullCheck32, label %79, label %ThrowNullRef31
+
+; <label>:79                                      ; preds = %74
+  %80 = getelementptr inbounds %Point, %Point addrspace(1)* %78, i32 0, i32 1
   %81 = load i32, i32 addrspace(1)* %80, align 8
-  %82 = icmp eq i32 %78, %81
-  %83 = sext i1 %82 to i32
-  br label %85
+  %82 = addrspacecast %Point* %loc1 to %Point addrspace(1)*
+  %NullCheck34 = icmp ne %Point addrspace(1)* %82, null
+  br i1 %NullCheck34, label %83, label %ThrowNullRef33
 
-; <label>:84                                      ; preds = %54
-  br label %85
+; <label>:83                                      ; preds = %79
+  %84 = getelementptr inbounds %Point, %Point addrspace(1)* %82, i32 0, i32 1
+  %85 = load i32, i32 addrspace(1)* %84, align 8
+  %86 = mul i32 %81, %85
+  store i32 %86, i32* %loc5
+  %87 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
+  %NullCheck36 = icmp ne %Point addrspace(1)* %87, null
+  br i1 %NullCheck36, label %88, label %ThrowNullRef35
 
-; <label>:85                                      ; preds = %77, %84
-  %86 = phi i32 [ %83, %77 ], [ 0, %84 ]
-  %87 = trunc i32 %86 to i8
-  store i8 %87, i8* %loc3
-  %88 = load i8, i8* %loc3
-  %89 = zext i8 %88 to i32
-  %90 = icmp ne i32 %89, 0
-  br i1 %90, label %92, label %91
+; <label>:88                                      ; preds = %83
+  %89 = getelementptr inbounds %Point, %Point addrspace(1)* %87, i32 0, i32 2
+  %90 = load i32, i32 addrspace(1)* %89, align 8
+  store i32 %90, i32* %loc6
+  %91 = load i32, i32* %loc4
+  %92 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
+  %NullCheck38 = icmp ne %Point addrspace(1)* %92, null
+  br i1 %NullCheck38, label %93, label %ThrowNullRef37
 
-; <label>:91                                      ; preds = %85
+; <label>:93                                      ; preds = %88
+  %94 = getelementptr inbounds %Point, %Point addrspace(1)* %92, i32 0, i32 0
+  %95 = load i32, i32 addrspace(1)* %94, align 8
+  %96 = icmp ne i32 %91, %95
+  br i1 %96, label %105, label %97
+
+; <label>:97                                      ; preds = %93
+  %98 = load i32, i32* %loc5
+  %99 = addrspacecast %Point* %loc1 to %Point addrspace(1)*
+  %NullCheck40 = icmp ne %Point addrspace(1)* %99, null
+  br i1 %NullCheck40, label %100, label %ThrowNullRef39
+
+; <label>:100                                     ; preds = %97
+  %101 = getelementptr inbounds %Point, %Point addrspace(1)* %99, i32 0, i32 1
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = icmp eq i32 %98, %102
+  %104 = sext i1 %103 to i32
+  br label %106
+
+; <label>:105                                     ; preds = %93
+  br label %106
+
+; <label>:106                                     ; preds = %100, %105
+  %107 = phi i32 [ %104, %100 ], [ 0, %105 ]
+  %108 = trunc i32 %107 to i8
+  store i8 %108, i8* %loc3
+  %109 = load i8, i8* %loc3
+  %110 = zext i8 %109 to i32
+  %111 = icmp ne i32 %110, 0
+  br i1 %111, label %113, label %112
+
+; <label>:112                                     ; preds = %106
   ret i32 -1
 
-; <label>:92                                      ; preds = %85
-  %93 = load i32, i32* %loc4
-  %94 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %95 = getelementptr inbounds %Point, %Point addrspace(1)* %94, i32 0, i32 0
-  %96 = load i32, i32 addrspace(1)* %95, align 8
-  %97 = add i32 %93, %96
-  store i32 %97, i32* %loc4
-  %98 = load i32, i32* %loc4
-  %99 = icmp eq i32 20, %98
-  br i1 %99, label %101, label %100
+; <label>:113                                     ; preds = %106
+  %114 = load i32, i32* %loc4
+  %115 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
+  %NullCheck42 = icmp ne %Point addrspace(1)* %115, null
+  br i1 %NullCheck42, label %116, label %ThrowNullRef41
 
-; <label>:100                                     ; preds = %92
-  ret i32 -1
-
-; <label>:101                                     ; preds = %92
-  %102 = load i32, i32* %loc5
-  %103 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %104 = getelementptr inbounds %Point, %Point addrspace(1)* %103, i32 0, i32 1
-  %105 = load i32, i32 addrspace(1)* %104, align 8
-  %106 = mul i32 %102, %105
-  store i32 %106, i32* %loc5
-  %107 = load i32, i32* %loc5
-  %108 = icmp eq i32 %107, 0
-  br i1 %108, label %110, label %109
-
-; <label>:109                                     ; preds = %101
-  ret i32 -1
-
-; <label>:110                                     ; preds = %101
-  %111 = load i32, i32* %loc6
-  %112 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %113 = getelementptr inbounds %Point, %Point addrspace(1)* %112, i32 0, i32 0
-  %114 = load i32, i32 addrspace(1)* %113, align 8
-  %115 = sdiv i32 %111, %114
-  store i32 %115, i32* %loc6
-  %116 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %117 = getelementptr inbounds %Point, %Point addrspace(1)* %116, i32 0, i32 0
+; <label>:116                                     ; preds = %113
+  %117 = getelementptr inbounds %Point, %Point addrspace(1)* %115, i32 0, i32 0
   %118 = load i32, i32 addrspace(1)* %117, align 8
-  %119 = add i32 %118, 10
-  %120 = getelementptr inbounds %Point, %Point addrspace(1)* %116, i32 0, i32 0
-  store i32 %119, i32 addrspace(1)* %120
-  %121 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %122 = getelementptr inbounds %Point, %Point addrspace(1)* %121, i32 0, i32 1
-  %123 = load i32, i32 addrspace(1)* %122, align 8
-  %124 = mul i32 %123, 3
-  %125 = getelementptr inbounds %Point, %Point addrspace(1)* %121, i32 0, i32 1
-  store i32 %124, i32 addrspace(1)* %125
-  %126 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %127 = getelementptr inbounds %Point, %Point addrspace(1)* %126, i32 0, i32 2
-  %128 = load i32, i32 addrspace(1)* %127, align 8
-  %129 = sdiv i32 %128, 5
-  %130 = getelementptr inbounds %Point, %Point addrspace(1)* %126, i32 0, i32 2
-  store i32 %129, i32 addrspace(1)* %130
-  %131 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %132 = getelementptr inbounds %Point, %Point addrspace(1)* %131, i32 0, i32 0
-  %133 = load i32, i32 addrspace(1)* %132, align 8
-  %134 = icmp eq i32 20, %133
-  br i1 %134, label %136, label %135
+  %119 = add i32 %114, %118
+  store i32 %119, i32* %loc4
+  %120 = load i32, i32* %loc4
+  %121 = icmp eq i32 20, %120
+  br i1 %121, label %123, label %122
 
-; <label>:135                                     ; preds = %110
+; <label>:122                                     ; preds = %116
   ret i32 -1
 
-; <label>:136                                     ; preds = %110
-  %137 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %138 = getelementptr inbounds %Point, %Point addrspace(1)* %137, i32 0, i32 1
-  %139 = load i32, i32 addrspace(1)* %138, align 8
-  %140 = icmp eq i32 60, %139
-  br i1 %140, label %142, label %141
+; <label>:123                                     ; preds = %116
+  %124 = load i32, i32* %loc5
+  %125 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
+  %NullCheck44 = icmp ne %Point addrspace(1)* %125, null
+  br i1 %NullCheck44, label %126, label %ThrowNullRef43
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %Point, %Point addrspace(1)* %125, i32 0, i32 1
+  %128 = load i32, i32 addrspace(1)* %127, align 8
+  %129 = mul i32 %124, %128
+  store i32 %129, i32* %loc5
+  %130 = load i32, i32* %loc5
+  %131 = icmp eq i32 %130, 0
+  br i1 %131, label %133, label %132
+
+; <label>:132                                     ; preds = %126
+  ret i32 -1
+
+; <label>:133                                     ; preds = %126
+  %134 = load i32, i32* %loc6
+  %135 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
+  %NullCheck46 = icmp ne %Point addrspace(1)* %135, null
+  br i1 %NullCheck46, label %136, label %ThrowNullRef45
+
+; <label>:136                                     ; preds = %133
+  %137 = getelementptr inbounds %Point, %Point addrspace(1)* %135, i32 0, i32 0
+  %138 = load i32, i32 addrspace(1)* %137, align 8
+  %139 = sdiv i32 %134, %138
+  store i32 %139, i32* %loc6
+  %140 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
+  %NullCheck48 = icmp ne %Point addrspace(1)* %140, null
+  br i1 %NullCheck48, label %141, label %ThrowNullRef47
 
 ; <label>:141                                     ; preds = %136
+  %142 = getelementptr inbounds %Point, %Point addrspace(1)* %140, i32 0, i32 0
+  %143 = load i32, i32 addrspace(1)* %142, align 8
+  %144 = add i32 %143, 10
+  %NullCheck50 = icmp ne %Point addrspace(1)* %140, null
+  br i1 %NullCheck50, label %145, label %ThrowNullRef49
+
+; <label>:145                                     ; preds = %141
+  %146 = getelementptr inbounds %Point, %Point addrspace(1)* %140, i32 0, i32 0
+  store i32 %144, i32 addrspace(1)* %146
+  %147 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
+  %NullCheck52 = icmp ne %Point addrspace(1)* %147, null
+  br i1 %NullCheck52, label %148, label %ThrowNullRef51
+
+; <label>:148                                     ; preds = %145
+  %149 = getelementptr inbounds %Point, %Point addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149, align 8
+  %151 = mul i32 %150, 3
+  %NullCheck54 = icmp ne %Point addrspace(1)* %147, null
+  br i1 %NullCheck54, label %152, label %ThrowNullRef53
+
+; <label>:152                                     ; preds = %148
+  %153 = getelementptr inbounds %Point, %Point addrspace(1)* %147, i32 0, i32 1
+  store i32 %151, i32 addrspace(1)* %153
+  %154 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
+  %NullCheck56 = icmp ne %Point addrspace(1)* %154, null
+  br i1 %NullCheck56, label %155, label %ThrowNullRef55
+
+; <label>:155                                     ; preds = %152
+  %156 = getelementptr inbounds %Point, %Point addrspace(1)* %154, i32 0, i32 2
+  %157 = load i32, i32 addrspace(1)* %156, align 8
+  %158 = sdiv i32 %157, 5
+  %NullCheck58 = icmp ne %Point addrspace(1)* %154, null
+  br i1 %NullCheck58, label %159, label %ThrowNullRef57
+
+; <label>:159                                     ; preds = %155
+  %160 = getelementptr inbounds %Point, %Point addrspace(1)* %154, i32 0, i32 2
+  store i32 %158, i32 addrspace(1)* %160
+  %161 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
+  %NullCheck60 = icmp ne %Point addrspace(1)* %161, null
+  br i1 %NullCheck60, label %162, label %ThrowNullRef59
+
+; <label>:162                                     ; preds = %159
+  %163 = getelementptr inbounds %Point, %Point addrspace(1)* %161, i32 0, i32 0
+  %164 = load i32, i32 addrspace(1)* %163, align 8
+  %165 = icmp eq i32 20, %164
+  br i1 %165, label %167, label %166
+
+; <label>:166                                     ; preds = %162
   ret i32 -1
 
-; <label>:142                                     ; preds = %136
-  %143 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
-  %144 = getelementptr inbounds %Point, %Point addrspace(1)* %143, i32 0, i32 2
-  %145 = load i32, i32 addrspace(1)* %144, align 8
-  %146 = icmp eq i32 6, %145
-  br i1 %146, label %148, label %147
+; <label>:167                                     ; preds = %162
+  %168 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
+  %NullCheck62 = icmp ne %Point addrspace(1)* %168, null
+  br i1 %NullCheck62, label %169, label %ThrowNullRef61
 
-; <label>:147                                     ; preds = %142
+; <label>:169                                     ; preds = %167
+  %170 = getelementptr inbounds %Point, %Point addrspace(1)* %168, i32 0, i32 1
+  %171 = load i32, i32 addrspace(1)* %170, align 8
+  %172 = icmp eq i32 60, %171
+  br i1 %172, label %174, label %173
+
+; <label>:173                                     ; preds = %169
   ret i32 -1
 
-; <label>:148                                     ; preds = %142
-  %149 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%PointFlt addrspace(1)*, float, float, float)*)(%PointFlt addrspace(1)* %149, float 1.000000e+01, float 2.000000e+01, float 3.000000e+01)
-  %150 = addrspacecast %PointFlt* %loc8 to %PointFlt addrspace(1)*
-  %151 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %150, i32 0, i32 0
-  store float 0.000000e+00, float addrspace(1)* %151
-  %152 = addrspacecast %PointFlt* %loc8 to %PointFlt addrspace(1)*
-  %153 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %152, i32 0, i32 1
-  store float 0.000000e+00, float addrspace(1)* %153
-  %154 = addrspacecast %PointFlt* %loc8 to %PointFlt addrspace(1)*
-  %155 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %154, i32 0, i32 2
-  store float 0.000000e+00, float addrspace(1)* %155
-  %156 = addrspacecast %PointFlt* %loc9 to %PointFlt addrspace(1)*
-  %157 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %158 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %157, i32 0, i32 0
-  %159 = load float, float addrspace(1)* %158, align 8
-  %160 = fadd float %159, 5.000000e+00
-  %161 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %156, i32 0, i32 0
-  store float %160, float addrspace(1)* %161
-  %162 = addrspacecast %PointFlt* %loc9 to %PointFlt addrspace(1)*
-  %163 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %164 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %163, i32 0, i32 1
-  %165 = load float, float addrspace(1)* %164, align 8
-  %166 = addrspacecast %PointFlt* %loc8 to %PointFlt addrspace(1)*
-  %167 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %166, i32 0, i32 1
-  %168 = load float, float addrspace(1)* %167, align 8
-  %169 = fadd float %165, %168
-  %170 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %162, i32 0, i32 1
-  store float %169, float addrspace(1)* %170
-  %171 = addrspacecast %PointFlt* %loc9 to %PointFlt addrspace(1)*
-  %172 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %173 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %172, i32 0, i32 2
-  %174 = load float, float addrspace(1)* %173, align 8
-  %175 = addrspacecast %PointFlt* %loc8 to %PointFlt addrspace(1)*
-  %176 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %175, i32 0, i32 2
-  %177 = load float, float addrspace(1)* %176, align 8
-  %178 = fmul float %174, %177
-  %179 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %171, i32 0, i32 2
-  store float %178, float addrspace(1)* %179
-  %180 = addrspacecast %PointFlt* %loc9 to %PointFlt addrspace(1)*
-  %181 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %180, i32 0, i32 0
-  %182 = load float, float addrspace(1)* %181, align 8
-  %183 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (float, float)*)(float %182, float 1.500000e+01)
-  %184 = zext i8 %183 to i32
-  %185 = icmp eq i32 %184, 0
-  br i1 %185, label %199, label %186
+; <label>:174                                     ; preds = %169
+  %175 = addrspacecast %Point* %loc0 to %Point addrspace(1)*
+  %NullCheck64 = icmp ne %Point addrspace(1)* %175, null
+  br i1 %NullCheck64, label %176, label %ThrowNullRef63
 
-; <label>:186                                     ; preds = %148
-  %187 = addrspacecast %PointFlt* %loc9 to %PointFlt addrspace(1)*
-  %188 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %187, i32 0, i32 1
-  %189 = load float, float addrspace(1)* %188, align 8
-  %190 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (float, float)*)(float %189, float 2.000000e+01)
-  %191 = zext i8 %190 to i32
-  %192 = icmp eq i32 %191, 0
-  br i1 %192, label %199, label %193
+; <label>:176                                     ; preds = %174
+  %177 = getelementptr inbounds %Point, %Point addrspace(1)* %175, i32 0, i32 2
+  %178 = load i32, i32 addrspace(1)* %177, align 8
+  %179 = icmp eq i32 6, %178
+  br i1 %179, label %181, label %180
 
-; <label>:193                                     ; preds = %186
-  %194 = addrspacecast %PointFlt* %loc9 to %PointFlt addrspace(1)*
-  %195 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %194, i32 0, i32 2
+; <label>:180                                     ; preds = %176
+  ret i32 -1
+
+; <label>:181                                     ; preds = %176
+  %182 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%PointFlt addrspace(1)*, float, float, float)*)(%PointFlt addrspace(1)* %182, float 1.000000e+01, float 2.000000e+01, float 3.000000e+01)
+  %183 = addrspacecast %PointFlt* %loc8 to %PointFlt addrspace(1)*
+  %NullCheck66 = icmp ne %PointFlt addrspace(1)* %183, null
+  br i1 %NullCheck66, label %184, label %ThrowNullRef65
+
+; <label>:184                                     ; preds = %181
+  %185 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %183, i32 0, i32 0
+  store float 0.000000e+00, float addrspace(1)* %185
+  %186 = addrspacecast %PointFlt* %loc8 to %PointFlt addrspace(1)*
+  %NullCheck68 = icmp ne %PointFlt addrspace(1)* %186, null
+  br i1 %NullCheck68, label %187, label %ThrowNullRef67
+
+; <label>:187                                     ; preds = %184
+  %188 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %186, i32 0, i32 1
+  store float 0.000000e+00, float addrspace(1)* %188
+  %189 = addrspacecast %PointFlt* %loc8 to %PointFlt addrspace(1)*
+  %NullCheck70 = icmp ne %PointFlt addrspace(1)* %189, null
+  br i1 %NullCheck70, label %190, label %ThrowNullRef69
+
+; <label>:190                                     ; preds = %187
+  %191 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %189, i32 0, i32 2
+  store float 0.000000e+00, float addrspace(1)* %191
+  %192 = addrspacecast %PointFlt* %loc9 to %PointFlt addrspace(1)*
+  %193 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
+  %NullCheck72 = icmp ne %PointFlt addrspace(1)* %193, null
+  br i1 %NullCheck72, label %194, label %ThrowNullRef71
+
+; <label>:194                                     ; preds = %190
+  %195 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %193, i32 0, i32 0
   %196 = load float, float addrspace(1)* %195, align 8
-  %197 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (float, float)*)(float %196, float 0.000000e+00)
-  %198 = zext i8 %197 to i32
-  br label %200
+  %197 = fadd float %196, 5.000000e+00
+  %NullCheck74 = icmp ne %PointFlt addrspace(1)* %192, null
+  br i1 %NullCheck74, label %198, label %ThrowNullRef73
 
-; <label>:199                                     ; preds = %148, %186
-  br label %200
+; <label>:198                                     ; preds = %194
+  %199 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %192, i32 0, i32 0
+  store float %197, float addrspace(1)* %199
+  %200 = addrspacecast %PointFlt* %loc9 to %PointFlt addrspace(1)*
+  %201 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
+  %NullCheck76 = icmp ne %PointFlt addrspace(1)* %201, null
+  br i1 %NullCheck76, label %202, label %ThrowNullRef75
 
-; <label>:200                                     ; preds = %193, %199
-  %201 = phi i32 [ %198, %193 ], [ 0, %199 ]
-  %202 = trunc i32 %201 to i8
-  store i8 %202, i8* %loc3
-  %203 = load i8, i8* %loc3
-  %204 = zext i8 %203 to i32
-  %205 = icmp ne i32 %204, 0
-  br i1 %205, label %207, label %206
+; <label>:202                                     ; preds = %198
+  %203 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %201, i32 0, i32 1
+  %204 = load float, float addrspace(1)* %203, align 8
+  %205 = addrspacecast %PointFlt* %loc8 to %PointFlt addrspace(1)*
+  %NullCheck78 = icmp ne %PointFlt addrspace(1)* %205, null
+  br i1 %NullCheck78, label %206, label %ThrowNullRef77
 
-; <label>:206                                     ; preds = %200
-  ret i32 -1
+; <label>:206                                     ; preds = %202
+  %207 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %205, i32 0, i32 1
+  %208 = load float, float addrspace(1)* %207, align 8
+  %209 = fadd float %204, %208
+  %NullCheck80 = icmp ne %PointFlt addrspace(1)* %200, null
+  br i1 %NullCheck80, label %210, label %ThrowNullRef79
 
-; <label>:207                                     ; preds = %200
-  %208 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %209 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %208, i32 0, i32 0
-  %210 = load float, float addrspace(1)* %209, align 8
-  %211 = addrspacecast %PointFlt* %loc8 to %PointFlt addrspace(1)*
-  %212 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %211, i32 0, i32 0
-  %213 = load float, float addrspace(1)* %212, align 8
-  %214 = fadd float %210, %213
-  store float %214, float* %loc10
-  %215 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %216 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %215, i32 0, i32 1
-  %217 = load float, float addrspace(1)* %216, align 8
-  %218 = addrspacecast %PointFlt* %loc8 to %PointFlt addrspace(1)*
-  %219 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %218, i32 0, i32 1
+; <label>:210                                     ; preds = %206
+  %211 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %200, i32 0, i32 1
+  store float %209, float addrspace(1)* %211
+  %212 = addrspacecast %PointFlt* %loc9 to %PointFlt addrspace(1)*
+  %213 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
+  %NullCheck82 = icmp ne %PointFlt addrspace(1)* %213, null
+  br i1 %NullCheck82, label %214, label %ThrowNullRef81
+
+; <label>:214                                     ; preds = %210
+  %215 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %213, i32 0, i32 2
+  %216 = load float, float addrspace(1)* %215, align 8
+  %217 = addrspacecast %PointFlt* %loc8 to %PointFlt addrspace(1)*
+  %NullCheck84 = icmp ne %PointFlt addrspace(1)* %217, null
+  br i1 %NullCheck84, label %218, label %ThrowNullRef83
+
+; <label>:218                                     ; preds = %214
+  %219 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %217, i32 0, i32 2
   %220 = load float, float addrspace(1)* %219, align 8
-  %221 = fmul float %217, %220
-  store float %221, float* %loc11
-  %222 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %223 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %222, i32 0, i32 2
-  %224 = load float, float addrspace(1)* %223, align 8
-  store float %224, float* %loc12
-  %225 = load float, float* %loc10
-  %226 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %227 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %226, i32 0, i32 0
-  %228 = load float, float addrspace(1)* %227, align 8
-  %229 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (float, float)*)(float %225, float %228)
-  %230 = zext i8 %229 to i32
-  %231 = icmp eq i32 %230, 0
-  br i1 %231, label %239, label %232
+  %221 = fmul float %216, %220
+  %NullCheck86 = icmp ne %PointFlt addrspace(1)* %212, null
+  br i1 %NullCheck86, label %222, label %ThrowNullRef85
 
-; <label>:232                                     ; preds = %207
-  %233 = load float, float* %loc11
-  %234 = addrspacecast %PointFlt* %loc8 to %PointFlt addrspace(1)*
-  %235 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %234, i32 0, i32 1
-  %236 = load float, float addrspace(1)* %235, align 8
-  %237 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (float, float)*)(float %233, float %236)
-  %238 = zext i8 %237 to i32
-  br label %240
+; <label>:222                                     ; preds = %218
+  %223 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %212, i32 0, i32 2
+  store float %221, float addrspace(1)* %223
+  %224 = addrspacecast %PointFlt* %loc9 to %PointFlt addrspace(1)*
+  %NullCheck88 = icmp ne %PointFlt addrspace(1)* %224, null
+  br i1 %NullCheck88, label %225, label %ThrowNullRef87
 
-; <label>:239                                     ; preds = %207
-  br label %240
+; <label>:225                                     ; preds = %222
+  %226 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %224, i32 0, i32 0
+  %227 = load float, float addrspace(1)* %226, align 8
+  %228 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (float, float)*)(float %227, float 1.500000e+01)
+  %229 = zext i8 %228 to i32
+  %230 = icmp eq i32 %229, 0
+  br i1 %230, label %246, label %231
 
-; <label>:240                                     ; preds = %232, %239
-  %241 = phi i32 [ %238, %232 ], [ 0, %239 ]
-  %242 = trunc i32 %241 to i8
-  store i8 %242, i8* %loc3
-  %243 = load i8, i8* %loc3
-  %244 = zext i8 %243 to i32
-  %245 = icmp ne i32 %244, 0
-  br i1 %245, label %247, label %246
+; <label>:231                                     ; preds = %225
+  %232 = addrspacecast %PointFlt* %loc9 to %PointFlt addrspace(1)*
+  %NullCheck90 = icmp ne %PointFlt addrspace(1)* %232, null
+  br i1 %NullCheck90, label %233, label %ThrowNullRef89
 
-; <label>:246                                     ; preds = %240
+; <label>:233                                     ; preds = %231
+  %234 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %232, i32 0, i32 1
+  %235 = load float, float addrspace(1)* %234, align 8
+  %236 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (float, float)*)(float %235, float 2.000000e+01)
+  %237 = zext i8 %236 to i32
+  %238 = icmp eq i32 %237, 0
+  br i1 %238, label %246, label %239
+
+; <label>:239                                     ; preds = %233
+  %240 = addrspacecast %PointFlt* %loc9 to %PointFlt addrspace(1)*
+  %NullCheck92 = icmp ne %PointFlt addrspace(1)* %240, null
+  br i1 %NullCheck92, label %241, label %ThrowNullRef91
+
+; <label>:241                                     ; preds = %239
+  %242 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %240, i32 0, i32 2
+  %243 = load float, float addrspace(1)* %242, align 8
+  %244 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (float, float)*)(float %243, float 0.000000e+00)
+  %245 = zext i8 %244 to i32
+  br label %247
+
+; <label>:246                                     ; preds = %225, %233
+  br label %247
+
+; <label>:247                                     ; preds = %241, %246
+  %248 = phi i32 [ %245, %241 ], [ 0, %246 ]
+  %249 = trunc i32 %248 to i8
+  store i8 %249, i8* %loc3
+  %250 = load i8, i8* %loc3
+  %251 = zext i8 %250 to i32
+  %252 = icmp ne i32 %251, 0
+  br i1 %252, label %254, label %253
+
+; <label>:253                                     ; preds = %247
   ret i32 -1
 
-; <label>:247                                     ; preds = %240
-  %248 = load float, float* %loc10
-  %249 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %250 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %249, i32 0, i32 0
-  %251 = load float, float addrspace(1)* %250, align 8
-  %252 = fadd float %248, %251
-  store float %252, float* %loc10
-  %253 = load float, float* %loc10
-  %254 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (float, float)*)(float 2.000000e+01, float %253)
-  %255 = zext i8 %254 to i32
-  %256 = icmp ne i32 %255, 0
-  br i1 %256, label %258, label %257
+; <label>:254                                     ; preds = %247
+  %255 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
+  %NullCheck94 = icmp ne %PointFlt addrspace(1)* %255, null
+  br i1 %NullCheck94, label %256, label %ThrowNullRef93
 
-; <label>:257                                     ; preds = %247
-  ret i32 -1
+; <label>:256                                     ; preds = %254
+  %257 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %255, i32 0, i32 0
+  %258 = load float, float addrspace(1)* %257, align 8
+  %259 = addrspacecast %PointFlt* %loc8 to %PointFlt addrspace(1)*
+  %NullCheck96 = icmp ne %PointFlt addrspace(1)* %259, null
+  br i1 %NullCheck96, label %260, label %ThrowNullRef95
 
-; <label>:258                                     ; preds = %247
-  %259 = load float, float* %loc11
-  %260 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %261 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %260, i32 0, i32 1
+; <label>:260                                     ; preds = %256
+  %261 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %259, i32 0, i32 0
   %262 = load float, float addrspace(1)* %261, align 8
-  %263 = fmul float %259, %262
-  store float %263, float* %loc11
-  %264 = load float, float* %loc11
-  %265 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (float, float)*)(float 0.000000e+00, float %264)
-  %266 = zext i8 %265 to i32
-  %267 = icmp ne i32 %266, 0
-  br i1 %267, label %269, label %268
+  %263 = fadd float %258, %262
+  store float %263, float* %loc10
+  %264 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
+  %NullCheck98 = icmp ne %PointFlt addrspace(1)* %264, null
+  br i1 %NullCheck98, label %265, label %ThrowNullRef97
 
-; <label>:268                                     ; preds = %258
+; <label>:265                                     ; preds = %260
+  %266 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %264, i32 0, i32 1
+  %267 = load float, float addrspace(1)* %266, align 8
+  %268 = addrspacecast %PointFlt* %loc8 to %PointFlt addrspace(1)*
+  %NullCheck100 = icmp ne %PointFlt addrspace(1)* %268, null
+  br i1 %NullCheck100, label %269, label %ThrowNullRef99
+
+; <label>:269                                     ; preds = %265
+  %270 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %268, i32 0, i32 1
+  %271 = load float, float addrspace(1)* %270, align 8
+  %272 = fmul float %267, %271
+  store float %272, float* %loc11
+  %273 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
+  %NullCheck102 = icmp ne %PointFlt addrspace(1)* %273, null
+  br i1 %NullCheck102, label %274, label %ThrowNullRef101
+
+; <label>:274                                     ; preds = %269
+  %275 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %273, i32 0, i32 2
+  %276 = load float, float addrspace(1)* %275, align 8
+  store float %276, float* %loc12
+  %277 = load float, float* %loc10
+  %278 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
+  %NullCheck104 = icmp ne %PointFlt addrspace(1)* %278, null
+  br i1 %NullCheck104, label %279, label %ThrowNullRef103
+
+; <label>:279                                     ; preds = %274
+  %280 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %278, i32 0, i32 0
+  %281 = load float, float addrspace(1)* %280, align 8
+  %282 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (float, float)*)(float %277, float %281)
+  %283 = zext i8 %282 to i32
+  %284 = icmp eq i32 %283, 0
+  br i1 %284, label %293, label %285
+
+; <label>:285                                     ; preds = %279
+  %286 = load float, float* %loc11
+  %287 = addrspacecast %PointFlt* %loc8 to %PointFlt addrspace(1)*
+  %NullCheck106 = icmp ne %PointFlt addrspace(1)* %287, null
+  br i1 %NullCheck106, label %288, label %ThrowNullRef105
+
+; <label>:288                                     ; preds = %285
+  %289 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %287, i32 0, i32 1
+  %290 = load float, float addrspace(1)* %289, align 8
+  %291 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (float, float)*)(float %286, float %290)
+  %292 = zext i8 %291 to i32
+  br label %294
+
+; <label>:293                                     ; preds = %279
+  br label %294
+
+; <label>:294                                     ; preds = %288, %293
+  %295 = phi i32 [ %292, %288 ], [ 0, %293 ]
+  %296 = trunc i32 %295 to i8
+  store i8 %296, i8* %loc3
+  %297 = load i8, i8* %loc3
+  %298 = zext i8 %297 to i32
+  %299 = icmp ne i32 %298, 0
+  br i1 %299, label %301, label %300
+
+; <label>:300                                     ; preds = %294
   ret i32 -1
 
-; <label>:269                                     ; preds = %258
-  %270 = load float, float* %loc12
-  %271 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %272 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %271, i32 0, i32 0
-  %273 = load float, float addrspace(1)* %272, align 8
-  %274 = fdiv float %270, %273
-  store float %274, float* %loc12
-  %275 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %276 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %275, i32 0, i32 0
-  %277 = load float, float addrspace(1)* %276, align 8
-  %278 = fadd float %277, 1.000000e+01
-  %279 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %275, i32 0, i32 0
-  store float %278, float addrspace(1)* %279
-  %280 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %281 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %280, i32 0, i32 1
-  %282 = load float, float addrspace(1)* %281, align 8
-  %283 = fmul float %282, 3.000000e+00
-  %284 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %280, i32 0, i32 1
-  store float %283, float addrspace(1)* %284
-  %285 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %286 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %285, i32 0, i32 2
-  %287 = load float, float addrspace(1)* %286, align 8
-  %288 = fdiv float %287, 5.000000e+00
-  %289 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %285, i32 0, i32 2
-  store float %288, float addrspace(1)* %289
-  %290 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %291 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %290, i32 0, i32 0
-  %292 = load float, float addrspace(1)* %291, align 8
-  %293 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (float, float)*)(float 2.000000e+01, float %292)
-  %294 = zext i8 %293 to i32
-  %295 = icmp ne i32 %294, 0
-  br i1 %295, label %297, label %296
+; <label>:301                                     ; preds = %294
+  %302 = load float, float* %loc10
+  %303 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
+  %NullCheck108 = icmp ne %PointFlt addrspace(1)* %303, null
+  br i1 %NullCheck108, label %304, label %ThrowNullRef107
 
-; <label>:296                                     ; preds = %269
-  ret i32 -1
-
-; <label>:297                                     ; preds = %269
-  %298 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %299 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %298, i32 0, i32 1
-  %300 = load float, float addrspace(1)* %299, align 8
-  %301 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (float, float)*)(float 6.000000e+01, float %300)
-  %302 = zext i8 %301 to i32
-  %303 = icmp ne i32 %302, 0
-  br i1 %303, label %305, label %304
-
-; <label>:304                                     ; preds = %297
-  ret i32 -1
-
-; <label>:305                                     ; preds = %297
-  %306 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
-  %307 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %306, i32 0, i32 2
-  %308 = load float, float addrspace(1)* %307, align 8
-  %309 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (float, float)*)(float 6.000000e+00, float %308)
+; <label>:304                                     ; preds = %301
+  %305 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %303, i32 0, i32 0
+  %306 = load float, float addrspace(1)* %305, align 8
+  %307 = fadd float %302, %306
+  store float %307, float* %loc10
+  %308 = load float, float* %loc10
+  %309 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (float, float)*)(float 2.000000e+01, float %308)
   %310 = zext i8 %309 to i32
   %311 = icmp ne i32 %310, 0
   br i1 %311, label %313, label %312
 
-; <label>:312                                     ; preds = %305
+; <label>:312                                     ; preds = %304
   ret i32 -1
 
-; <label>:313                                     ; preds = %305
-  %314 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%PointDbl addrspace(1)*, double, double, double)*)(%PointDbl addrspace(1)* %314, double 1.000000e+01, double 2.000000e+01, double 3.000000e+01)
-  %315 = addrspacecast %PointDbl* %loc14 to %PointDbl addrspace(1)*
-  %316 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %315, i32 0, i32 0
-  store double 0.000000e+00, double addrspace(1)* %316
-  %317 = addrspacecast %PointDbl* %loc14 to %PointDbl addrspace(1)*
-  %318 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %317, i32 0, i32 1
-  store double 0.000000e+00, double addrspace(1)* %318
-  %319 = addrspacecast %PointDbl* %loc14 to %PointDbl addrspace(1)*
-  %320 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %319, i32 0, i32 2
-  store double 0.000000e+00, double addrspace(1)* %320
-  %321 = addrspacecast %PointDbl* %loc15 to %PointDbl addrspace(1)*
-  %322 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %323 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %322, i32 0, i32 0
-  %324 = load double, double addrspace(1)* %323, align 8
-  %325 = fadd double %324, 5.000000e+00
-  %326 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %321, i32 0, i32 0
-  store double %325, double addrspace(1)* %326
-  %327 = addrspacecast %PointDbl* %loc15 to %PointDbl addrspace(1)*
-  %328 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %329 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %328, i32 0, i32 1
-  %330 = load double, double addrspace(1)* %329, align 8
-  %331 = addrspacecast %PointDbl* %loc14 to %PointDbl addrspace(1)*
-  %332 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %331, i32 0, i32 1
-  %333 = load double, double addrspace(1)* %332, align 8
-  %334 = fadd double %330, %333
-  %335 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %327, i32 0, i32 1
-  store double %334, double addrspace(1)* %335
-  %336 = addrspacecast %PointDbl* %loc15 to %PointDbl addrspace(1)*
-  %337 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %338 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %337, i32 0, i32 2
-  %339 = load double, double addrspace(1)* %338, align 8
-  %340 = addrspacecast %PointDbl* %loc14 to %PointDbl addrspace(1)*
-  %341 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %340, i32 0, i32 2
-  %342 = load double, double addrspace(1)* %341, align 8
-  %343 = fmul double %339, %342
-  %344 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %336, i32 0, i32 2
-  store double %343, double addrspace(1)* %344
-  %345 = addrspacecast %PointDbl* %loc15 to %PointDbl addrspace(1)*
-  %346 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %345, i32 0, i32 0
-  %347 = load double, double addrspace(1)* %346, align 8
-  %348 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (double, double)*)(double %347, double 1.500000e+01)
-  %349 = zext i8 %348 to i32
-  %350 = icmp eq i32 %349, 0
-  br i1 %350, label %364, label %351
+; <label>:313                                     ; preds = %304
+  %314 = load float, float* %loc11
+  %315 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
+  %NullCheck110 = icmp ne %PointFlt addrspace(1)* %315, null
+  br i1 %NullCheck110, label %316, label %ThrowNullRef109
 
-; <label>:351                                     ; preds = %313
-  %352 = addrspacecast %PointDbl* %loc15 to %PointDbl addrspace(1)*
-  %353 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %352, i32 0, i32 1
-  %354 = load double, double addrspace(1)* %353, align 8
-  %355 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (double, double)*)(double %354, double 2.000000e+01)
-  %356 = zext i8 %355 to i32
-  %357 = icmp eq i32 %356, 0
-  br i1 %357, label %364, label %358
+; <label>:316                                     ; preds = %313
+  %317 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %315, i32 0, i32 1
+  %318 = load float, float addrspace(1)* %317, align 8
+  %319 = fmul float %314, %318
+  store float %319, float* %loc11
+  %320 = load float, float* %loc11
+  %321 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (float, float)*)(float 0.000000e+00, float %320)
+  %322 = zext i8 %321 to i32
+  %323 = icmp ne i32 %322, 0
+  br i1 %323, label %325, label %324
 
-; <label>:358                                     ; preds = %351
-  %359 = addrspacecast %PointDbl* %loc15 to %PointDbl addrspace(1)*
-  %360 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %359, i32 0, i32 2
-  %361 = load double, double addrspace(1)* %360, align 8
-  %362 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (double, double)*)(double %361, double 0.000000e+00)
-  %363 = zext i8 %362 to i32
-  br label %365
-
-; <label>:364                                     ; preds = %313, %351
-  br label %365
-
-; <label>:365                                     ; preds = %358, %364
-  %366 = phi i32 [ %363, %358 ], [ 0, %364 ]
-  %367 = trunc i32 %366 to i8
-  store i8 %367, i8* %loc3
-  %368 = load i8, i8* %loc3
-  %369 = zext i8 %368 to i32
-  %370 = icmp ne i32 %369, 0
-  br i1 %370, label %372, label %371
-
-; <label>:371                                     ; preds = %365
+; <label>:324                                     ; preds = %316
   ret i32 -1
 
-; <label>:372                                     ; preds = %365
-  %373 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %374 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %373, i32 0, i32 0
-  %375 = load double, double addrspace(1)* %374, align 8
-  %376 = addrspacecast %PointDbl* %loc14 to %PointDbl addrspace(1)*
-  %377 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %376, i32 0, i32 0
-  %378 = load double, double addrspace(1)* %377, align 8
-  %379 = fadd double %375, %378
-  store double %379, double* %loc16
+; <label>:325                                     ; preds = %316
+  %326 = load float, float* %loc12
+  %327 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
+  %NullCheck112 = icmp ne %PointFlt addrspace(1)* %327, null
+  br i1 %NullCheck112, label %328, label %ThrowNullRef111
+
+; <label>:328                                     ; preds = %325
+  %329 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %327, i32 0, i32 0
+  %330 = load float, float addrspace(1)* %329, align 8
+  %331 = fdiv float %326, %330
+  store float %331, float* %loc12
+  %332 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
+  %NullCheck114 = icmp ne %PointFlt addrspace(1)* %332, null
+  br i1 %NullCheck114, label %333, label %ThrowNullRef113
+
+; <label>:333                                     ; preds = %328
+  %334 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %332, i32 0, i32 0
+  %335 = load float, float addrspace(1)* %334, align 8
+  %336 = fadd float %335, 1.000000e+01
+  %NullCheck116 = icmp ne %PointFlt addrspace(1)* %332, null
+  br i1 %NullCheck116, label %337, label %ThrowNullRef115
+
+; <label>:337                                     ; preds = %333
+  %338 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %332, i32 0, i32 0
+  store float %336, float addrspace(1)* %338
+  %339 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
+  %NullCheck118 = icmp ne %PointFlt addrspace(1)* %339, null
+  br i1 %NullCheck118, label %340, label %ThrowNullRef117
+
+; <label>:340                                     ; preds = %337
+  %341 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %339, i32 0, i32 1
+  %342 = load float, float addrspace(1)* %341, align 8
+  %343 = fmul float %342, 3.000000e+00
+  %NullCheck120 = icmp ne %PointFlt addrspace(1)* %339, null
+  br i1 %NullCheck120, label %344, label %ThrowNullRef119
+
+; <label>:344                                     ; preds = %340
+  %345 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %339, i32 0, i32 1
+  store float %343, float addrspace(1)* %345
+  %346 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
+  %NullCheck122 = icmp ne %PointFlt addrspace(1)* %346, null
+  br i1 %NullCheck122, label %347, label %ThrowNullRef121
+
+; <label>:347                                     ; preds = %344
+  %348 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %346, i32 0, i32 2
+  %349 = load float, float addrspace(1)* %348, align 8
+  %350 = fdiv float %349, 5.000000e+00
+  %NullCheck124 = icmp ne %PointFlt addrspace(1)* %346, null
+  br i1 %NullCheck124, label %351, label %ThrowNullRef123
+
+; <label>:351                                     ; preds = %347
+  %352 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %346, i32 0, i32 2
+  store float %350, float addrspace(1)* %352
+  %353 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
+  %NullCheck126 = icmp ne %PointFlt addrspace(1)* %353, null
+  br i1 %NullCheck126, label %354, label %ThrowNullRef125
+
+; <label>:354                                     ; preds = %351
+  %355 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %353, i32 0, i32 0
+  %356 = load float, float addrspace(1)* %355, align 8
+  %357 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (float, float)*)(float 2.000000e+01, float %356)
+  %358 = zext i8 %357 to i32
+  %359 = icmp ne i32 %358, 0
+  br i1 %359, label %361, label %360
+
+; <label>:360                                     ; preds = %354
+  ret i32 -1
+
+; <label>:361                                     ; preds = %354
+  %362 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
+  %NullCheck128 = icmp ne %PointFlt addrspace(1)* %362, null
+  br i1 %NullCheck128, label %363, label %ThrowNullRef127
+
+; <label>:363                                     ; preds = %361
+  %364 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %362, i32 0, i32 1
+  %365 = load float, float addrspace(1)* %364, align 8
+  %366 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (float, float)*)(float 6.000000e+01, float %365)
+  %367 = zext i8 %366 to i32
+  %368 = icmp ne i32 %367, 0
+  br i1 %368, label %370, label %369
+
+; <label>:369                                     ; preds = %363
+  ret i32 -1
+
+; <label>:370                                     ; preds = %363
+  %371 = addrspacecast %PointFlt* %loc7 to %PointFlt addrspace(1)*
+  %NullCheck130 = icmp ne %PointFlt addrspace(1)* %371, null
+  br i1 %NullCheck130, label %372, label %ThrowNullRef129
+
+; <label>:372                                     ; preds = %370
+  %373 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %371, i32 0, i32 2
+  %374 = load float, float addrspace(1)* %373, align 8
+  %375 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (float, float)*)(float 6.000000e+00, float %374)
+  %376 = zext i8 %375 to i32
+  %377 = icmp ne i32 %376, 0
+  br i1 %377, label %379, label %378
+
+; <label>:378                                     ; preds = %372
+  ret i32 -1
+
+; <label>:379                                     ; preds = %372
   %380 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %381 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %380, i32 0, i32 1
-  %382 = load double, double addrspace(1)* %381, align 8
-  %383 = addrspacecast %PointDbl* %loc14 to %PointDbl addrspace(1)*
-  %384 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %383, i32 0, i32 1
-  %385 = load double, double addrspace(1)* %384, align 8
-  %386 = fmul double %382, %385
-  store double %386, double* %loc17
-  %387 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %388 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %387, i32 0, i32 2
-  %389 = load double, double addrspace(1)* %388, align 8
-  store double %389, double* %loc18
-  %390 = load double, double* %loc16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%PointDbl addrspace(1)*, double, double, double)*)(%PointDbl addrspace(1)* %380, double 1.000000e+01, double 2.000000e+01, double 3.000000e+01)
+  %381 = addrspacecast %PointDbl* %loc14 to %PointDbl addrspace(1)*
+  %NullCheck132 = icmp ne %PointDbl addrspace(1)* %381, null
+  br i1 %NullCheck132, label %382, label %ThrowNullRef131
+
+; <label>:382                                     ; preds = %379
+  %383 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %381, i32 0, i32 0
+  store double 0.000000e+00, double addrspace(1)* %383
+  %384 = addrspacecast %PointDbl* %loc14 to %PointDbl addrspace(1)*
+  %NullCheck134 = icmp ne %PointDbl addrspace(1)* %384, null
+  br i1 %NullCheck134, label %385, label %ThrowNullRef133
+
+; <label>:385                                     ; preds = %382
+  %386 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %384, i32 0, i32 1
+  store double 0.000000e+00, double addrspace(1)* %386
+  %387 = addrspacecast %PointDbl* %loc14 to %PointDbl addrspace(1)*
+  %NullCheck136 = icmp ne %PointDbl addrspace(1)* %387, null
+  br i1 %NullCheck136, label %388, label %ThrowNullRef135
+
+; <label>:388                                     ; preds = %385
+  %389 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %387, i32 0, i32 2
+  store double 0.000000e+00, double addrspace(1)* %389
+  %390 = addrspacecast %PointDbl* %loc15 to %PointDbl addrspace(1)*
   %391 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %392 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %391, i32 0, i32 0
-  %393 = load double, double addrspace(1)* %392, align 8
-  %394 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (double, double)*)(double %390, double %393)
-  %395 = zext i8 %394 to i32
-  %396 = icmp eq i32 %395, 0
-  br i1 %396, label %404, label %397
+  %NullCheck138 = icmp ne %PointDbl addrspace(1)* %391, null
+  br i1 %NullCheck138, label %392, label %ThrowNullRef137
 
-; <label>:397                                     ; preds = %372
-  %398 = load double, double* %loc17
-  %399 = addrspacecast %PointDbl* %loc14 to %PointDbl addrspace(1)*
-  %400 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %399, i32 0, i32 1
-  %401 = load double, double addrspace(1)* %400, align 8
-  %402 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (double, double)*)(double %398, double %401)
-  %403 = zext i8 %402 to i32
-  br label %405
+; <label>:392                                     ; preds = %388
+  %393 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %391, i32 0, i32 0
+  %394 = load double, double addrspace(1)* %393, align 8
+  %395 = fadd double %394, 5.000000e+00
+  %NullCheck140 = icmp ne %PointDbl addrspace(1)* %390, null
+  br i1 %NullCheck140, label %396, label %ThrowNullRef139
 
-; <label>:404                                     ; preds = %372
-  br label %405
+; <label>:396                                     ; preds = %392
+  %397 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %390, i32 0, i32 0
+  store double %395, double addrspace(1)* %397
+  %398 = addrspacecast %PointDbl* %loc15 to %PointDbl addrspace(1)*
+  %399 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
+  %NullCheck142 = icmp ne %PointDbl addrspace(1)* %399, null
+  br i1 %NullCheck142, label %400, label %ThrowNullRef141
 
-; <label>:405                                     ; preds = %397, %404
-  %406 = phi i32 [ %403, %397 ], [ 0, %404 ]
-  %407 = trunc i32 %406 to i8
-  store i8 %407, i8* %loc3
-  %408 = load i8, i8* %loc3
-  %409 = zext i8 %408 to i32
-  %410 = icmp ne i32 %409, 0
-  br i1 %410, label %412, label %411
+; <label>:400                                     ; preds = %396
+  %401 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %399, i32 0, i32 1
+  %402 = load double, double addrspace(1)* %401, align 8
+  %403 = addrspacecast %PointDbl* %loc14 to %PointDbl addrspace(1)*
+  %NullCheck144 = icmp ne %PointDbl addrspace(1)* %403, null
+  br i1 %NullCheck144, label %404, label %ThrowNullRef143
 
-; <label>:411                                     ; preds = %405
+; <label>:404                                     ; preds = %400
+  %405 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %403, i32 0, i32 1
+  %406 = load double, double addrspace(1)* %405, align 8
+  %407 = fadd double %402, %406
+  %NullCheck146 = icmp ne %PointDbl addrspace(1)* %398, null
+  br i1 %NullCheck146, label %408, label %ThrowNullRef145
+
+; <label>:408                                     ; preds = %404
+  %409 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %398, i32 0, i32 1
+  store double %407, double addrspace(1)* %409
+  %410 = addrspacecast %PointDbl* %loc15 to %PointDbl addrspace(1)*
+  %411 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
+  %NullCheck148 = icmp ne %PointDbl addrspace(1)* %411, null
+  br i1 %NullCheck148, label %412, label %ThrowNullRef147
+
+; <label>:412                                     ; preds = %408
+  %413 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %411, i32 0, i32 2
+  %414 = load double, double addrspace(1)* %413, align 8
+  %415 = addrspacecast %PointDbl* %loc14 to %PointDbl addrspace(1)*
+  %NullCheck150 = icmp ne %PointDbl addrspace(1)* %415, null
+  br i1 %NullCheck150, label %416, label %ThrowNullRef149
+
+; <label>:416                                     ; preds = %412
+  %417 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %415, i32 0, i32 2
+  %418 = load double, double addrspace(1)* %417, align 8
+  %419 = fmul double %414, %418
+  %NullCheck152 = icmp ne %PointDbl addrspace(1)* %410, null
+  br i1 %NullCheck152, label %420, label %ThrowNullRef151
+
+; <label>:420                                     ; preds = %416
+  %421 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %410, i32 0, i32 2
+  store double %419, double addrspace(1)* %421
+  %422 = addrspacecast %PointDbl* %loc15 to %PointDbl addrspace(1)*
+  %NullCheck154 = icmp ne %PointDbl addrspace(1)* %422, null
+  br i1 %NullCheck154, label %423, label %ThrowNullRef153
+
+; <label>:423                                     ; preds = %420
+  %424 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %422, i32 0, i32 0
+  %425 = load double, double addrspace(1)* %424, align 8
+  %426 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (double, double)*)(double %425, double 1.500000e+01)
+  %427 = zext i8 %426 to i32
+  %428 = icmp eq i32 %427, 0
+  br i1 %428, label %444, label %429
+
+; <label>:429                                     ; preds = %423
+  %430 = addrspacecast %PointDbl* %loc15 to %PointDbl addrspace(1)*
+  %NullCheck156 = icmp ne %PointDbl addrspace(1)* %430, null
+  br i1 %NullCheck156, label %431, label %ThrowNullRef155
+
+; <label>:431                                     ; preds = %429
+  %432 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %430, i32 0, i32 1
+  %433 = load double, double addrspace(1)* %432, align 8
+  %434 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (double, double)*)(double %433, double 2.000000e+01)
+  %435 = zext i8 %434 to i32
+  %436 = icmp eq i32 %435, 0
+  br i1 %436, label %444, label %437
+
+; <label>:437                                     ; preds = %431
+  %438 = addrspacecast %PointDbl* %loc15 to %PointDbl addrspace(1)*
+  %NullCheck158 = icmp ne %PointDbl addrspace(1)* %438, null
+  br i1 %NullCheck158, label %439, label %ThrowNullRef157
+
+; <label>:439                                     ; preds = %437
+  %440 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %438, i32 0, i32 2
+  %441 = load double, double addrspace(1)* %440, align 8
+  %442 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (double, double)*)(double %441, double 0.000000e+00)
+  %443 = zext i8 %442 to i32
+  br label %445
+
+; <label>:444                                     ; preds = %423, %431
+  br label %445
+
+; <label>:445                                     ; preds = %439, %444
+  %446 = phi i32 [ %443, %439 ], [ 0, %444 ]
+  %447 = trunc i32 %446 to i8
+  store i8 %447, i8* %loc3
+  %448 = load i8, i8* %loc3
+  %449 = zext i8 %448 to i32
+  %450 = icmp ne i32 %449, 0
+  br i1 %450, label %452, label %451
+
+; <label>:451                                     ; preds = %445
   ret i32 -1
 
-; <label>:412                                     ; preds = %405
-  %413 = load double, double* %loc16
-  %414 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %415 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %414, i32 0, i32 0
-  %416 = load double, double addrspace(1)* %415, align 8
-  %417 = fadd double %413, %416
-  store double %417, double* %loc16
-  %418 = load double, double* %loc16
-  %419 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (double, double)*)(double 2.000000e+01, double %418)
-  %420 = zext i8 %419 to i32
-  %421 = icmp ne i32 %420, 0
-  br i1 %421, label %423, label %422
+; <label>:452                                     ; preds = %445
+  %453 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
+  %NullCheck160 = icmp ne %PointDbl addrspace(1)* %453, null
+  br i1 %NullCheck160, label %454, label %ThrowNullRef159
 
-; <label>:422                                     ; preds = %412
-  ret i32 -1
+; <label>:454                                     ; preds = %452
+  %455 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %453, i32 0, i32 0
+  %456 = load double, double addrspace(1)* %455, align 8
+  %457 = addrspacecast %PointDbl* %loc14 to %PointDbl addrspace(1)*
+  %NullCheck162 = icmp ne %PointDbl addrspace(1)* %457, null
+  br i1 %NullCheck162, label %458, label %ThrowNullRef161
 
-; <label>:423                                     ; preds = %412
-  %424 = load double, double* %loc17
-  %425 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %426 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %425, i32 0, i32 1
-  %427 = load double, double addrspace(1)* %426, align 8
-  %428 = fmul double %424, %427
-  store double %428, double* %loc17
-  %429 = load double, double* %loc17
-  %430 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (double, double)*)(double 0.000000e+00, double %429)
-  %431 = zext i8 %430 to i32
-  %432 = icmp ne i32 %431, 0
-  br i1 %432, label %434, label %433
+; <label>:458                                     ; preds = %454
+  %459 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %457, i32 0, i32 0
+  %460 = load double, double addrspace(1)* %459, align 8
+  %461 = fadd double %456, %460
+  store double %461, double* %loc16
+  %462 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
+  %NullCheck164 = icmp ne %PointDbl addrspace(1)* %462, null
+  br i1 %NullCheck164, label %463, label %ThrowNullRef163
 
-; <label>:433                                     ; preds = %423
-  ret i32 -1
-
-; <label>:434                                     ; preds = %423
-  %435 = load double, double* %loc18
-  %436 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %437 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %436, i32 0, i32 0
-  %438 = load double, double addrspace(1)* %437, align 8
-  %439 = fdiv double %435, %438
-  store double %439, double* %loc18
-  %440 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %441 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %440, i32 0, i32 0
-  %442 = load double, double addrspace(1)* %441, align 8
-  %443 = fadd double %442, 1.000000e+01
-  %444 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %440, i32 0, i32 0
-  store double %443, double addrspace(1)* %444
-  %445 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %446 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %445, i32 0, i32 1
-  %447 = load double, double addrspace(1)* %446, align 8
-  %448 = fmul double %447, 3.000000e+00
-  %449 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %445, i32 0, i32 1
-  store double %448, double addrspace(1)* %449
-  %450 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %451 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %450, i32 0, i32 2
-  %452 = load double, double addrspace(1)* %451, align 8
-  %453 = fdiv double %452, 5.000000e+00
-  %454 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %450, i32 0, i32 2
-  store double %453, double addrspace(1)* %454
-  %455 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %456 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %455, i32 0, i32 0
-  %457 = load double, double addrspace(1)* %456, align 8
-  %458 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (double, double)*)(double 2.000000e+01, double %457)
-  %459 = zext i8 %458 to i32
-  %460 = icmp ne i32 %459, 0
-  br i1 %460, label %462, label %461
-
-; <label>:461                                     ; preds = %434
-  ret i32 -1
-
-; <label>:462                                     ; preds = %434
-  %463 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %464 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %463, i32 0, i32 1
+; <label>:463                                     ; preds = %458
+  %464 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %462, i32 0, i32 1
   %465 = load double, double addrspace(1)* %464, align 8
-  %466 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (double, double)*)(double 6.000000e+01, double %465)
-  %467 = zext i8 %466 to i32
-  %468 = icmp ne i32 %467, 0
-  br i1 %468, label %470, label %469
+  %466 = addrspacecast %PointDbl* %loc14 to %PointDbl addrspace(1)*
+  %NullCheck166 = icmp ne %PointDbl addrspace(1)* %466, null
+  br i1 %NullCheck166, label %467, label %ThrowNullRef165
 
-; <label>:469                                     ; preds = %462
-  ret i32 -1
-
-; <label>:470                                     ; preds = %462
+; <label>:467                                     ; preds = %463
+  %468 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %466, i32 0, i32 1
+  %469 = load double, double addrspace(1)* %468, align 8
+  %470 = fmul double %465, %469
+  store double %470, double* %loc17
   %471 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
-  %472 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %471, i32 0, i32 2
-  %473 = load double, double addrspace(1)* %472, align 8
-  %474 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (double, double)*)(double 6.000000e+00, double %473)
-  %475 = zext i8 %474 to i32
-  %476 = icmp ne i32 %475, 0
-  br i1 %476, label %478, label %477
+  %NullCheck168 = icmp ne %PointDbl addrspace(1)* %471, null
+  br i1 %NullCheck168, label %472, label %ThrowNullRef167
 
-; <label>:477                                     ; preds = %470
+; <label>:472                                     ; preds = %467
+  %473 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %471, i32 0, i32 2
+  %474 = load double, double addrspace(1)* %473, align 8
+  store double %474, double* %loc18
+  %475 = load double, double* %loc16
+  %476 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
+  %NullCheck170 = icmp ne %PointDbl addrspace(1)* %476, null
+  br i1 %NullCheck170, label %477, label %ThrowNullRef169
+
+; <label>:477                                     ; preds = %472
+  %478 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %476, i32 0, i32 0
+  %479 = load double, double addrspace(1)* %478, align 8
+  %480 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (double, double)*)(double %475, double %479)
+  %481 = zext i8 %480 to i32
+  %482 = icmp eq i32 %481, 0
+  br i1 %482, label %491, label %483
+
+; <label>:483                                     ; preds = %477
+  %484 = load double, double* %loc17
+  %485 = addrspacecast %PointDbl* %loc14 to %PointDbl addrspace(1)*
+  %NullCheck172 = icmp ne %PointDbl addrspace(1)* %485, null
+  br i1 %NullCheck172, label %486, label %ThrowNullRef171
+
+; <label>:486                                     ; preds = %483
+  %487 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %485, i32 0, i32 1
+  %488 = load double, double addrspace(1)* %487, align 8
+  %489 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (double, double)*)(double %484, double %488)
+  %490 = zext i8 %489 to i32
+  br label %492
+
+; <label>:491                                     ; preds = %477
+  br label %492
+
+; <label>:492                                     ; preds = %486, %491
+  %493 = phi i32 [ %490, %486 ], [ 0, %491 ]
+  %494 = trunc i32 %493 to i8
+  store i8 %494, i8* %loc3
+  %495 = load i8, i8* %loc3
+  %496 = zext i8 %495 to i32
+  %497 = icmp ne i32 %496, 0
+  br i1 %497, label %499, label %498
+
+; <label>:498                                     ; preds = %492
   ret i32 -1
 
-; <label>:478                                     ; preds = %470
+; <label>:499                                     ; preds = %492
+  %500 = load double, double* %loc16
+  %501 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
+  %NullCheck174 = icmp ne %PointDbl addrspace(1)* %501, null
+  br i1 %NullCheck174, label %502, label %ThrowNullRef173
+
+; <label>:502                                     ; preds = %499
+  %503 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %501, i32 0, i32 0
+  %504 = load double, double addrspace(1)* %503, align 8
+  %505 = fadd double %500, %504
+  store double %505, double* %loc16
+  %506 = load double, double* %loc16
+  %507 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (double, double)*)(double 2.000000e+01, double %506)
+  %508 = zext i8 %507 to i32
+  %509 = icmp ne i32 %508, 0
+  br i1 %509, label %511, label %510
+
+; <label>:510                                     ; preds = %502
+  ret i32 -1
+
+; <label>:511                                     ; preds = %502
+  %512 = load double, double* %loc17
+  %513 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
+  %NullCheck176 = icmp ne %PointDbl addrspace(1)* %513, null
+  br i1 %NullCheck176, label %514, label %ThrowNullRef175
+
+; <label>:514                                     ; preds = %511
+  %515 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %513, i32 0, i32 1
+  %516 = load double, double addrspace(1)* %515, align 8
+  %517 = fmul double %512, %516
+  store double %517, double* %loc17
+  %518 = load double, double* %loc17
+  %519 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (double, double)*)(double 0.000000e+00, double %518)
+  %520 = zext i8 %519 to i32
+  %521 = icmp ne i32 %520, 0
+  br i1 %521, label %523, label %522
+
+; <label>:522                                     ; preds = %514
+  ret i32 -1
+
+; <label>:523                                     ; preds = %514
+  %524 = load double, double* %loc18
+  %525 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
+  %NullCheck178 = icmp ne %PointDbl addrspace(1)* %525, null
+  br i1 %NullCheck178, label %526, label %ThrowNullRef177
+
+; <label>:526                                     ; preds = %523
+  %527 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %525, i32 0, i32 0
+  %528 = load double, double addrspace(1)* %527, align 8
+  %529 = fdiv double %524, %528
+  store double %529, double* %loc18
+  %530 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
+  %NullCheck180 = icmp ne %PointDbl addrspace(1)* %530, null
+  br i1 %NullCheck180, label %531, label %ThrowNullRef179
+
+; <label>:531                                     ; preds = %526
+  %532 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %530, i32 0, i32 0
+  %533 = load double, double addrspace(1)* %532, align 8
+  %534 = fadd double %533, 1.000000e+01
+  %NullCheck182 = icmp ne %PointDbl addrspace(1)* %530, null
+  br i1 %NullCheck182, label %535, label %ThrowNullRef181
+
+; <label>:535                                     ; preds = %531
+  %536 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %530, i32 0, i32 0
+  store double %534, double addrspace(1)* %536
+  %537 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
+  %NullCheck184 = icmp ne %PointDbl addrspace(1)* %537, null
+  br i1 %NullCheck184, label %538, label %ThrowNullRef183
+
+; <label>:538                                     ; preds = %535
+  %539 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %537, i32 0, i32 1
+  %540 = load double, double addrspace(1)* %539, align 8
+  %541 = fmul double %540, 3.000000e+00
+  %NullCheck186 = icmp ne %PointDbl addrspace(1)* %537, null
+  br i1 %NullCheck186, label %542, label %ThrowNullRef185
+
+; <label>:542                                     ; preds = %538
+  %543 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %537, i32 0, i32 1
+  store double %541, double addrspace(1)* %543
+  %544 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
+  %NullCheck188 = icmp ne %PointDbl addrspace(1)* %544, null
+  br i1 %NullCheck188, label %545, label %ThrowNullRef187
+
+; <label>:545                                     ; preds = %542
+  %546 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %544, i32 0, i32 2
+  %547 = load double, double addrspace(1)* %546, align 8
+  %548 = fdiv double %547, 5.000000e+00
+  %NullCheck190 = icmp ne %PointDbl addrspace(1)* %544, null
+  br i1 %NullCheck190, label %549, label %ThrowNullRef189
+
+; <label>:549                                     ; preds = %545
+  %550 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %544, i32 0, i32 2
+  store double %548, double addrspace(1)* %550
+  %551 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
+  %NullCheck192 = icmp ne %PointDbl addrspace(1)* %551, null
+  br i1 %NullCheck192, label %552, label %ThrowNullRef191
+
+; <label>:552                                     ; preds = %549
+  %553 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %551, i32 0, i32 0
+  %554 = load double, double addrspace(1)* %553, align 8
+  %555 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (double, double)*)(double 2.000000e+01, double %554)
+  %556 = zext i8 %555 to i32
+  %557 = icmp ne i32 %556, 0
+  br i1 %557, label %559, label %558
+
+; <label>:558                                     ; preds = %552
+  ret i32 -1
+
+; <label>:559                                     ; preds = %552
+  %560 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
+  %NullCheck194 = icmp ne %PointDbl addrspace(1)* %560, null
+  br i1 %NullCheck194, label %561, label %ThrowNullRef193
+
+; <label>:561                                     ; preds = %559
+  %562 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %560, i32 0, i32 1
+  %563 = load double, double addrspace(1)* %562, align 8
+  %564 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (double, double)*)(double 6.000000e+01, double %563)
+  %565 = zext i8 %564 to i32
+  %566 = icmp ne i32 %565, 0
+  br i1 %566, label %568, label %567
+
+; <label>:567                                     ; preds = %561
+  ret i32 -1
+
+; <label>:568                                     ; preds = %561
+  %569 = addrspacecast %PointDbl* %loc13 to %PointDbl addrspace(1)*
+  %NullCheck196 = icmp ne %PointDbl addrspace(1)* %569, null
+  br i1 %NullCheck196, label %570, label %ThrowNullRef195
+
+; <label>:570                                     ; preds = %568
+  %571 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %569, i32 0, i32 2
+  %572 = load double, double addrspace(1)* %571, align 8
+  %573 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (double, double)*)(double 6.000000e+00, double %572)
+  %574 = zext i8 %573 to i32
+  %575 = icmp ne i32 %574, 0
+  br i1 %575, label %577, label %576
+
+; <label>:576                                     ; preds = %570
+  ret i32 -1
+
+; <label>:577                                     ; preds = %570
   ret i32 100
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %97
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %133
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %141
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %174
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %181
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %184
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %187
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %198
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %206
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %210
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %214
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %218
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %222
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %231
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %239
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %254
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %260
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %269
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %274
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %285
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %301
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %313
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %325
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %328
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %333
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %337
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %340
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %344
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %347
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %351
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %361
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %370
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %379
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %382
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %385
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %388
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %392
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %396
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %400
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %404
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %408
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %412
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %416
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %420
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %429
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %437
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %452
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %454
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %458
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %463
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %467
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %472
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef171:                                  ; preds = %483
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef173:                                  ; preds = %499
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef175:                                  ; preds = %511
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef177:                                  ; preds = %523
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef179:                                  ; preds = %526
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef181:                                  ; preds = %531
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef183:                                  ; preds = %535
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef185:                                  ; preds = %538
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef187:                                  ; preds = %542
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef189:                                  ; preds = %545
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef191:                                  ; preds = %549
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef193:                                  ; preds = %559
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef195:                                  ; preds = %568
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Point::.ctor using LLILCJit
@@ -7573,17 +11653,41 @@ entry:
   store i32 %param3, i32* %arg3
   %0 = load %Point addrspace(1)*, %Point addrspace(1)** %this
   %1 = load i32, i32* %arg1
-  %2 = getelementptr inbounds %Point, %Point addrspace(1)* %0, i32 0, i32 0
-  store i32 %1, i32 addrspace(1)* %2
-  %3 = load %Point addrspace(1)*, %Point addrspace(1)** %this
-  %4 = load i32, i32* %arg2
-  %5 = getelementptr inbounds %Point, %Point addrspace(1)* %3, i32 0, i32 1
-  store i32 %4, i32 addrspace(1)* %5
-  %6 = load %Point addrspace(1)*, %Point addrspace(1)** %this
-  %7 = load i32, i32* %arg3
-  %8 = getelementptr inbounds %Point, %Point addrspace(1)* %6, i32 0, i32 2
-  store i32 %7, i32 addrspace(1)* %8
+  %NullCheck = icmp ne %Point addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %Point, %Point addrspace(1)* %0, i32 0, i32 0
+  store i32 %1, i32 addrspace(1)* %3
+  %4 = load %Point addrspace(1)*, %Point addrspace(1)** %this
+  %5 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %Point addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %Point, %Point addrspace(1)* %4, i32 0, i32 1
+  store i32 %5, i32 addrspace(1)* %7
+  %8 = load %Point addrspace(1)*, %Point addrspace(1)** %this
+  %9 = load i32, i32* %arg3
+  %NullCheck4 = icmp ne %Point addrspace(1)* %8, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %Point, %Point addrspace(1)* %8, i32 0, i32 2
+  store i32 %9, i32 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PointFlt::.ctor using LLILCJit
@@ -7601,17 +11705,41 @@ entry:
   store float %param3, float* %arg3
   %0 = load %PointFlt addrspace(1)*, %PointFlt addrspace(1)** %this
   %1 = load float, float* %arg1
-  %2 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %0, i32 0, i32 0
-  store float %1, float addrspace(1)* %2
-  %3 = load %PointFlt addrspace(1)*, %PointFlt addrspace(1)** %this
-  %4 = load float, float* %arg2
-  %5 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %3, i32 0, i32 1
-  store float %4, float addrspace(1)* %5
-  %6 = load %PointFlt addrspace(1)*, %PointFlt addrspace(1)** %this
-  %7 = load float, float* %arg3
-  %8 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %6, i32 0, i32 2
-  store float %7, float addrspace(1)* %8
+  %NullCheck = icmp ne %PointFlt addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %0, i32 0, i32 0
+  store float %1, float addrspace(1)* %3
+  %4 = load %PointFlt addrspace(1)*, %PointFlt addrspace(1)** %this
+  %5 = load float, float* %arg2
+  %NullCheck2 = icmp ne %PointFlt addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %4, i32 0, i32 1
+  store float %5, float addrspace(1)* %7
+  %8 = load %PointFlt addrspace(1)*, %PointFlt addrspace(1)** %this
+  %9 = load float, float* %arg3
+  %NullCheck4 = icmp ne %PointFlt addrspace(1)* %8, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %PointFlt, %PointFlt addrspace(1)* %8, i32 0, i32 2
+  store float %9, float addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method BringUpTest::equals using LLILCJit
@@ -7631,17 +11759,41 @@ entry:
   store double %param3, double* %arg3
   %0 = load %PointDbl addrspace(1)*, %PointDbl addrspace(1)** %this
   %1 = load double, double* %arg1
-  %2 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %0, i32 0, i32 0
-  store double %1, double addrspace(1)* %2
-  %3 = load %PointDbl addrspace(1)*, %PointDbl addrspace(1)** %this
-  %4 = load double, double* %arg2
-  %5 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %3, i32 0, i32 1
-  store double %4, double addrspace(1)* %5
-  %6 = load %PointDbl addrspace(1)*, %PointDbl addrspace(1)** %this
-  %7 = load double, double* %arg3
-  %8 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %6, i32 0, i32 2
-  store double %7, double addrspace(1)* %8
+  %NullCheck = icmp ne %PointDbl addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %0, i32 0, i32 0
+  store double %1, double addrspace(1)* %3
+  %4 = load %PointDbl addrspace(1)*, %PointDbl addrspace(1)** %this
+  %5 = load double, double* %arg2
+  %NullCheck2 = icmp ne %PointDbl addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %4, i32 0, i32 1
+  store double %5, double addrspace(1)* %7
+  %8 = load %PointDbl addrspace(1)*, %PointDbl addrspace(1)** %this
+  %9 = load double, double* %arg3
+  %NullCheck4 = icmp ne %PointDbl addrspace(1)* %8, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %PointDbl, %PointDbl addrspace(1)* %8, i32 0, i32 2
+  store double %9, double addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method BringUpTest::equals using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Or1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Or1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/OrRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/OrRef.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6896,11 +10184,19 @@ entry:
   store i32 addrspace(1)* %param1, i32 addrspace(1)** %arg1
   %0 = load i32, i32* %arg0
   %1 = load i32 addrspace(1)*, i32 addrspace(1)** %arg1
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = or i32 %0, %2
-  store i32 %3, i32* %arg0
-  %4 = load i32, i32* %arg0
-  ret i32 %4
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  %4 = or i32 %0, %3
+  store i32 %4, i32* %arg0
+  %5 = load i32, i32* %arg0
+  ret i32 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/RightShiftRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/RightShiftRef.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6893,12 +10181,28 @@ entry:
   store i32 addrspace(1)* %param0, i32 addrspace(1)** %arg0
   store i32 %param1, i32* %arg1
   %0 = load i32 addrspace(1)*, i32 addrspace(1)** %arg0
-  %1 = load i32, i32 addrspace(1)* %0, align 8
-  %2 = load i32, i32* %arg1
-  %3 = and i32 %2, 31
-  %4 = ashr i32 %1, %3
-  store i32 %4, i32 addrspace(1)* %0, align 8
+  %NullCheck = icmp ne i32 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = load i32, i32 addrspace(1)* %0, align 8
+  %3 = load i32, i32* %arg1
+  %4 = and i32 %3, 31
+  %5 = ashr i32 %2, %4
+  %NullCheck2 = icmp ne i32 addrspace(1)* %0, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  store i32 %5, i32 addrspace(1)* %0, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StaticCalls.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StaticCalls.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7464,16 +10752,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i32, i32* %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 96
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 16
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 16
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7591,19 +10887,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7635,9 +10947,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7681,17 +11001,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7712,17 +11048,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7759,11 +11111,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7779,7 +11139,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7787,27 +11147,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7923,31 +11291,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7960,40 +11360,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8007,8 +11431,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -8076,38 +11508,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -8120,39 +11584,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -8163,39 +11651,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -8223,29 +11751,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -8310,9 +11854,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -8339,16 +11891,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -8365,12 +11933,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -8396,19 +11980,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -8474,51 +12082,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -8531,11 +12147,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -8555,116 +12179,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8675,19 +12427,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8735,34 +12503,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8788,9 +12588,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8801,32 +12609,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8839,20 +12679,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8887,59 +12743,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8950,11 +12822,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8982,20 +12870,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -9007,36 +12903,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9055,177 +12959,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -9290,27 +13362,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -9321,28 +13417,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9539,44 +13651,68 @@ entry:
   store i32 %param1, i32* %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load i32, i32* %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 96
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 16
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load i32, i32* %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 96
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, i32)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, i32 %8)
-  br label %18
+  %17 = add i64 %16, 16
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, i32 %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9591,27 +13727,43 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i32, i32* %arg1
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 80
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 0
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
-  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
-  %13 = load i64, i64 addrspace(1)* %12
-  %14 = add i64 %13, 88
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
-  %17 = add i64 %16, 40
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
-  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 80
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 0
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %3
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 88
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 40
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::Write using LLILCJit
@@ -9627,28 +13779,44 @@ entry:
   %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 32
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
-  %13 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
-  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int32 addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
-  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 80
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 56
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 32
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
+  %14 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int32 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %4
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 80
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 56
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Int32::ToString using LLILCJit
@@ -9662,11 +13830,19 @@ entry:
   store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
-  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  %4 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %5 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %4)
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
@@ -9680,37 +13856,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -9728,215 +13952,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -9962,25 +14594,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -9994,11 +14650,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -10054,25 +14718,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -10083,24 +14771,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -10127,13 +14839,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -10144,24 +14864,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -10172,24 +14916,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -10200,24 +14968,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -10228,24 +15020,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -10256,24 +15072,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -10284,24 +15124,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10318,106 +15182,186 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %64, label %2
+  br i1 %1, label %74, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
   %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
-  %6 = load i32, i32 addrspace(1)* %5
-  store i32 %6, i32* %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %2
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  store i32 %7, i32* %loc0
   store i32 0, i32* %loc1
-  br label %53
+  br label %62
 
-; <label>:7                                       ; preds = %53
-  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = icmp ne i32 %10, %13
-  br i1 %14, label %17, label %15
+; <label>:8                                       ; preds = %62
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
-  br label %17
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 9
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %7, %15
-  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
-  %20 = load i32, i32 addrspace(1)* %19, align 8
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %13, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %12, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %14
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %14, %18
   %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
-  %23 = load i32, i32 addrspace(1)* %22, align 8
-  %24 = sub i32 %20, %23
-  store i32 %24, i32* %loc2
-  %25 = load i32, i32* %loc2
-  %26 = load i32, i32* %loc0
-  %27 = icmp sle i32 %25, %26
-  br i1 %27, label %30, label %28
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %21, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
 
-; <label>:28                                      ; preds = %17
-  %29 = load i32, i32* %loc0
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %24 = load i32, i32 addrspace(1)* %23, align 8
+  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 9
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = sub i32 %24, %28
   store i32 %29, i32* %loc2
-  br label %30
+  %30 = load i32, i32* %loc2
+  %31 = load i32, i32* %loc0
+  %32 = icmp sle i32 %30, %31
+  br i1 %32, label %35, label %33
 
-; <label>:30                                      ; preds = %17, %28
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load i32, i32* %loc1
-  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
-  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
-  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = load i32, i32* %loc2
-  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:33                                      ; preds = %26
+  %34 = load i32, i32* %loc0
+  store i32 %34, i32* %loc2
+  br label %35
 
-; <label>:40                                      ; preds = %30
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
-  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  %43 = load i32, i32 addrspace(1)* %42, align 8
-  %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
-  store i32 %45, i32 addrspace(1)* %46
-  %47 = load i32, i32* %loc1
-  %48 = load i32, i32* %loc2
-  %49 = add i32 %47, %48
-  store i32 %49, i32* %loc1
-  %50 = load i32, i32* %loc0
-  %51 = load i32, i32* %loc2
-  %52 = sub i32 %50, %51
-  store i32 %52, i32* %loc0
-  br label %53
+; <label>:35                                      ; preds = %26, %33
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %37 = load i32, i32* %loc1
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:53                                      ; preds = %2, %40
-  %54 = load i32, i32* %loc0
-  %55 = icmp sgt i32 %54, 0
-  br i1 %55, label %7, label %56
+; <label>:39                                      ; preds = %35
+  %40 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %38, i32 0, i32 7
+  %41 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %40, align 8
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:56                                      ; preds = %53
-  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
-  %59 = load i8, i8 addrspace(1)* %58, align 8
-  %60 = zext i8 %59 to i32
-  %61 = icmp eq i32 %60, 0
-  br i1 %61, label %64, label %62
+; <label>:43                                      ; preds = %39
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 9
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = load i32, i32* %loc2
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %36, null
+  br i1 %NullCheck16, label %47, label %ThrowNullRef15
 
-; <label>:62                                      ; preds = %56
-  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
-  br label %64
+; <label>:47                                      ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %36, i32 %37, %"System.Char[]" addrspace(1)* %41, i32 %45, i32 %46)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:64                                      ; preds = %entry, %56, %62
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %51 = load i32, i32 addrspace(1)* %50, align 8
+  %52 = load i32, i32* %loc2
+  %53 = add i32 %51, %52
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %48, null
+  br i1 %NullCheck20, label %54, label %ThrowNullRef19
+
+; <label>:54                                      ; preds = %49
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %53, i32 addrspace(1)* %55
+  %56 = load i32, i32* %loc1
+  %57 = load i32, i32* %loc2
+  %58 = add i32 %56, %57
+  store i32 %58, i32* %loc1
+  %59 = load i32, i32* %loc0
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %5, %54
+  %63 = load i32, i32* %loc0
+  %64 = icmp sgt i32 %63, 0
+  br i1 %64, label %8, label %65
+
+; <label>:65                                      ; preds = %62
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %66, null
+  br i1 %NullCheck2, label %67, label %ThrowNullRef1
+
+; <label>:67                                      ; preds = %65
+  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 11
+  %69 = load i8, i8 addrspace(1)* %68, align 8
+  %70 = zext i8 %69 to i32
+  %71 = icmp eq i32 %70, 0
+  br i1 %71, label %74, label %72
+
+; <label>:72                                      ; preds = %67
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %73, i8 1, i8 0)
+  br label %74
+
+; <label>:74                                      ; preds = %entry, %67, %72
   ret void
 
-ThrowNullRef:                                     ; preds = %30
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -10549,30 +15493,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10598,25 +15574,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10676,38 +15660,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10720,23 +15720,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10748,27 +15756,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -10780,19 +15796,35 @@ entry:
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
-  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 40
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
-  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 72
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 40
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
@@ -10819,100 +15851,180 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
   store i32 0, i32* %loc0
   %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = zext i32 %7 to i64
-  %9 = trunc i64 %8 to i32
-  store i32 %9, i32* %loc1
-  br label %60
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %60
-  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
-  %13 = load i32, i32 addrspace(1)* %12, align 8
-  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = icmp ne i32 %13, %16
-  br i1 %17, label %20, label %18
+; <label>:6                                       ; preds = %3
+  %7 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = zext i32 %8 to i64
+  %10 = trunc i64 %9 to i32
+  store i32 %10, i32* %loc1
+  br label %69
 
-; <label>:18                                      ; preds = %10
-  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
-  br label %20
+; <label>:11                                      ; preds = %69
+  %12 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:20                                      ; preds = %10, %18
-  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
-  %23 = load i32, i32 addrspace(1)* %22, align 8
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %12, i32 0, i32 9
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %16, i32 0, i32 10
+  %19 = load i32, i32 addrspace(1)* %18, align 8
+  %20 = icmp ne i32 %15, %19
+  br i1 %20, label %23, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %22, i8 0, i8 0)
+  br label %23
+
+; <label>:23                                      ; preds = %17, %21
   %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
-  %26 = load i32, i32 addrspace(1)* %25, align 8
-  %27 = sub i32 %23, %26
-  store i32 %27, i32* %loc2
-  %28 = load i32, i32* %loc2
-  %29 = load i32, i32* %loc1
-  %30 = icmp sle i32 %28, %29
-  br i1 %30, label %33, label %31
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %24, null
+  br i1 %NullCheck8, label %25, label %ThrowNullRef7
 
-; <label>:31                                      ; preds = %20
-  %32 = load i32, i32* %loc1
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 10
+  %27 = load i32, i32 addrspace(1)* %26, align 8
+  %28 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %28, null
+  br i1 %NullCheck10, label %29, label %ThrowNullRef9
+
+; <label>:29                                      ; preds = %25
+  %30 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %28, i32 0, i32 9
+  %31 = load i32, i32 addrspace(1)* %30, align 8
+  %32 = sub i32 %27, %31
   store i32 %32, i32* %loc2
-  br label %33
+  %33 = load i32, i32* %loc2
+  %34 = load i32, i32* %loc1
+  %35 = icmp sle i32 %33, %34
+  br i1 %35, label %38, label %36
 
-; <label>:33                                      ; preds = %20, %31
-  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %35 = load i32, i32* %loc0
-  %36 = mul i32 %35, 2
-  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
-  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = mul i32 %42, 2
-  %44 = load i32, i32* %loc2
-  %45 = mul i32 %44, 2
-  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
-  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  %50 = load i32, i32 addrspace(1)* %49, align 8
+; <label>:36                                      ; preds = %29
+  %37 = load i32, i32* %loc1
+  store i32 %37, i32* %loc2
+  br label %38
+
+; <label>:38                                      ; preds = %29, %36
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %40 = load i32, i32* %loc0
+  %41 = mul i32 %40, 2
+  %42 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %42, null
+  br i1 %NullCheck12, label %43, label %ThrowNullRef11
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %42, i32 0, i32 7
+  %45 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %44, align 8
+  %46 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %46, null
+  br i1 %NullCheck14, label %47, label %ThrowNullRef13
+
+; <label>:47                                      ; preds = %43
+  %48 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %46, i32 0, i32 9
+  %49 = load i32, i32 addrspace(1)* %48, align 8
+  %50 = mul i32 %49, 2
   %51 = load i32, i32* %loc2
-  %52 = add i32 %50, %51
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
-  store i32 %52, i32 addrspace(1)* %53
-  %54 = load i32, i32* %loc0
-  %55 = load i32, i32* %loc2
-  %56 = add i32 %54, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc1
-  %58 = load i32, i32* %loc2
-  %59 = sub i32 %57, %58
-  store i32 %59, i32* %loc1
-  br label %60
+  %52 = mul i32 %51, 2
+  %53 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  %54 = bitcast %"System.Char[]" addrspace(1)* %45 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %53, i32 %41, %System.Array addrspace(1)* %54, i32 %50, i32 %52)
+  %55 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck16, label %56, label %ThrowNullRef15
 
-; <label>:60                                      ; preds = %3, %33
-  %61 = load i32, i32* %loc1
-  %62 = icmp sgt i32 %61, 0
-  br i1 %62, label %10, label %63
+; <label>:56                                      ; preds = %47
+  %57 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  %58 = load i32, i32 addrspace(1)* %57, align 8
+  %59 = load i32, i32* %loc2
+  %60 = add i32 %58, %59
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %55, null
+  br i1 %NullCheck18, label %61, label %ThrowNullRef17
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
-  %66 = load i8, i8 addrspace(1)* %65, align 8
-  %67 = zext i8 %66 to i32
-  %68 = icmp eq i32 %67, 0
-  br i1 %68, label %71, label %69
+; <label>:61                                      ; preds = %56
+  %62 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %55, i32 0, i32 9
+  store i32 %60, i32 addrspace(1)* %62
+  %63 = load i32, i32* %loc0
+  %64 = load i32, i32* %loc2
+  %65 = add i32 %63, %64
+  store i32 %65, i32* %loc0
+  %66 = load i32, i32* %loc1
+  %67 = load i32, i32* %loc2
+  %68 = sub i32 %66, %67
+  store i32 %68, i32* %loc1
+  br label %69
 
-; <label>:69                                      ; preds = %63
-  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
-  br label %71
+; <label>:69                                      ; preds = %6, %61
+  %70 = load i32, i32* %loc1
+  %71 = icmp sgt i32 %70, 0
+  br i1 %71, label %11, label %72
 
-; <label>:71                                      ; preds = %63, %69
+; <label>:72                                      ; preds = %69
+  %73 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %73, null
+  br i1 %NullCheck2, label %74, label %ThrowNullRef1
+
+; <label>:74                                      ; preds = %72
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %73, i32 0, i32 11
+  %76 = load i8, i8 addrspace(1)* %75, align 8
+  %77 = zext i8 %76 to i32
+  %78 = icmp eq i32 %77, 0
+  br i1 %78, label %81, label %79
+
+; <label>:79                                      ; preds = %74
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %80, i8 1, i8 0)
+  br label %81
+
+; <label>:81                                      ; preds = %74, %79
   ret void
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StructFldAddr.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StructFldAddr.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StructInstMethod.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StructInstMethod.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6880,17 +10168,41 @@ entry:
   store i32 %param3, i32* %arg3
   %0 = load %Point addrspace(1)*, %Point addrspace(1)** %this
   %1 = load i32, i32* %arg1
-  %2 = getelementptr inbounds %Point, %Point addrspace(1)* %0, i32 0, i32 0
-  store i32 %1, i32 addrspace(1)* %2
-  %3 = load %Point addrspace(1)*, %Point addrspace(1)** %this
-  %4 = load i32, i32* %arg2
-  %5 = getelementptr inbounds %Point, %Point addrspace(1)* %3, i32 0, i32 1
-  store i32 %4, i32 addrspace(1)* %5
-  %6 = load %Point addrspace(1)*, %Point addrspace(1)** %this
-  %7 = load i32, i32* %arg3
-  %8 = getelementptr inbounds %Point, %Point addrspace(1)* %6, i32 0, i32 2
-  store i32 %7, i32 addrspace(1)* %8
+  %NullCheck = icmp ne %Point addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %Point, %Point addrspace(1)* %0, i32 0, i32 0
+  store i32 %1, i32 addrspace(1)* %3
+  %4 = load %Point addrspace(1)*, %Point addrspace(1)** %this
+  %5 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %Point addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %Point, %Point addrspace(1)* %4, i32 0, i32 1
+  store i32 %5, i32 addrspace(1)* %7
+  %8 = load %Point addrspace(1)*, %Point addrspace(1)** %this
+  %9 = load i32, i32* %arg3
+  %NullCheck4 = icmp ne %Point addrspace(1)* %8, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %Point, %Point addrspace(1)* %8, i32 0, i32 2
+  store i32 %9, i32 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Point::StructInstMethod using LLILCJit
@@ -6901,29 +10213,53 @@ entry:
   %this = alloca %Point addrspace(1)*
   store %Point addrspace(1)* %param0, %Point addrspace(1)** %this
   %0 = load %Point addrspace(1)*, %Point addrspace(1)** %this
-  %1 = getelementptr inbounds %Point, %Point addrspace(1)* %0, i32 0, i32 0
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, 0
-  br i1 %3, label %16, label %4
+  %NullCheck = icmp ne %Point addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %Point addrspace(1)*, %Point addrspace(1)** %this
-  %6 = getelementptr inbounds %Point, %Point addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %16, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %Point, %Point addrspace(1)* %0, i32 0, i32 0
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %19, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %Point addrspace(1)*, %Point addrspace(1)** %this
-  %11 = getelementptr inbounds %Point, %Point addrspace(1)* %10, i32 0, i32 2
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  %13 = icmp eq i32 %12, 0
-  %14 = sext i1 %13 to i32
-  %15 = trunc i32 %14 to i8
-  ret i8 %15
+; <label>:5                                       ; preds = %1
+  %6 = load %Point addrspace(1)*, %Point addrspace(1)** %this
+  %NullCheck2 = icmp ne %Point addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %entry, %4
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %Point, %Point addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8, align 8
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %19, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %Point addrspace(1)*, %Point addrspace(1)** %this
+  %NullCheck4 = icmp ne %Point addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %Point, %Point addrspace(1)* %12, i32 0, i32 2
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  %16 = icmp eq i32 %15, 0
+  %17 = sext i1 %16 to i32
+  %18 = trunc i32 %17 to i8
+  ret i8 %18
+
+; <label>:19                                      ; preds = %1, %7
   ret i8 0
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Point::StructInstMethod using LLILCJit
@@ -6941,10 +10277,18 @@ entry:
   store i32 %1, i32* %loc0
   %2 = load i32, i32* %loc0
   %3 = load %Point addrspace(1)*, %Point addrspace(1)** %arg1
-  %4 = getelementptr inbounds %Point, %Point addrspace(1)* %3, i32 0, i32 0
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %Point addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %Point, %Point addrspace(1)* %3, i32 0, i32 0
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = add i32 %2, %6
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Point::get_X using LLILCJit
@@ -6955,9 +10299,17 @@ entry:
   %this = alloca %Point addrspace(1)*
   store %Point addrspace(1)* %param0, %Point addrspace(1)** %this
   %0 = load %Point addrspace(1)*, %Point addrspace(1)** %this
-  %1 = getelementptr inbounds %Point, %Point addrspace(1)* %0, i32 0, i32 0
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %Point addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %Point, %Point addrspace(1)* %0, i32 0, i32 0
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method BringUpTest::StructInstMethod using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Sub1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Sub1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/SubRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/SubRef.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6896,11 +10184,19 @@ entry:
   store i32 addrspace(1)* %param1, i32 addrspace(1)** %arg1
   %0 = load i32, i32* %arg0
   %1 = load i32 addrspace(1)*, i32 addrspace(1)** %arg1
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = sub i32 %0, %2
-  store i32 %3, i32* %arg0
-  %4 = load i32, i32* %arg0
-  ret i32 %4
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  %4 = sub i32 %0, %3
+  store i32 %4, i32* %arg0
+  %5 = load i32, i32* %arg0
+  ret i32 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Swap.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Swap.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6887,10 +10175,18 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* ()*)()
-  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %3)
-  ret %System.String addrspace(1)* %4
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* ()*)()
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %3, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::get_CurrentInfo using LLILCJit
@@ -7083,37 +10379,85 @@ entry:
   %loc0 = alloca %System.Globalization.NumberFormatInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %2, null
-  br i1 %3, label %19, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 6
-  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %6, align 8
-  %8 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.CultureData addrspace(1)* %7)
-  store %System.Globalization.NumberFormatInfo addrspace(1)* %8, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %9 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %10, i32 0, i32 11
-  %12 = load i8, i8 addrspace(1)* %11, align 8
-  %13 = zext i8 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %9, i32 0, i32 29
-  store i8 %14, i8 addrspace(1)* %15
-  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %17 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
-  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %18, %System.Globalization.NumberFormatInfo addrspace(1)* %17)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %3, null
+  br i1 %4, label %24, label %5
 
-; <label>:19                                      ; preds = %entry, %4
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %8, align 8
+  %10 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.CultureData addrspace(1)* %9)
+  store %System.Globalization.NumberFormatInfo addrspace(1)* %10, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %7
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  %15 = load i8, i8 addrspace(1)* %14, align 8
+  %16 = zext i8 %15 to i32
+  %17 = trunc i32 %16 to i8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %11, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %13
+  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %11, i32 0, i32 29
+  store i8 %17, i8 addrspace(1)* %19
   %20 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %21 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
-  %22 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %21, align 8
-  ret %System.Globalization.NumberFormatInfo addrspace(1)* %22
+  %21 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %20, null
+  br i1 %NullCheck8, label %22, label %ThrowNullRef7
+
+; <label>:22                                      ; preds = %18
+  %23 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %20, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(%System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %23, %System.Globalization.NumberFormatInfo addrspace(1)* %21)
+  br label %24
+
+; <label>:24                                      ; preds = %1, %22
+  %25 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %25, null
+  br i1 %NullCheck10, label %26, label %ThrowNullRef9
+
+; <label>:26                                      ; preds = %24
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %25, i32 0, i32 3
+  %28 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)* addrspace(1)* %27, align 8
+  ret %System.Globalization.NumberFormatInfo addrspace(1)* %28
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NumberFormatInfo::.ctor using LLILCJit
@@ -7131,215 +10475,623 @@ entry:
   %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
   %2 = zext i8 %1 to i32
   %3 = icmp eq i32 %2, 0
-  br i1 %3, label %65, label %4
+  br i1 %3, label %89, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %8)
-  %10 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 19
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %12, align 8
-  %14 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %10, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %13)
-  %15 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %16, i32 0, i32 23
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
-  %19 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %15, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  %20 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 22
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 18
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %8, align 8
+  %NullCheck2 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %5, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %5, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %9)
+  %12 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 19
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %15, align 8
+  %NullCheck6 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %12, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %12, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %16)
+  %19 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %20 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %20, null
+  br i1 %NullCheck8, label %21, label %ThrowNullRef7
+
+; <label>:21                                      ; preds = %17
+  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %20, i32 0, i32 23
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  %24 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %20, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %23)
-  %25 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %26 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %26, i32 0, i32 51
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %25, i32 0, i32 21
-  store i32 %28, i32 addrspace(1)* %29
-  %30 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %31 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %31, i32 0, i32 52
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %30, i32 0, i32 25
-  store i32 %33, i32 addrspace(1)* %34
-  %35 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %36 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %37 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %36, i32 0, i32 29
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %37, align 8
-  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %35, i32 0, i32 10
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %39, %System.String addrspace(1)* %38)
+  %NullCheck10 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %19, null
+  br i1 %NullCheck10, label %24, label %ThrowNullRef9
+
+; <label>:24                                      ; preds = %21
+  %25 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %19, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %25, %System.String addrspace(1)* %23)
+  %26 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %27 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %27, i32 0, i32 22
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %29, align 8
+  %NullCheck14 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %26, null
+  br i1 %NullCheck14, label %31, label %ThrowNullRef13
+
+; <label>:31                                      ; preds = %28
+  %32 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %26, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %32, %System.String addrspace(1)* %30)
+  %33 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %34 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.Globalization.CultureData addrspace(1)* %34, null
+  br i1 %NullCheck16, label %35, label %ThrowNullRef15
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %34, i32 0, i32 51
+  %37 = load i32, i32 addrspace(1)* %36, align 8
+  %NullCheck18 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %33, null
+  br i1 %NullCheck18, label %38, label %ThrowNullRef17
+
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %33, i32 0, i32 21
+  store i32 %37, i32 addrspace(1)* %39
   %40 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %41 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 35
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %42, align 8
-  %44 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %44, %System.String addrspace(1)* %43)
-  %45 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %46 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %46, i32 0, i32 34
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %47, align 8
-  %49 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %45, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %49, %System.String addrspace(1)* %48)
-  %50 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %51 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %52 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %51, i32 0, i32 55
-  %53 = load i32, i32 addrspace(1)* %52, align 8
-  %54 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %50, i32 0, i32 22
-  store i32 %53, i32 addrspace(1)* %54
-  %55 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %56 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %56, i32 0, i32 57
-  %58 = load i32, i32 addrspace(1)* %57, align 8
-  %59 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %55, i32 0, i32 24
-  store i32 %58, i32 addrspace(1)* %59
-  %60 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %61 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %62 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %61, i32 0, i32 56
-  %63 = load i32, i32 addrspace(1)* %62, align 8
-  %64 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %60, i32 0, i32 23
-  store i32 %63, i32 addrspace(1)* %64
-  br label %76
+  %NullCheck20 = icmp ne %System.Globalization.CultureData addrspace(1)* %41, null
+  br i1 %NullCheck20, label %42, label %ThrowNullRef19
 
-; <label>:65                                      ; preds = %entry
-  %66 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %67 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %66, i32 0, i32 2
-  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %70 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %71 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %70)
-  %72 = zext i8 %71 to i32
-  %73 = trunc i32 %72 to i8
-  %74 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %68, %System.Globalization.NumberFormatInfo addrspace(1)* %69, i8 %73)
-  %75 = zext i8 %74 to i32
-  br label %76
+; <label>:42                                      ; preds = %38
+  %43 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %41, i32 0, i32 52
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %NullCheck22 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %40, null
+  br i1 %NullCheck22, label %45, label %ThrowNullRef21
 
-; <label>:76                                      ; preds = %4, %65
-  %77 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %78 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %79 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %78)
-  %80 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %77, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %80, %"System.Int32[]" addrspace(1)* %79)
-  %81 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %82 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %83 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %82)
-  %84 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %81, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %84, %"System.Int32[]" addrspace(1)* %83)
-  %85 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %86 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %87 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %86)
-  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %85, i32 0, i32 27
-  store i32 %87, i32 addrspace(1)* %88
-  %89 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %40, i32 0, i32 25
+  store i32 %44, i32 addrspace(1)* %46
+  %47 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %48 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.Globalization.CultureData addrspace(1)* %48, null
+  br i1 %NullCheck24, label %49, label %ThrowNullRef23
+
+; <label>:49                                      ; preds = %45
+  %50 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %48, i32 0, i32 29
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck26 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %47, null
+  br i1 %NullCheck26, label %52, label %ThrowNullRef25
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %47, i32 0, i32 10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %53, %System.String addrspace(1)* %51)
+  %54 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %55 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Globalization.CultureData addrspace(1)* %55, null
+  br i1 %NullCheck28, label %56, label %ThrowNullRef27
+
+; <label>:56                                      ; preds = %52
+  %57 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %55, i32 0, i32 35
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %57, align 8
+  %NullCheck30 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %54, null
+  br i1 %NullCheck30, label %59, label %ThrowNullRef29
+
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %54, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %60, %System.String addrspace(1)* %58)
+  %61 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %62 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.Globalization.CultureData addrspace(1)* %62, null
+  br i1 %NullCheck32, label %63, label %ThrowNullRef31
+
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %62, i32 0, i32 34
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %64, align 8
+  %NullCheck34 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %61, null
+  br i1 %NullCheck34, label %66, label %ThrowNullRef33
+
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %61, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %67, %System.String addrspace(1)* %65)
+  %68 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %69 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck36 = icmp ne %System.Globalization.CultureData addrspace(1)* %69, null
+  br i1 %NullCheck36, label %70, label %ThrowNullRef35
+
+; <label>:70                                      ; preds = %66
+  %71 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %69, i32 0, i32 55
+  %72 = load i32, i32 addrspace(1)* %71, align 8
+  %NullCheck38 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %68, null
+  br i1 %NullCheck38, label %73, label %ThrowNullRef37
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %68, i32 0, i32 22
+  store i32 %72, i32 addrspace(1)* %74
+  %75 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %76 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck40 = icmp ne %System.Globalization.CultureData addrspace(1)* %76, null
+  br i1 %NullCheck40, label %77, label %ThrowNullRef39
+
+; <label>:77                                      ; preds = %73
+  %78 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %76, i32 0, i32 57
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %NullCheck42 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %75, null
+  br i1 %NullCheck42, label %80, label %ThrowNullRef41
+
+; <label>:80                                      ; preds = %77
+  %81 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %75, i32 0, i32 24
+  store i32 %79, i32 addrspace(1)* %81
+  %82 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %83 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck44 = icmp ne %System.Globalization.CultureData addrspace(1)* %83, null
+  br i1 %NullCheck44, label %84, label %ThrowNullRef43
+
+; <label>:84                                      ; preds = %80
+  %85 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %83, i32 0, i32 56
+  %86 = load i32, i32 addrspace(1)* %85, align 8
+  %NullCheck46 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %82, null
+  br i1 %NullCheck46, label %87, label %ThrowNullRef45
+
+; <label>:87                                      ; preds = %84
+  %88 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %82, i32 0, i32 23
+  store i32 %86, i32 addrspace(1)* %88
+  br label %101
+
+; <label>:89                                      ; preds = %entry
   %90 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %91 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %90)
-  %92 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %89, i32 0, i32 26
-  store i32 %91, i32 addrspace(1)* %92
-  %93 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %94 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %95 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %94)
-  %96 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %93, i32 0, i32 17
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %96, %System.String addrspace(1)* %95)
-  %97 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %98 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %99 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %98)
-  %100 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %97, i32 0, i32 18
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %100, %System.String addrspace(1)* %99)
-  %101 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %102 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %103 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %102)
-  %104 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %101, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %104, %System.String addrspace(1)* %103)
-  %105 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %106 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %107 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %106)
-  %108 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %105, i32 0, i32 13
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %108, %System.String addrspace(1)* %107)
-  %109 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %110 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %111 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %110)
-  %112 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %109, i32 0, i32 12
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %112, %System.String addrspace(1)* %111)
-  %113 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %114 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %115 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %114, i32 0, i32 21
-  %116 = load i32, i32 addrspace(1)* %115, align 8
-  %117 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %113, i32 0, i32 28
-  store i32 %116, i32 addrspace(1)* %117
-  %118 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %119 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %120 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %119, i32 0, i32 6
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %120, align 8
-  %122 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %118, i32 0, i32 15
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %122, %System.String addrspace(1)* %121)
-  %123 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %124 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %125 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %124, i32 0, i32 1
-  %126 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %125, align 8
-  %127 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %123, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %127, %"System.Int32[]" addrspace(1)* %126)
-  %128 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %129 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %130 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %129, i32 0, i32 7
-  %131 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %130, align 8
-  %132 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %128, i32 0, i32 16
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %132, %System.String addrspace(1)* %131)
-  %133 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %134 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %133, i32 0, i32 4
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %134, align 8
-  %136 = icmp eq %System.String addrspace(1)* %135, null
-  br i1 %136, label %144, label %137
+  %NullCheck100 = icmp ne %System.Globalization.CultureData addrspace(1)* %90, null
+  br i1 %NullCheck100, label %91, label %ThrowNullRef99
 
-; <label>:137                                     ; preds = %76
-  %138 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %138, i32 0, i32 4
-  %140 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %139, align 8
-  %141 = getelementptr inbounds %System.String, %System.String addrspace(1)* %140, i32 0, i32 1
-  %142 = load i32, i32 addrspace(1)* %141
-  %143 = icmp ne i32 %142, 0
-  br i1 %143, label %148, label %144
+; <label>:91                                      ; preds = %89
+  %92 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %90, i32 0, i32 2
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %92, align 8
+  %94 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %95 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %96 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %95)
+  %97 = zext i8 %96 to i32
+  %98 = trunc i32 %97 to i8
+  %99 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*, i8)*)(%System.String addrspace(1)* %93, %System.Globalization.NumberFormatInfo addrspace(1)* %94, i8 %98)
+  %100 = zext i8 %99 to i32
+  br label %101
 
-; <label>:144                                     ; preds = %76, %137
-  %145 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %147 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %145, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %147, %System.String addrspace(1)* %146)
-  br label %148
+; <label>:101                                     ; preds = %87, %91
+  %102 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %103 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %104 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %103)
+  %NullCheck48 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %102, null
+  br i1 %NullCheck48, label %105, label %ThrowNullRef47
 
-; <label>:148                                     ; preds = %137, %144
-  %149 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %149, i32 0, i32 9
-  %151 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %150, align 8
-  %152 = icmp eq %System.String addrspace(1)* %151, null
-  br i1 %152, label %160, label %153
+; <label>:105                                     ; preds = %101
+  %106 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %102, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %106, %"System.Int32[]" addrspace(1)* %104)
+  %107 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %108 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %109 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %108)
+  %NullCheck50 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %107, null
+  br i1 %NullCheck50, label %110, label %ThrowNullRef49
 
-; <label>:153                                     ; preds = %148
+; <label>:110                                     ; preds = %105
+  %111 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %107, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %111, %"System.Int32[]" addrspace(1)* %109)
+  %112 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %113 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %114 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %113)
+  %NullCheck52 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %112, null
+  br i1 %NullCheck52, label %115, label %ThrowNullRef51
+
+; <label>:115                                     ; preds = %110
+  %116 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %112, i32 0, i32 27
+  store i32 %114, i32 addrspace(1)* %116
+  %117 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %118 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %119 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %118)
+  %NullCheck54 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %117, null
+  br i1 %NullCheck54, label %120, label %ThrowNullRef53
+
+; <label>:120                                     ; preds = %115
+  %121 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %117, i32 0, i32 26
+  store i32 %119, i32 addrspace(1)* %121
+  %122 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %123 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %124 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %123)
+  %NullCheck56 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %122, null
+  br i1 %NullCheck56, label %125, label %ThrowNullRef55
+
+; <label>:125                                     ; preds = %120
+  %126 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %122, i32 0, i32 17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %126, %System.String addrspace(1)* %124)
+  %127 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %128 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %129 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %128)
+  %NullCheck58 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %127, null
+  br i1 %NullCheck58, label %130, label %ThrowNullRef57
+
+; <label>:130                                     ; preds = %125
+  %131 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %127, i32 0, i32 18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %131, %System.String addrspace(1)* %129)
+  %132 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %133 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %134 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %133)
+  %NullCheck60 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %132, null
+  br i1 %NullCheck60, label %135, label %ThrowNullRef59
+
+; <label>:135                                     ; preds = %130
+  %136 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %132, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %136, %System.String addrspace(1)* %134)
+  %137 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %138 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %139 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %138)
+  %NullCheck62 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %137, null
+  br i1 %NullCheck62, label %140, label %ThrowNullRef61
+
+; <label>:140                                     ; preds = %135
+  %141 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %137, i32 0, i32 13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %141, %System.String addrspace(1)* %139)
+  %142 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %143 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %144 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %143)
+  %NullCheck64 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %142, null
+  br i1 %NullCheck64, label %145, label %ThrowNullRef63
+
+; <label>:145                                     ; preds = %140
+  %146 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %142, i32 0, i32 12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %146, %System.String addrspace(1)* %144)
+  %147 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %148 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck66 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %148, null
+  br i1 %NullCheck66, label %149, label %ThrowNullRef65
+
+; <label>:149                                     ; preds = %145
+  %150 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %148, i32 0, i32 21
+  %151 = load i32, i32 addrspace(1)* %150, align 8
+  %NullCheck68 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %147, null
+  br i1 %NullCheck68, label %152, label %ThrowNullRef67
+
+; <label>:152                                     ; preds = %149
+  %153 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %147, i32 0, i32 28
+  store i32 %151, i32 addrspace(1)* %153
   %154 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %155 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 9
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %155, align 8
-  %157 = getelementptr inbounds %System.String, %System.String addrspace(1)* %156, i32 0, i32 1
-  %158 = load i32, i32 addrspace(1)* %157
-  %159 = icmp ne i32 %158, 0
-  br i1 %159, label %166, label %160
+  %155 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck70 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %155, null
+  br i1 %NullCheck70, label %156, label %ThrowNullRef69
 
-; <label>:160                                     ; preds = %148, %153
+; <label>:156                                     ; preds = %152
+  %157 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %155, i32 0, i32 6
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %157, align 8
+  %NullCheck72 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %154, null
+  br i1 %NullCheck72, label %159, label %ThrowNullRef71
+
+; <label>:159                                     ; preds = %156
+  %160 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %154, i32 0, i32 15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %160, %System.String addrspace(1)* %158)
   %161 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
   %162 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
-  %163 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 6
-  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %163, align 8
-  %165 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %165, %System.String addrspace(1)* %164)
-  br label %166
+  %NullCheck74 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %162, null
+  br i1 %NullCheck74, label %163, label %ThrowNullRef73
 
-; <label>:166                                     ; preds = %153, %160
+; <label>:163                                     ; preds = %159
+  %164 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %162, i32 0, i32 1
+  %165 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %164, align 8
+  %NullCheck76 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %161, null
+  br i1 %NullCheck76, label %166, label %ThrowNullRef75
+
+; <label>:166                                     ; preds = %163
+  %167 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %161, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %167, %"System.Int32[]" addrspace(1)* %165)
+  %168 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %169 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck78 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %169, null
+  br i1 %NullCheck78, label %170, label %ThrowNullRef77
+
+; <label>:170                                     ; preds = %166
+  %171 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %169, i32 0, i32 7
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %171, align 8
+  %NullCheck80 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %168, null
+  br i1 %NullCheck80, label %173, label %ThrowNullRef79
+
+; <label>:173                                     ; preds = %170
+  %174 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %168, i32 0, i32 16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %174, %System.String addrspace(1)* %172)
+  %175 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck82 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %175, null
+  br i1 %NullCheck82, label %176, label %ThrowNullRef81
+
+; <label>:176                                     ; preds = %173
+  %177 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %175, i32 0, i32 4
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %177, align 8
+  %179 = icmp eq %System.String addrspace(1)* %178, null
+  br i1 %179, label %189, label %180
+
+; <label>:180                                     ; preds = %176
+  %181 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck84 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %181, null
+  br i1 %NullCheck84, label %182, label %ThrowNullRef83
+
+; <label>:182                                     ; preds = %180
+  %183 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %181, i32 0, i32 4
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %183, align 8
+  %NullCheck86 = icmp ne %System.String addrspace(1)* %184, null
+  br i1 %NullCheck86, label %185, label %ThrowNullRef85
+
+; <label>:185                                     ; preds = %182
+  %186 = getelementptr inbounds %System.String, %System.String addrspace(1)* %184, i32 0, i32 1
+  %187 = load i32, i32 addrspace(1)* %186
+  %188 = icmp ne i32 %187, 0
+  br i1 %188, label %194, label %189
+
+; <label>:189                                     ; preds = %176, %185
+  %190 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck98 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %190, null
+  br i1 %NullCheck98, label %192, label %ThrowNullRef97
+
+; <label>:192                                     ; preds = %189
+  %193 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %190, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %193, %System.String addrspace(1)* %191)
+  br label %194
+
+; <label>:194                                     ; preds = %185, %192
+  %195 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck88 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %195, null
+  br i1 %NullCheck88, label %196, label %ThrowNullRef87
+
+; <label>:196                                     ; preds = %194
+  %197 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %195, i32 0, i32 9
+  %198 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %197, align 8
+  %199 = icmp eq %System.String addrspace(1)* %198, null
+  br i1 %199, label %209, label %200
+
+; <label>:200                                     ; preds = %196
+  %201 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck90 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %201, null
+  br i1 %NullCheck90, label %202, label %ThrowNullRef89
+
+; <label>:202                                     ; preds = %200
+  %203 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %201, i32 0, i32 9
+  %204 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %203, align 8
+  %NullCheck92 = icmp ne %System.String addrspace(1)* %204, null
+  br i1 %NullCheck92, label %205, label %ThrowNullRef91
+
+; <label>:205                                     ; preds = %202
+  %206 = getelementptr inbounds %System.String, %System.String addrspace(1)* %204, i32 0, i32 1
+  %207 = load i32, i32 addrspace(1)* %206
+  %208 = icmp ne i32 %207, 0
+  br i1 %208, label %217, label %209
+
+; <label>:209                                     ; preds = %196, %205
+  %210 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %211 = load %System.Globalization.NumberFormatInfo addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)** %arg1
+  %NullCheck94 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %211, null
+  br i1 %NullCheck94, label %212, label %ThrowNullRef93
+
+; <label>:212                                     ; preds = %209
+  %213 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %211, i32 0, i32 6
+  %214 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %213, align 8
+  %NullCheck96 = icmp ne %System.Globalization.NumberFormatInfo addrspace(1)* %210, null
+  br i1 %NullCheck96, label %215, label %ThrowNullRef95
+
+; <label>:215                                     ; preds = %212
+  %216 = getelementptr inbounds %System.Globalization.NumberFormatInfo, %System.Globalization.NumberFormatInfo addrspace(1)* %210, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %216, %System.String addrspace(1)* %214)
+  br label %217
+
+; <label>:217                                     ; preds = %205, %215
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %110
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %115
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %120
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %125
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %135
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %152
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %156
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %159
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %163
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %173
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %180
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %182
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %194
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %202
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %209
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %212
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %189
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %89
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
@@ -7365,25 +11117,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 21
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 16)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 21
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 16)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 21
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 21
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -7397,11 +11173,19 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
   %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
-  %4 = load i32, i32* %arg1
-  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
-  ret %System.String addrspace(1)* %5
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %3, align 8
+  %5 = load i32, i32* %arg1
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %4, i32 %5)
+  ret %System.String addrspace(1)* %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
@@ -7457,25 +11241,49 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
-  %2 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Int32[]" addrspace(1)* %2, null
-  br i1 %3, label %10, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 33
+  %3 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Int32[]" addrspace(1)* %3, null
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 24)
-  %8 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %7)
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 33
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %9, %"System.Int32[]" addrspace(1)* %8)
-  br label %10
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 24)
+  %9 = call %"System.Int32[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Int32[]" addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %entry, %4
-  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %12 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 33
-  %13 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %12, align 8
-  ret %"System.Int32[]" addrspace(1)* %13
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 33
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Int32[]" addrspace(1)* addrspace(1)*, %"System.Int32[]" addrspace(1)*)*)(%"System.Int32[]" addrspace(1)* addrspace(1)* %11, %"System.Int32[]" addrspace(1)* %9)
+  br label %12
+
+; <label>:12                                      ; preds = %1, %10
+  %13 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %13, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %13, i32 0, i32 33
+  %16 = load %"System.Int32[]" addrspace(1)*, %"System.Int32[]" addrspace(1)* addrspace(1)* %15, align 8
+  ret %"System.Int32[]" addrspace(1)* %16
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_INEGATIVEPERCENT using LLILCJit
@@ -7486,24 +11294,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 53
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 116)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 53
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 116)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 53
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 53
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 53
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfoInt using LLILCJit
@@ -7530,13 +11362,21 @@ entry:
 
 ; <label>:7                                       ; preds = %entry, %4
   %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
-  %11 = load i32, i32* %arg1
-  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %10, i32 %11)
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  ret i32 %13
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %7
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
+  %12 = load i32, i32* %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %11, i32 %12)
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_IPOSITIVEPERCENT using LLILCJit
@@ -7547,24 +11387,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = icmp ne i32 %2, -1
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 54
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = icmp ne i32 %3, -1
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 117)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 54
-  store i32 %7, i32 addrspace(1)* %8
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 117)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 54
-  %12 = load i32, i32 addrspace(1)* %11, align 8
-  ret i32 %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 %8, i32 addrspace(1)* %10
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 54
+  %15 = load i32, i32 addrspace(1)* %14, align 8
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERCENT using LLILCJit
@@ -7575,24 +11439,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 27
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 118)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 27
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 118)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 27
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 27
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPERMILLE using LLILCJit
@@ -7603,24 +11491,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 28
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 119)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 28
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 119)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 28
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 28
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNEGINFINITY using LLILCJit
@@ -7631,24 +11543,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 26
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 107)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 26
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 107)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 26
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 26
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SPOSINFINITY using LLILCJit
@@ -7659,24 +11595,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 25
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 106)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 25
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 106)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 25
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 25
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::get_SNAN using LLILCJit
@@ -7687,24 +11647,48 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 24
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %11, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %6, i32 105)
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 24
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  br label %9
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %8 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %7, i32 105)
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry, %4
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 24
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.String addrspace(1)* %12
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  br label %11
+
+; <label>:11                                      ; preds = %1, %9
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 24
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
+  ret %System.String addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::ConcatArray using LLILCJit
@@ -7719,16 +11703,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 104
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 8
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 104
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7846,19 +11838,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7890,9 +11898,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7936,17 +11952,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7967,17 +11999,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -8014,11 +12062,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -8034,7 +12090,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -8042,27 +12098,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -8178,31 +12242,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -8215,40 +12311,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8262,8 +12382,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -8331,38 +12459,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -8375,39 +12535,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -8418,39 +12602,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -8478,29 +12702,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -8565,9 +12805,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -8594,16 +12842,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -8620,12 +12884,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -8651,19 +12931,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -8729,51 +13033,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -8786,11 +13098,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -8810,116 +13130,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8930,19 +13378,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8990,34 +13454,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9043,9 +13539,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -9056,32 +13560,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -9094,20 +13630,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -9142,59 +13694,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -9205,11 +13773,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -9237,20 +13821,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -9262,36 +13854,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9310,177 +13910,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -9545,27 +14313,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -9576,28 +14368,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -9617,44 +14425,68 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 104
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 8
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 104
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, %System.String addrspace(1)* %8)
-  br label %18
+  %17 = add i64 %16, 8
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, %System.String addrspace(1)* %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9718,116 +14550,196 @@ entry:
 
 ; <label>:23                                      ; preds = %15
   %24 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
-  %26 = load i32, i32 addrspace(1)* %25
-  %27 = zext i32 %26 to i64
-  %28 = trunc i64 %27 to i32
-  %29 = load i32, i32* %arg2
-  %30 = sub i32 %28, %29
-  %31 = load i32, i32* %arg3
-  %32 = icmp sge i32 %30, %31
-  br i1 %32, label %37, label %33
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %24, null
+  br i1 %NullCheck, label %25, label %ThrowNullRef
 
-; <label>:33                                      ; preds = %23
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %35 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %34)
-  %36 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36, %System.String addrspace(1)* %35)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36) #0
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = trunc i64 %28 to i32
+  %30 = load i32, i32* %arg2
+  %31 = sub i32 %29, %30
+  %32 = load i32, i32* %arg3
+  %33 = icmp sge i32 %31, %32
+  br i1 %33, label %38, label %34
+
+; <label>:34                                      ; preds = %25
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %37, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %37) #0
   unreachable
 
-; <label>:37                                      ; preds = %23
-  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %38)
-  br label %89
+; <label>:38                                      ; preds = %25
+  %39 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %39)
+  br label %98
 
-; <label>:39                                      ; preds = %89
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %43, i32 0, i32 10
-  %45 = load i32, i32 addrspace(1)* %44, align 8
-  %46 = icmp ne i32 %42, %45
-  br i1 %46, label %49, label %47
+; <label>:40                                      ; preds = %98
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %41, null
+  br i1 %NullCheck4, label %42, label %ThrowNullRef3
 
-; <label>:47                                      ; preds = %39
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %48, i8 0, i8 0)
-  br label %49
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %45, null
+  br i1 %NullCheck6, label %46, label %ThrowNullRef5
 
-; <label>:49                                      ; preds = %39, %47
-  %50 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %51 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %50, i32 0, i32 10
-  %52 = load i32, i32 addrspace(1)* %51, align 8
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %45, i32 0, i32 10
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %49 = icmp ne i32 %44, %48
+  br i1 %49, label %52, label %50
+
+; <label>:50                                      ; preds = %46
+  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %51, i8 0, i8 0)
+  br label %52
+
+; <label>:52                                      ; preds = %46, %50
   %53 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %54 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 9
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = sub i32 %52, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc0
-  %58 = load i32, i32* %arg3
-  %59 = icmp sle i32 %57, %58
-  br i1 %59, label %62, label %60
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %53, null
+  br i1 %NullCheck8, label %54, label %ThrowNullRef7
 
-; <label>:60                                      ; preds = %49
-  %61 = load i32, i32* %arg3
+; <label>:54                                      ; preds = %52
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 10
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck10, label %58, label %ThrowNullRef9
+
+; <label>:58                                      ; preds = %54
+  %59 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 9
+  %60 = load i32, i32 addrspace(1)* %59, align 8
+  %61 = sub i32 %56, %60
   store i32 %61, i32* %loc0
-  br label %62
+  %62 = load i32, i32* %loc0
+  %63 = load i32, i32* %arg3
+  %64 = icmp sle i32 %62, %63
+  br i1 %64, label %67, label %65
 
-; <label>:62                                      ; preds = %49, %60
-  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %64 = load i32, i32* %arg2
-  %65 = mul i32 %64, 2
-  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %67 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 7
-  %68 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %70 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %69, i32 0, i32 9
-  %71 = load i32, i32 addrspace(1)* %70, align 8
-  %72 = mul i32 %71, 2
-  %73 = load i32, i32* %loc0
-  %74 = mul i32 %73, 2
-  %75 = bitcast %"System.Char[]" addrspace(1)* %63 to %System.Array addrspace(1)*
-  %76 = bitcast %"System.Char[]" addrspace(1)* %68 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %75, i32 %65, %System.Array addrspace(1)* %76, i32 %72, i32 %74)
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
+; <label>:65                                      ; preds = %58
+  %66 = load i32, i32* %arg3
+  store i32 %66, i32* %loc0
+  br label %67
+
+; <label>:67                                      ; preds = %58, %65
+  %68 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %69 = load i32, i32* %arg2
+  %70 = mul i32 %69, 2
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %71, null
+  br i1 %NullCheck12, label %72, label %ThrowNullRef11
+
+; <label>:72                                      ; preds = %67
+  %73 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 7
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %73, align 8
+  %75 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %75, null
+  br i1 %NullCheck14, label %76, label %ThrowNullRef13
+
+; <label>:76                                      ; preds = %72
+  %77 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %75, i32 0, i32 9
+  %78 = load i32, i32 addrspace(1)* %77, align 8
+  %79 = mul i32 %78, 2
   %80 = load i32, i32* %loc0
-  %81 = add i32 %79, %80
-  %82 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  store i32 %81, i32 addrspace(1)* %82
-  %83 = load i32, i32* %arg2
-  %84 = load i32, i32* %loc0
-  %85 = add i32 %83, %84
-  store i32 %85, i32* %arg2
-  %86 = load i32, i32* %arg3
-  %87 = load i32, i32* %loc0
-  %88 = sub i32 %86, %87
-  store i32 %88, i32* %arg3
-  br label %89
+  %81 = mul i32 %80, 2
+  %82 = bitcast %"System.Char[]" addrspace(1)* %68 to %System.Array addrspace(1)*
+  %83 = bitcast %"System.Char[]" addrspace(1)* %74 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %82, i32 %70, %System.Array addrspace(1)* %83, i32 %79, i32 %81)
+  %84 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck16, label %85, label %ThrowNullRef15
 
-; <label>:89                                      ; preds = %37, %62
-  %90 = load i32, i32* %arg3
-  %91 = icmp sgt i32 %90, 0
-  br i1 %91, label %39, label %92
+; <label>:85                                      ; preds = %76
+  %86 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = load i32, i32* %loc0
+  %89 = add i32 %87, %88
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck18, label %90, label %ThrowNullRef17
 
-; <label>:92                                      ; preds = %89
-  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %94 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 11
-  %95 = load i8, i8 addrspace(1)* %94, align 8
-  %96 = zext i8 %95 to i32
-  %97 = icmp eq i32 %96, 0
-  br i1 %97, label %100, label %98
+; <label>:90                                      ; preds = %85
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load i32, i32* %arg2
+  %93 = load i32, i32* %loc0
+  %94 = add i32 %92, %93
+  store i32 %94, i32* %arg2
+  %95 = load i32, i32* %arg3
+  %96 = load i32, i32* %loc0
+  %97 = sub i32 %95, %96
+  store i32 %97, i32* %arg3
+  br label %98
 
-; <label>:98                                      ; preds = %92
-  %99 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %99, i8 1, i8 0)
-  br label %100
+; <label>:98                                      ; preds = %38, %90
+  %99 = load i32, i32* %arg3
+  %100 = icmp sgt i32 %99, 0
+  br i1 %100, label %40, label %101
 
-; <label>:100                                     ; preds = %92, %98
+; <label>:101                                     ; preds = %98
+  %102 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %102, null
+  br i1 %NullCheck2, label %103, label %ThrowNullRef1
+
+; <label>:103                                     ; preds = %101
+  %104 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %102, i32 0, i32 11
+  %105 = load i8, i8 addrspace(1)* %104, align 8
+  %106 = zext i8 %105 to i32
+  %107 = icmp eq i32 %106, 0
+  br i1 %107, label %110, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %109, i8 1, i8 0)
+  br label %110
+
+; <label>:110                                     ; preds = %103, %108
   ret void
+
+ThrowNullRef:                                     ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
@@ -9955,30 +14867,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -10004,25 +14948,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -10082,38 +15034,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -10126,23 +15094,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -10154,27 +15130,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method BringUpTest::Swap using LLILCJit
@@ -10188,16 +15172,48 @@ entry:
   store i32 addrspace(1)* %param0, i32 addrspace(1)** %arg0
   store i32 addrspace(1)* %param1, i32 addrspace(1)** %arg1
   %0 = load i32 addrspace(1)*, i32 addrspace(1)** %arg0
-  %1 = load i32, i32 addrspace(1)* %0, align 8
-  store i32 %1, i32* %loc0
-  %2 = load i32 addrspace(1)*, i32 addrspace(1)** %arg0
-  %3 = load i32 addrspace(1)*, i32 addrspace(1)** %arg1
-  %4 = load i32, i32 addrspace(1)* %3, align 8
-  store i32 %4, i32 addrspace(1)* %2, align 8
-  %5 = load i32 addrspace(1)*, i32 addrspace(1)** %arg1
-  %6 = load i32, i32* %loc0
-  store i32 %6, i32 addrspace(1)* %5, align 8
+  %NullCheck = icmp ne i32 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = load i32, i32 addrspace(1)* %0, align 8
+  store i32 %2, i32* %loc0
+  %3 = load i32 addrspace(1)*, i32 addrspace(1)** %arg0
+  %4 = load i32 addrspace(1)*, i32 addrspace(1)** %arg1
+  %NullCheck2 = icmp ne i32 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i32, i32 addrspace(1)* %4, align 8
+  %NullCheck4 = icmp ne i32 addrspace(1)* %3, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %5
+  store i32 %6, i32 addrspace(1)* %3, align 8
+  %8 = load i32 addrspace(1)*, i32 addrspace(1)** %arg1
+  %9 = load i32, i32* %loc0
+  %NullCheck6 = icmp ne i32 addrspace(1)* %8, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  store i32 %9, i32 addrspace(1)* %8, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Switch.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Switch.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Unbox.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Unbox.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Xor1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Xor1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/XorRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/XorRef.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6896,11 +10184,19 @@ entry:
   store i32 addrspace(1)* %param1, i32 addrspace(1)** %arg1
   %0 = load i32, i32* %arg0
   %1 = load i32 addrspace(1)*, i32 addrspace(1)** %arg1
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = xor i32 %0, %2
-  store i32 %3, i32* %arg0
-  %4 = load i32, i32* %arg0
-  ret i32 %4
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  %4 = xor i32 %0, %3
+  store i32 %4, i32* %arg0
+  %5 = load i32, i32* %arg0
+  ret i32 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/addref.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/addref.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6896,11 +10184,19 @@ entry:
   store i32 addrspace(1)* %param1, i32 addrspace(1)** %arg1
   %0 = load i32, i32* %arg0
   %1 = load i32 addrspace(1)*, i32 addrspace(1)** %arg1
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = add i32 %0, %2
-  store i32 %3, i32* %arg0
-  %4 = load i32, i32* %arg0
-  ret i32 %4
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  %4 = add i32 %0, %3
+  store i32 %4, i32* %arg0
+  %5 = load i32, i32* %arg0
+  ret i32 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/div1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/div1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/divref.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/divref.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6896,9 +10184,17 @@ entry:
   store i32 addrspace(1)* %param1, i32 addrspace(1)** %arg1
   %0 = load i32, i32* %arg0
   %1 = load i32 addrspace(1)*, i32 addrspace(1)** %arg1
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = sdiv i32 %0, %2
-  ret i32 %3
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  %4 = sdiv i32 %0, %3
+  ret i32 %4
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul2.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul3.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul3.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul4.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul4.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6893,9 +10181,17 @@ entry:
   %arg0 = alloca i32 addrspace(1)*
   store i32 addrspace(1)* %param0, i32 addrspace(1)** %arg0
   %0 = load i32 addrspace(1)*, i32 addrspace(1)** %arg0
-  %1 = load i32, i32 addrspace(1)* %0, align 8
-  %2 = mul i32 %1, 1038
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = load i32, i32 addrspace(1)* %0, align 8
+  %3 = mul i32 %2, 1038
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/rem1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/rem1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit

--- a/test/BaseLine/JIT/Directed/Arrays/complex1.error.txt
+++ b/test/BaseLine/JIT/Directed/Arrays/complex1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6875,16 +10163,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 104
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 8
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 104
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7002,19 +10298,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7046,9 +10358,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7092,17 +10412,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7123,17 +10459,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7170,11 +10522,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7190,7 +10550,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7198,27 +10558,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7334,31 +10702,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7371,40 +10771,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7418,8 +10842,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7487,38 +10919,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7531,39 +10995,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7574,39 +11062,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7634,29 +11162,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7721,9 +11265,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7750,16 +11302,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7776,12 +11344,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7807,19 +11391,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7885,51 +11493,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7942,11 +11558,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7966,116 +11590,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8086,19 +11838,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8146,34 +11914,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8199,9 +11999,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8212,32 +12020,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8250,20 +12090,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8298,59 +12154,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8361,11 +12233,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8393,20 +12281,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8418,36 +12314,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8466,177 +12370,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8701,27 +12773,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8732,28 +12828,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8950,44 +13062,68 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 104
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 8
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 104
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, %System.String addrspace(1)* %8)
-  br label %18
+  %17 = add i64 %16, 8
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, %System.String addrspace(1)* %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9051,116 +13187,196 @@ entry:
 
 ; <label>:23                                      ; preds = %15
   %24 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
-  %26 = load i32, i32 addrspace(1)* %25
-  %27 = zext i32 %26 to i64
-  %28 = trunc i64 %27 to i32
-  %29 = load i32, i32* %arg2
-  %30 = sub i32 %28, %29
-  %31 = load i32, i32* %arg3
-  %32 = icmp sge i32 %30, %31
-  br i1 %32, label %37, label %33
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %24, null
+  br i1 %NullCheck, label %25, label %ThrowNullRef
 
-; <label>:33                                      ; preds = %23
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %35 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %34)
-  %36 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36, %System.String addrspace(1)* %35)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36) #0
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = trunc i64 %28 to i32
+  %30 = load i32, i32* %arg2
+  %31 = sub i32 %29, %30
+  %32 = load i32, i32* %arg3
+  %33 = icmp sge i32 %31, %32
+  br i1 %33, label %38, label %34
+
+; <label>:34                                      ; preds = %25
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %37, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %37) #0
   unreachable
 
-; <label>:37                                      ; preds = %23
-  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %38)
-  br label %89
+; <label>:38                                      ; preds = %25
+  %39 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %39)
+  br label %98
 
-; <label>:39                                      ; preds = %89
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %43, i32 0, i32 10
-  %45 = load i32, i32 addrspace(1)* %44, align 8
-  %46 = icmp ne i32 %42, %45
-  br i1 %46, label %49, label %47
+; <label>:40                                      ; preds = %98
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %41, null
+  br i1 %NullCheck4, label %42, label %ThrowNullRef3
 
-; <label>:47                                      ; preds = %39
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %48, i8 0, i8 0)
-  br label %49
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %45, null
+  br i1 %NullCheck6, label %46, label %ThrowNullRef5
 
-; <label>:49                                      ; preds = %39, %47
-  %50 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %51 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %50, i32 0, i32 10
-  %52 = load i32, i32 addrspace(1)* %51, align 8
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %45, i32 0, i32 10
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %49 = icmp ne i32 %44, %48
+  br i1 %49, label %52, label %50
+
+; <label>:50                                      ; preds = %46
+  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %51, i8 0, i8 0)
+  br label %52
+
+; <label>:52                                      ; preds = %46, %50
   %53 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %54 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 9
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = sub i32 %52, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc0
-  %58 = load i32, i32* %arg3
-  %59 = icmp sle i32 %57, %58
-  br i1 %59, label %62, label %60
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %53, null
+  br i1 %NullCheck8, label %54, label %ThrowNullRef7
 
-; <label>:60                                      ; preds = %49
-  %61 = load i32, i32* %arg3
+; <label>:54                                      ; preds = %52
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 10
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck10, label %58, label %ThrowNullRef9
+
+; <label>:58                                      ; preds = %54
+  %59 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 9
+  %60 = load i32, i32 addrspace(1)* %59, align 8
+  %61 = sub i32 %56, %60
   store i32 %61, i32* %loc0
-  br label %62
+  %62 = load i32, i32* %loc0
+  %63 = load i32, i32* %arg3
+  %64 = icmp sle i32 %62, %63
+  br i1 %64, label %67, label %65
 
-; <label>:62                                      ; preds = %49, %60
-  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %64 = load i32, i32* %arg2
-  %65 = mul i32 %64, 2
-  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %67 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 7
-  %68 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %70 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %69, i32 0, i32 9
-  %71 = load i32, i32 addrspace(1)* %70, align 8
-  %72 = mul i32 %71, 2
-  %73 = load i32, i32* %loc0
-  %74 = mul i32 %73, 2
-  %75 = bitcast %"System.Char[]" addrspace(1)* %63 to %System.Array addrspace(1)*
-  %76 = bitcast %"System.Char[]" addrspace(1)* %68 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %75, i32 %65, %System.Array addrspace(1)* %76, i32 %72, i32 %74)
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
+; <label>:65                                      ; preds = %58
+  %66 = load i32, i32* %arg3
+  store i32 %66, i32* %loc0
+  br label %67
+
+; <label>:67                                      ; preds = %58, %65
+  %68 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %69 = load i32, i32* %arg2
+  %70 = mul i32 %69, 2
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %71, null
+  br i1 %NullCheck12, label %72, label %ThrowNullRef11
+
+; <label>:72                                      ; preds = %67
+  %73 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 7
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %73, align 8
+  %75 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %75, null
+  br i1 %NullCheck14, label %76, label %ThrowNullRef13
+
+; <label>:76                                      ; preds = %72
+  %77 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %75, i32 0, i32 9
+  %78 = load i32, i32 addrspace(1)* %77, align 8
+  %79 = mul i32 %78, 2
   %80 = load i32, i32* %loc0
-  %81 = add i32 %79, %80
-  %82 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  store i32 %81, i32 addrspace(1)* %82
-  %83 = load i32, i32* %arg2
-  %84 = load i32, i32* %loc0
-  %85 = add i32 %83, %84
-  store i32 %85, i32* %arg2
-  %86 = load i32, i32* %arg3
-  %87 = load i32, i32* %loc0
-  %88 = sub i32 %86, %87
-  store i32 %88, i32* %arg3
-  br label %89
+  %81 = mul i32 %80, 2
+  %82 = bitcast %"System.Char[]" addrspace(1)* %68 to %System.Array addrspace(1)*
+  %83 = bitcast %"System.Char[]" addrspace(1)* %74 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %82, i32 %70, %System.Array addrspace(1)* %83, i32 %79, i32 %81)
+  %84 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck16, label %85, label %ThrowNullRef15
 
-; <label>:89                                      ; preds = %37, %62
-  %90 = load i32, i32* %arg3
-  %91 = icmp sgt i32 %90, 0
-  br i1 %91, label %39, label %92
+; <label>:85                                      ; preds = %76
+  %86 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = load i32, i32* %loc0
+  %89 = add i32 %87, %88
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck18, label %90, label %ThrowNullRef17
 
-; <label>:92                                      ; preds = %89
-  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %94 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 11
-  %95 = load i8, i8 addrspace(1)* %94, align 8
-  %96 = zext i8 %95 to i32
-  %97 = icmp eq i32 %96, 0
-  br i1 %97, label %100, label %98
+; <label>:90                                      ; preds = %85
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load i32, i32* %arg2
+  %93 = load i32, i32* %loc0
+  %94 = add i32 %92, %93
+  store i32 %94, i32* %arg2
+  %95 = load i32, i32* %arg3
+  %96 = load i32, i32* %loc0
+  %97 = sub i32 %95, %96
+  store i32 %97, i32* %arg3
+  br label %98
 
-; <label>:98                                      ; preds = %92
-  %99 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %99, i8 1, i8 0)
-  br label %100
+; <label>:98                                      ; preds = %38, %90
+  %99 = load i32, i32* %arg3
+  %100 = icmp sgt i32 %99, 0
+  br i1 %100, label %40, label %101
 
-; <label>:100                                     ; preds = %92, %98
+; <label>:101                                     ; preds = %98
+  %102 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %102, null
+  br i1 %NullCheck2, label %103, label %ThrowNullRef1
+
+; <label>:103                                     ; preds = %101
+  %104 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %102, i32 0, i32 11
+  %105 = load i8, i8 addrspace(1)* %104, align 8
+  %106 = zext i8 %105 to i32
+  %107 = icmp eq i32 %106, 0
+  br i1 %107, label %110, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %109, i8 1, i8 0)
+  br label %110
+
+; <label>:110                                     ; preds = %103, %108
   ret void
+
+ThrowNullRef:                                     ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
@@ -9288,30 +13504,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -9337,25 +13585,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -9415,38 +13671,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -9459,23 +13731,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -9487,27 +13767,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 

--- a/test/BaseLine/JIT/Directed/Arrays/simple1.error.txt
+++ b/test/BaseLine/JIT/Directed/Arrays/simple1.error.txt
@@ -25,49 +25,57 @@ entry:
   %2 = bitcast %System.AppDomain addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %4 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
-  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %4, align 8
-  %6 = icmp ne %System.AppDomainSetup addrspace(1)* %5, null
-  br i1 %6, label %14, label %7
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
-  store %System.AppDomainSetup addrspace(1)* %8, %System.AppDomainSetup addrspace(1)** %loc0
-  %9 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %9, null
-  br i1 %NullCheck, label %11, label %ThrowNullRef
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %3, i32 0, i32 3
+  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp ne %System.AppDomainSetup addrspace(1)* %6, null
+  br i1 %7, label %15, label %8
 
-; <label>:11                                      ; preds = %7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9, %System.String addrspace(1)* %10)
-  %12 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %12, %System.AppDomainSetup addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* null)
-  br label %14
+; <label>:8                                       ; preds = %4
+  %9 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %9)
+  store %System.AppDomainSetup addrspace(1)* %9, %System.AppDomainSetup addrspace(1)** %loc0
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %entry, %11
+; <label>:12                                      ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10, %System.String addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomain addrspace(1)*, %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomain addrspace(1)* %13, %System.AppDomainSetup addrspace(1)* %14, %System.AppDomainSetup addrspace(1)* null)
   br label %15
 
-; <label>:15                                      ; preds = %14
-  %16 = load i8, i8* %loc1
-  %17 = zext i8 %16 to i32
-  %18 = icmp eq i32 %17, 0
-  br i1 %18, label %22, label %19
+; <label>:15                                      ; preds = %4, %12
+  br label %16
 
-; <label>:19                                      ; preds = %15
-  %20 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
-  %21 = bitcast %System.AppDomain addrspace(1)* %20 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %21)
-  br label %22
+; <label>:16                                      ; preds = %15
+  %17 = load i8, i8* %loc1
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %23, label %20
 
-; <label>:22                                      ; preds = %15, %19
+; <label>:20                                      ; preds = %16
+  %21 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %loc2
+  %22 = bitcast %System.AppDomain addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   br label %23
 
-; <label>:23                                      ; preds = %22
+; <label>:23                                      ; preds = %16, %20
+  br label %24
+
+; <label>:24                                      ; preds = %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -82,20 +90,28 @@ entry:
   store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
   store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
   %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  %1 = load i8, i8 addrspace(1)* %0, align 8
-  %2 = sext i8 %1 to i32
-  %3 = icmp eq i32 %2, 0
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne i8 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = load i8, i8 addrspace(1)* %0, align 8
+  %3 = sext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %7, i8 addrspace(1)* %8)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
@@ -109,9 +125,17 @@ entry:
   %1 = bitcast %System.AppDomainSetup addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
-  store i32 0, i32 addrspace(1)* %3
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %2, i32 0, i32 11
+  store i32 0, i32 addrspace(1)* %4
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Object::.ctor using LLILCJit
@@ -135,9 +159,17 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %3, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::SetupFusionStore using LLILCJit
@@ -206,8 +238,8 @@ entry:
 ; <label>:25                                      ; preds = %11, %22
   %26 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %27 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %NullCheck10 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
-  br i1 %NullCheck10, label %28, label %ThrowNullRef9
+  %NullCheck12 = icmp ne %System.AppDomainSetup addrspace(1)* %27, null
+  br i1 %NullCheck12, label %28, label %ThrowNullRef11
 
 ; <label>:28                                      ; preds = %25
   %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %27)
@@ -217,8 +249,12 @@ entry:
 ; <label>:30                                      ; preds = %14, %22, %28
   %31 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
   %32 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg1
-  %33 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %33, %System.AppDomainSetup addrspace(1)* %32)
+  %NullCheck10 = icmp ne %System.AppDomain addrspace(1)* %31, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %31, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainSetup addrspace(1)* addrspace(1)*, %System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* addrspace(1)* %34, %System.AppDomainSetup addrspace(1)* %32)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
@@ -241,7 +277,11 @@ ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef9:                                    ; preds = %25
+ThrowNullRef9:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -275,35 +315,43 @@ entry:
   store i8 %param2, i8* %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %16, label %2
+  br i1 %1, label %17, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp ne i32 %5, 0
-  br i1 %6, label %8, label %7
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %2
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %9, label %8
+
+; <label>:8                                       ; preds = %4
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
-  br label %16
+  br label %17
 
-; <label>:8                                       ; preds = %2
-  %9 = load i8, i8* %arg2
-  %10 = zext i8 %9 to i32
-  %11 = icmp eq i32 %10, 0
-  br i1 %11, label %16, label %12
+; <label>:9                                       ; preds = %4
+  %10 = load i8, i8* %arg2
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
 
-; <label>:12                                      ; preds = %8
-  %13 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
-  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
-  br label %16
+; <label>:13                                      ; preds = %9
+  %14 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %14, %System.String addrspace(1)* %15, i8 1)
+  store %System.String addrspace(1)* %16, %System.String addrspace(1)** %arg1
+  br label %17
 
-; <label>:16                                      ; preds = %entry, %7, %8, %12
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  ret %System.String addrspace(1)* %17
+; <label>:17                                      ; preds = %entry, %8, %9, %13
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %18
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
@@ -320,14 +368,30 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = sub i32 %4, 1
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
-  ret i32 %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = sub i32 %5, 1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %3
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %6, i32 %10)
+  ret i32 %11
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Substring using LLILCJit
@@ -357,85 +421,109 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg1
   %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
-  %11 = load i32, i32 addrspace(1)* %10
-  %12 = icmp sle i32 %8, %11
-  br i1 %12, label %18, label %13
+  %NullCheck = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %12 = load i32, i32 addrspace(1)* %11
+  %13 = icmp sle i32 %8, %12
+  br i1 %13, label %19, label %14
+
+; <label>:14                                      ; preds = %10
   %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %16)
+  %18 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18, %System.String addrspace(1)* %15, %System.String addrspace(1)* %17)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %18) #0
   unreachable
 
-; <label>:18                                      ; preds = %7
-  %19 = load i32, i32* %arg2
-  %20 = icmp sge i32 %19, 0
-  br i1 %20, label %26, label %21
+; <label>:19                                      ; preds = %10
+  %20 = load i32, i32* %arg2
+  %21 = icmp sge i32 %20, 0
+  br i1 %21, label %27, label %22
 
-; <label>:21                                      ; preds = %18
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:22                                      ; preds = %19
   %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
-  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
   unreachable
 
-; <label>:26                                      ; preds = %18
-  %27 = load i32, i32* %arg1
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = load i32, i32* %arg2
-  %32 = sub i32 %30, %31
-  %33 = icmp sle i32 %27, %32
-  br i1 %33, label %39, label %34
+; <label>:27                                      ; preds = %19
+  %28 = load i32, i32* %arg1
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %29, null
+  br i1 %NullCheck2, label %30, label %ThrowNullRef1
 
-; <label>:34                                      ; preds = %26
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
-  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+; <label>:30                                      ; preds = %27
+  %31 = getelementptr inbounds %System.String, %System.String addrspace(1)* %29, i32 0, i32 1
+  %32 = load i32, i32 addrspace(1)* %31
+  %33 = load i32, i32* %arg2
+  %34 = sub i32 %32, %33
+  %35 = icmp sle i32 %28, %34
+  br i1 %35, label %41, label %36
+
+; <label>:36                                      ; preds = %30
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %39 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %38)
+  %40 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40, %System.String addrspace(1)* %37, %System.String addrspace(1)* %39)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %40) #0
   unreachable
 
-; <label>:39                                      ; preds = %26
-  %40 = load i32, i32* %arg2
-  %41 = icmp ne i32 %40, 0
-  br i1 %41, label %44, label %42
+; <label>:41                                      ; preds = %30
+  %42 = load i32, i32* %arg2
+  %43 = icmp ne i32 %42, 0
+  br i1 %43, label %46, label %44
 
-; <label>:42                                      ; preds = %39
-  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %43
+; <label>:44                                      ; preds = %41
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %45
 
-; <label>:44                                      ; preds = %39
-  %45 = load i32, i32* %arg1
-  %46 = icmp ne i32 %45, 0
-  br i1 %46, label %55, label %47
+; <label>:46                                      ; preds = %41
+  %47 = load i32, i32* %arg1
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %58, label %49
 
-; <label>:47                                      ; preds = %44
-  %48 = load i32, i32* %arg2
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
-  %51 = load i32, i32 addrspace(1)* %50
-  %52 = icmp ne i32 %48, %51
-  br i1 %52, label %55, label %53
+; <label>:49                                      ; preds = %46
+  %50 = load i32, i32* %arg2
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck4, label %52, label %ThrowNullRef3
 
-; <label>:53                                      ; preds = %47
-  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %54
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = icmp ne i32 %50, %54
+  br i1 %55, label %58, label %56
 
-; <label>:55                                      ; preds = %44, %47
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %57 = load i32, i32* %arg1
-  %58 = load i32, i32* %arg2
-  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
-  ret %System.String addrspace(1)* %59
+; <label>:56                                      ; preds = %52
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %57
+
+; <label>:58                                      ; preds = %46, %52
+  %59 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %60 = load i32, i32* %arg1
+  %61 = load i32, i32* %arg2
+  %62 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %59, i32 %60, i32 %61)
+  ret %System.String addrspace(1)* %62
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::InternalSubString using LLILCJit
@@ -557,19 +645,19 @@ entry:
   %4 = sub i64 %1, %3
   %5 = load i64, i64* %arg2
   %6 = icmp ult i64 %4, %5
-  br i1 %6, label %397, label %7
+  br i1 %6, label %483, label %7
 
 ; <label>:7                                       ; preds = %entry
   %8 = load i64, i64* %arg2
   store i64 %8, i64* %loc1
   %9 = load i64, i64* %loc1
   %10 = icmp sgt i64 %9, 16
-  br i1 %10, label %257, label %11
+  br i1 %10, label %325, label %11
 
 ; <label>:11                                      ; preds = %7
   %12 = load i64, i64* %loc1
   %13 = icmp slt i64 %12, 0
-  br i1 %13, label %257, label %14
+  br i1 %13, label %325, label %14
 
 ; <label>:14                                      ; preds = %11
   %15 = load i64, i64* %loc1
@@ -577,25 +665,25 @@ entry:
   switch i32 %16, label %17 [
     i32 0, label %18
     i32 1, label %19
-    i32 2, label %25
-    i32 3, label %33
-    i32 4, label %48
-    i32 5, label %54
-    i32 6, label %67
-    i32 7, label %82
-    i32 8, label %104
-    i32 9, label %110
-    i32 10, label %123
-    i32 11, label %138
-    i32 12, label %160
-    i32 13, label %173
-    i32 14, label %193
-    i32 15, label %215
-    i32 16, label %244
+    i32 2, label %27
+    i32 3, label %37
+    i32 4, label %56
+    i32 5, label %64
+    i32 6, label %81
+    i32 7, label %100
+    i32 8, label %128
+    i32 9, label %136
+    i32 10, label %153
+    i32 11, label %172
+    i32 12, label %200
+    i32 13, label %217
+    i32 14, label %243
+    i32 15, label %271
+    i32 16, label %308
   ]
 
 ; <label>:17                                      ; preds = %14
-  br label %257
+  br label %325
 
 ; <label>:18                                      ; preds = %14
   ret void
@@ -603,519 +691,1207 @@ entry:
 ; <label>:19                                      ; preds = %14
   %20 = load i8*, i8** %arg0
   %21 = load i8*, i8** %arg1
-  %22 = load i8, i8* %21, align 8
-  %23 = zext i8 %22 to i32
-  %24 = trunc i32 %23 to i8
-  store i8 %24, i8* %20, align 8
+  %NullCheck132 = icmp ne i8* %21, null
+  br i1 %NullCheck132, label %22, label %ThrowNullRef131
+
+; <label>:22                                      ; preds = %19
+  %23 = load i8, i8* %21, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %NullCheck134 = icmp ne i8* %20, null
+  br i1 %NullCheck134, label %26, label %ThrowNullRef133
+
+; <label>:26                                      ; preds = %22
+  store i8 %25, i8* %20, align 8
   ret void
 
-; <label>:25                                      ; preds = %14
-  %26 = load i8*, i8** %arg0
-  %27 = load i8*, i8** %arg1
-  %28 = bitcast i8* %27 to i16*
-  %29 = load i16, i16* %28, align 8
-  %30 = sext i16 %29 to i32
-  %31 = bitcast i8* %26 to i16*
-  %32 = trunc i32 %30 to i16
-  store i16 %32, i16* %31, align 8
+; <label>:27                                      ; preds = %14
+  %28 = load i8*, i8** %arg0
+  %29 = load i8*, i8** %arg1
+  %30 = bitcast i8* %29 to i16*
+  %NullCheck128 = icmp ne i16* %30, null
+  br i1 %NullCheck128, label %31, label %ThrowNullRef127
+
+; <label>:31                                      ; preds = %27
+  %32 = load i16, i16* %30, align 8
+  %33 = sext i16 %32 to i32
+  %34 = bitcast i8* %28 to i16*
+  %35 = trunc i32 %33 to i16
+  %NullCheck130 = icmp ne i16* %34, null
+  br i1 %NullCheck130, label %36, label %ThrowNullRef129
+
+; <label>:36                                      ; preds = %31
+  store i16 %35, i16* %34, align 8
   ret void
 
-; <label>:33                                      ; preds = %14
-  %34 = load i8*, i8** %arg0
-  %35 = load i8*, i8** %arg1
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = sext i16 %37 to i32
-  %39 = bitcast i8* %34 to i16*
-  %40 = trunc i32 %38 to i16
-  store i16 %40, i16* %39, align 8
-  %41 = load i8*, i8** %arg0
-  %42 = getelementptr inbounds i8, i8* %41, i64 2
-  %43 = load i8*, i8** %arg1
-  %44 = getelementptr inbounds i8, i8* %43, i64 2
-  %45 = load i8, i8* %44, align 8
-  %46 = zext i8 %45 to i32
-  %47 = trunc i32 %46 to i8
-  store i8 %47, i8* %42, align 8
+; <label>:37                                      ; preds = %14
+  %38 = load i8*, i8** %arg0
+  %39 = load i8*, i8** %arg1
+  %40 = bitcast i8* %39 to i16*
+  %NullCheck120 = icmp ne i16* %40, null
+  br i1 %NullCheck120, label %41, label %ThrowNullRef119
+
+; <label>:41                                      ; preds = %37
+  %42 = load i16, i16* %40, align 8
+  %43 = sext i16 %42 to i32
+  %44 = bitcast i8* %38 to i16*
+  %45 = trunc i32 %43 to i16
+  %NullCheck122 = icmp ne i16* %44, null
+  br i1 %NullCheck122, label %46, label %ThrowNullRef121
+
+; <label>:46                                      ; preds = %41
+  store i16 %45, i16* %44, align 8
+  %47 = load i8*, i8** %arg0
+  %48 = getelementptr inbounds i8, i8* %47, i64 2
+  %49 = load i8*, i8** %arg1
+  %50 = getelementptr inbounds i8, i8* %49, i64 2
+  %NullCheck124 = icmp ne i8* %50, null
+  br i1 %NullCheck124, label %51, label %ThrowNullRef123
+
+; <label>:51                                      ; preds = %46
+  %52 = load i8, i8* %50, align 8
+  %53 = zext i8 %52 to i32
+  %54 = trunc i32 %53 to i8
+  %NullCheck126 = icmp ne i8* %48, null
+  br i1 %NullCheck126, label %55, label %ThrowNullRef125
+
+; <label>:55                                      ; preds = %51
+  store i8 %54, i8* %48, align 8
   ret void
 
-; <label>:48                                      ; preds = %14
-  %49 = load i8*, i8** %arg0
-  %50 = load i8*, i8** %arg1
-  %51 = bitcast i8* %50 to i32*
-  %52 = load i32, i32* %51, align 8
-  %53 = bitcast i8* %49 to i32*
-  store i32 %52, i32* %53, align 8
+; <label>:56                                      ; preds = %14
+  %57 = load i8*, i8** %arg0
+  %58 = load i8*, i8** %arg1
+  %59 = bitcast i8* %58 to i32*
+  %NullCheck116 = icmp ne i32* %59, null
+  br i1 %NullCheck116, label %60, label %ThrowNullRef115
+
+; <label>:60                                      ; preds = %56
+  %61 = load i32, i32* %59, align 8
+  %62 = bitcast i8* %57 to i32*
+  %NullCheck118 = icmp ne i32* %62, null
+  br i1 %NullCheck118, label %63, label %ThrowNullRef117
+
+; <label>:63                                      ; preds = %60
+  store i32 %61, i32* %62, align 8
   ret void
 
-; <label>:54                                      ; preds = %14
-  %55 = load i8*, i8** %arg0
-  %56 = load i8*, i8** %arg1
-  %57 = bitcast i8* %56 to i32*
-  %58 = load i32, i32* %57, align 8
-  %59 = bitcast i8* %55 to i32*
-  store i32 %58, i32* %59, align 8
-  %60 = load i8*, i8** %arg0
-  %61 = getelementptr inbounds i8, i8* %60, i64 4
-  %62 = load i8*, i8** %arg1
-  %63 = getelementptr inbounds i8, i8* %62, i64 4
-  %64 = load i8, i8* %63, align 8
-  %65 = zext i8 %64 to i32
-  %66 = trunc i32 %65 to i8
-  store i8 %66, i8* %61, align 8
+; <label>:64                                      ; preds = %14
+  %65 = load i8*, i8** %arg0
+  %66 = load i8*, i8** %arg1
+  %67 = bitcast i8* %66 to i32*
+  %NullCheck108 = icmp ne i32* %67, null
+  br i1 %NullCheck108, label %68, label %ThrowNullRef107
+
+; <label>:68                                      ; preds = %64
+  %69 = load i32, i32* %67, align 8
+  %70 = bitcast i8* %65 to i32*
+  %NullCheck110 = icmp ne i32* %70, null
+  br i1 %NullCheck110, label %71, label %ThrowNullRef109
+
+; <label>:71                                      ; preds = %68
+  store i32 %69, i32* %70, align 8
+  %72 = load i8*, i8** %arg0
+  %73 = getelementptr inbounds i8, i8* %72, i64 4
+  %74 = load i8*, i8** %arg1
+  %75 = getelementptr inbounds i8, i8* %74, i64 4
+  %NullCheck112 = icmp ne i8* %75, null
+  br i1 %NullCheck112, label %76, label %ThrowNullRef111
+
+; <label>:76                                      ; preds = %71
+  %77 = load i8, i8* %75, align 8
+  %78 = zext i8 %77 to i32
+  %79 = trunc i32 %78 to i8
+  %NullCheck114 = icmp ne i8* %73, null
+  br i1 %NullCheck114, label %80, label %ThrowNullRef113
+
+; <label>:80                                      ; preds = %76
+  store i8 %79, i8* %73, align 8
   ret void
 
-; <label>:67                                      ; preds = %14
-  %68 = load i8*, i8** %arg0
-  %69 = load i8*, i8** %arg1
-  %70 = bitcast i8* %69 to i32*
-  %71 = load i32, i32* %70, align 8
-  %72 = bitcast i8* %68 to i32*
-  store i32 %71, i32* %72, align 8
-  %73 = load i8*, i8** %arg0
-  %74 = getelementptr inbounds i8, i8* %73, i64 4
-  %75 = load i8*, i8** %arg1
-  %76 = getelementptr inbounds i8, i8* %75, i64 4
-  %77 = bitcast i8* %76 to i16*
-  %78 = load i16, i16* %77, align 8
-  %79 = sext i16 %78 to i32
-  %80 = bitcast i8* %74 to i16*
-  %81 = trunc i32 %79 to i16
-  store i16 %81, i16* %80, align 8
-  ret void
+; <label>:81                                      ; preds = %14
+  %82 = load i8*, i8** %arg0
+  %83 = load i8*, i8** %arg1
+  %84 = bitcast i8* %83 to i32*
+  %NullCheck100 = icmp ne i32* %84, null
+  br i1 %NullCheck100, label %85, label %ThrowNullRef99
 
-; <label>:82                                      ; preds = %14
-  %83 = load i8*, i8** %arg0
-  %84 = load i8*, i8** %arg1
-  %85 = bitcast i8* %84 to i32*
-  %86 = load i32, i32* %85, align 8
-  %87 = bitcast i8* %83 to i32*
+; <label>:85                                      ; preds = %81
+  %86 = load i32, i32* %84, align 8
+  %87 = bitcast i8* %82 to i32*
+  %NullCheck102 = icmp ne i32* %87, null
+  br i1 %NullCheck102, label %88, label %ThrowNullRef101
+
+; <label>:88                                      ; preds = %85
   store i32 %86, i32* %87, align 8
-  %88 = load i8*, i8** %arg0
-  %89 = getelementptr inbounds i8, i8* %88, i64 4
-  %90 = load i8*, i8** %arg1
-  %91 = getelementptr inbounds i8, i8* %90, i64 4
-  %92 = bitcast i8* %91 to i16*
-  %93 = load i16, i16* %92, align 8
-  %94 = sext i16 %93 to i32
-  %95 = bitcast i8* %89 to i16*
-  %96 = trunc i32 %94 to i16
-  store i16 %96, i16* %95, align 8
-  %97 = load i8*, i8** %arg0
-  %98 = getelementptr inbounds i8, i8* %97, i64 6
-  %99 = load i8*, i8** %arg1
-  %100 = getelementptr inbounds i8, i8* %99, i64 6
-  %101 = load i8, i8* %100, align 8
-  %102 = zext i8 %101 to i32
-  %103 = trunc i32 %102 to i8
-  store i8 %103, i8* %98, align 8
+  %89 = load i8*, i8** %arg0
+  %90 = getelementptr inbounds i8, i8* %89, i64 4
+  %91 = load i8*, i8** %arg1
+  %92 = getelementptr inbounds i8, i8* %91, i64 4
+  %93 = bitcast i8* %92 to i16*
+  %NullCheck104 = icmp ne i16* %93, null
+  br i1 %NullCheck104, label %94, label %ThrowNullRef103
+
+; <label>:94                                      ; preds = %88
+  %95 = load i16, i16* %93, align 8
+  %96 = sext i16 %95 to i32
+  %97 = bitcast i8* %90 to i16*
+  %98 = trunc i32 %96 to i16
+  %NullCheck106 = icmp ne i16* %97, null
+  br i1 %NullCheck106, label %99, label %ThrowNullRef105
+
+; <label>:99                                      ; preds = %94
+  store i16 %98, i16* %97, align 8
   ret void
 
-; <label>:104                                     ; preds = %14
-  %105 = load i8*, i8** %arg0
-  %106 = load i8*, i8** %arg1
-  %107 = bitcast i8* %106 to i64*
-  %108 = load i64, i64* %107, align 8
-  %109 = bitcast i8* %105 to i64*
-  store i64 %108, i64* %109, align 8
+; <label>:100                                     ; preds = %14
+  %101 = load i8*, i8** %arg0
+  %102 = load i8*, i8** %arg1
+  %103 = bitcast i8* %102 to i32*
+  %NullCheck88 = icmp ne i32* %103, null
+  br i1 %NullCheck88, label %104, label %ThrowNullRef87
+
+; <label>:104                                     ; preds = %100
+  %105 = load i32, i32* %103, align 8
+  %106 = bitcast i8* %101 to i32*
+  %NullCheck90 = icmp ne i32* %106, null
+  br i1 %NullCheck90, label %107, label %ThrowNullRef89
+
+; <label>:107                                     ; preds = %104
+  store i32 %105, i32* %106, align 8
+  %108 = load i8*, i8** %arg0
+  %109 = getelementptr inbounds i8, i8* %108, i64 4
+  %110 = load i8*, i8** %arg1
+  %111 = getelementptr inbounds i8, i8* %110, i64 4
+  %112 = bitcast i8* %111 to i16*
+  %NullCheck92 = icmp ne i16* %112, null
+  br i1 %NullCheck92, label %113, label %ThrowNullRef91
+
+; <label>:113                                     ; preds = %107
+  %114 = load i16, i16* %112, align 8
+  %115 = sext i16 %114 to i32
+  %116 = bitcast i8* %109 to i16*
+  %117 = trunc i32 %115 to i16
+  %NullCheck94 = icmp ne i16* %116, null
+  br i1 %NullCheck94, label %118, label %ThrowNullRef93
+
+; <label>:118                                     ; preds = %113
+  store i16 %117, i16* %116, align 8
+  %119 = load i8*, i8** %arg0
+  %120 = getelementptr inbounds i8, i8* %119, i64 6
+  %121 = load i8*, i8** %arg1
+  %122 = getelementptr inbounds i8, i8* %121, i64 6
+  %NullCheck96 = icmp ne i8* %122, null
+  br i1 %NullCheck96, label %123, label %ThrowNullRef95
+
+; <label>:123                                     ; preds = %118
+  %124 = load i8, i8* %122, align 8
+  %125 = zext i8 %124 to i32
+  %126 = trunc i32 %125 to i8
+  %NullCheck98 = icmp ne i8* %120, null
+  br i1 %NullCheck98, label %127, label %ThrowNullRef97
+
+; <label>:127                                     ; preds = %123
+  store i8 %126, i8* %120, align 8
   ret void
 
-; <label>:110                                     ; preds = %14
-  %111 = load i8*, i8** %arg0
-  %112 = load i8*, i8** %arg1
-  %113 = bitcast i8* %112 to i64*
-  %114 = load i64, i64* %113, align 8
-  %115 = bitcast i8* %111 to i64*
-  store i64 %114, i64* %115, align 8
-  %116 = load i8*, i8** %arg0
-  %117 = getelementptr inbounds i8, i8* %116, i64 8
-  %118 = load i8*, i8** %arg1
-  %119 = getelementptr inbounds i8, i8* %118, i64 8
-  %120 = load i8, i8* %119, align 8
-  %121 = zext i8 %120 to i32
-  %122 = trunc i32 %121 to i8
-  store i8 %122, i8* %117, align 8
-  ret void
-
-; <label>:123                                     ; preds = %14
-  %124 = load i8*, i8** %arg0
-  %125 = load i8*, i8** %arg1
-  %126 = bitcast i8* %125 to i64*
-  %127 = load i64, i64* %126, align 8
-  %128 = bitcast i8* %124 to i64*
-  store i64 %127, i64* %128, align 8
+; <label>:128                                     ; preds = %14
   %129 = load i8*, i8** %arg0
-  %130 = getelementptr inbounds i8, i8* %129, i64 8
-  %131 = load i8*, i8** %arg1
-  %132 = getelementptr inbounds i8, i8* %131, i64 8
-  %133 = bitcast i8* %132 to i16*
-  %134 = load i16, i16* %133, align 8
-  %135 = sext i16 %134 to i32
-  %136 = bitcast i8* %130 to i16*
-  %137 = trunc i32 %135 to i16
-  store i16 %137, i16* %136, align 8
+  %130 = load i8*, i8** %arg1
+  %131 = bitcast i8* %130 to i64*
+  %NullCheck84 = icmp ne i64* %131, null
+  br i1 %NullCheck84, label %132, label %ThrowNullRef83
+
+; <label>:132                                     ; preds = %128
+  %133 = load i64, i64* %131, align 8
+  %134 = bitcast i8* %129 to i64*
+  %NullCheck86 = icmp ne i64* %134, null
+  br i1 %NullCheck86, label %135, label %ThrowNullRef85
+
+; <label>:135                                     ; preds = %132
+  store i64 %133, i64* %134, align 8
   ret void
 
-; <label>:138                                     ; preds = %14
-  %139 = load i8*, i8** %arg0
-  %140 = load i8*, i8** %arg1
-  %141 = bitcast i8* %140 to i64*
-  %142 = load i64, i64* %141, align 8
-  %143 = bitcast i8* %139 to i64*
-  store i64 %142, i64* %143, align 8
+; <label>:136                                     ; preds = %14
+  %137 = load i8*, i8** %arg0
+  %138 = load i8*, i8** %arg1
+  %139 = bitcast i8* %138 to i64*
+  %NullCheck76 = icmp ne i64* %139, null
+  br i1 %NullCheck76, label %140, label %ThrowNullRef75
+
+; <label>:140                                     ; preds = %136
+  %141 = load i64, i64* %139, align 8
+  %142 = bitcast i8* %137 to i64*
+  %NullCheck78 = icmp ne i64* %142, null
+  br i1 %NullCheck78, label %143, label %ThrowNullRef77
+
+; <label>:143                                     ; preds = %140
+  store i64 %141, i64* %142, align 8
   %144 = load i8*, i8** %arg0
   %145 = getelementptr inbounds i8, i8* %144, i64 8
   %146 = load i8*, i8** %arg1
   %147 = getelementptr inbounds i8, i8* %146, i64 8
-  %148 = bitcast i8* %147 to i16*
-  %149 = load i16, i16* %148, align 8
-  %150 = sext i16 %149 to i32
-  %151 = bitcast i8* %145 to i16*
-  %152 = trunc i32 %150 to i16
-  store i16 %152, i16* %151, align 8
-  %153 = load i8*, i8** %arg0
-  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %NullCheck80 = icmp ne i8* %147, null
+  br i1 %NullCheck80, label %148, label %ThrowNullRef79
+
+; <label>:148                                     ; preds = %143
+  %149 = load i8, i8* %147, align 8
+  %150 = zext i8 %149 to i32
+  %151 = trunc i32 %150 to i8
+  %NullCheck82 = icmp ne i8* %145, null
+  br i1 %NullCheck82, label %152, label %ThrowNullRef81
+
+; <label>:152                                     ; preds = %148
+  store i8 %151, i8* %145, align 8
+  ret void
+
+; <label>:153                                     ; preds = %14
+  %154 = load i8*, i8** %arg0
   %155 = load i8*, i8** %arg1
-  %156 = getelementptr inbounds i8, i8* %155, i64 10
-  %157 = load i8, i8* %156, align 8
-  %158 = zext i8 %157 to i32
-  %159 = trunc i32 %158 to i8
-  store i8 %159, i8* %154, align 8
-  ret void
+  %156 = bitcast i8* %155 to i64*
+  %NullCheck68 = icmp ne i64* %156, null
+  br i1 %NullCheck68, label %157, label %ThrowNullRef67
 
-; <label>:160                                     ; preds = %14
+; <label>:157                                     ; preds = %153
+  %158 = load i64, i64* %156, align 8
+  %159 = bitcast i8* %154 to i64*
+  %NullCheck70 = icmp ne i64* %159, null
+  br i1 %NullCheck70, label %160, label %ThrowNullRef69
+
+; <label>:160                                     ; preds = %157
+  store i64 %158, i64* %159, align 8
   %161 = load i8*, i8** %arg0
-  %162 = load i8*, i8** %arg1
-  %163 = bitcast i8* %162 to i64*
-  %164 = load i64, i64* %163, align 8
-  %165 = bitcast i8* %161 to i64*
-  store i64 %164, i64* %165, align 8
-  %166 = load i8*, i8** %arg0
-  %167 = getelementptr inbounds i8, i8* %166, i64 8
-  %168 = load i8*, i8** %arg1
-  %169 = getelementptr inbounds i8, i8* %168, i64 8
-  %170 = bitcast i8* %169 to i32*
-  %171 = load i32, i32* %170, align 8
-  %172 = bitcast i8* %167 to i32*
-  store i32 %171, i32* %172, align 8
+  %162 = getelementptr inbounds i8, i8* %161, i64 8
+  %163 = load i8*, i8** %arg1
+  %164 = getelementptr inbounds i8, i8* %163, i64 8
+  %165 = bitcast i8* %164 to i16*
+  %NullCheck72 = icmp ne i16* %165, null
+  br i1 %NullCheck72, label %166, label %ThrowNullRef71
+
+; <label>:166                                     ; preds = %160
+  %167 = load i16, i16* %165, align 8
+  %168 = sext i16 %167 to i32
+  %169 = bitcast i8* %162 to i16*
+  %170 = trunc i32 %168 to i16
+  %NullCheck74 = icmp ne i16* %169, null
+  br i1 %NullCheck74, label %171, label %ThrowNullRef73
+
+; <label>:171                                     ; preds = %166
+  store i16 %170, i16* %169, align 8
   ret void
 
-; <label>:173                                     ; preds = %14
-  %174 = load i8*, i8** %arg0
-  %175 = load i8*, i8** %arg1
-  %176 = bitcast i8* %175 to i64*
-  %177 = load i64, i64* %176, align 8
-  %178 = bitcast i8* %174 to i64*
+; <label>:172                                     ; preds = %14
+  %173 = load i8*, i8** %arg0
+  %174 = load i8*, i8** %arg1
+  %175 = bitcast i8* %174 to i64*
+  %NullCheck56 = icmp ne i64* %175, null
+  br i1 %NullCheck56, label %176, label %ThrowNullRef55
+
+; <label>:176                                     ; preds = %172
+  %177 = load i64, i64* %175, align 8
+  %178 = bitcast i8* %173 to i64*
+  %NullCheck58 = icmp ne i64* %178, null
+  br i1 %NullCheck58, label %179, label %ThrowNullRef57
+
+; <label>:179                                     ; preds = %176
   store i64 %177, i64* %178, align 8
-  %179 = load i8*, i8** %arg0
-  %180 = getelementptr inbounds i8, i8* %179, i64 8
-  %181 = load i8*, i8** %arg1
-  %182 = getelementptr inbounds i8, i8* %181, i64 8
-  %183 = bitcast i8* %182 to i32*
-  %184 = load i32, i32* %183, align 8
-  %185 = bitcast i8* %180 to i32*
-  store i32 %184, i32* %185, align 8
-  %186 = load i8*, i8** %arg0
-  %187 = getelementptr inbounds i8, i8* %186, i64 12
-  %188 = load i8*, i8** %arg1
-  %189 = getelementptr inbounds i8, i8* %188, i64 12
-  %190 = load i8, i8* %189, align 8
-  %191 = zext i8 %190 to i32
-  %192 = trunc i32 %191 to i8
-  store i8 %192, i8* %187, align 8
+  %180 = load i8*, i8** %arg0
+  %181 = getelementptr inbounds i8, i8* %180, i64 8
+  %182 = load i8*, i8** %arg1
+  %183 = getelementptr inbounds i8, i8* %182, i64 8
+  %184 = bitcast i8* %183 to i16*
+  %NullCheck60 = icmp ne i16* %184, null
+  br i1 %NullCheck60, label %185, label %ThrowNullRef59
+
+; <label>:185                                     ; preds = %179
+  %186 = load i16, i16* %184, align 8
+  %187 = sext i16 %186 to i32
+  %188 = bitcast i8* %181 to i16*
+  %189 = trunc i32 %187 to i16
+  %NullCheck62 = icmp ne i16* %188, null
+  br i1 %NullCheck62, label %190, label %ThrowNullRef61
+
+; <label>:190                                     ; preds = %185
+  store i16 %189, i16* %188, align 8
+  %191 = load i8*, i8** %arg0
+  %192 = getelementptr inbounds i8, i8* %191, i64 10
+  %193 = load i8*, i8** %arg1
+  %194 = getelementptr inbounds i8, i8* %193, i64 10
+  %NullCheck64 = icmp ne i8* %194, null
+  br i1 %NullCheck64, label %195, label %ThrowNullRef63
+
+; <label>:195                                     ; preds = %190
+  %196 = load i8, i8* %194, align 8
+  %197 = zext i8 %196 to i32
+  %198 = trunc i32 %197 to i8
+  %NullCheck66 = icmp ne i8* %192, null
+  br i1 %NullCheck66, label %199, label %ThrowNullRef65
+
+; <label>:199                                     ; preds = %195
+  store i8 %198, i8* %192, align 8
   ret void
 
-; <label>:193                                     ; preds = %14
-  %194 = load i8*, i8** %arg0
-  %195 = load i8*, i8** %arg1
-  %196 = bitcast i8* %195 to i64*
-  %197 = load i64, i64* %196, align 8
-  %198 = bitcast i8* %194 to i64*
-  store i64 %197, i64* %198, align 8
-  %199 = load i8*, i8** %arg0
-  %200 = getelementptr inbounds i8, i8* %199, i64 8
-  %201 = load i8*, i8** %arg1
-  %202 = getelementptr inbounds i8, i8* %201, i64 8
-  %203 = bitcast i8* %202 to i32*
-  %204 = load i32, i32* %203, align 8
-  %205 = bitcast i8* %200 to i32*
-  store i32 %204, i32* %205, align 8
-  %206 = load i8*, i8** %arg0
-  %207 = getelementptr inbounds i8, i8* %206, i64 12
-  %208 = load i8*, i8** %arg1
-  %209 = getelementptr inbounds i8, i8* %208, i64 12
-  %210 = bitcast i8* %209 to i16*
-  %211 = load i16, i16* %210, align 8
-  %212 = sext i16 %211 to i32
-  %213 = bitcast i8* %207 to i16*
-  %214 = trunc i32 %212 to i16
-  store i16 %214, i16* %213, align 8
+; <label>:200                                     ; preds = %14
+  %201 = load i8*, i8** %arg0
+  %202 = load i8*, i8** %arg1
+  %203 = bitcast i8* %202 to i64*
+  %NullCheck48 = icmp ne i64* %203, null
+  br i1 %NullCheck48, label %204, label %ThrowNullRef47
+
+; <label>:204                                     ; preds = %200
+  %205 = load i64, i64* %203, align 8
+  %206 = bitcast i8* %201 to i64*
+  %NullCheck50 = icmp ne i64* %206, null
+  br i1 %NullCheck50, label %207, label %ThrowNullRef49
+
+; <label>:207                                     ; preds = %204
+  store i64 %205, i64* %206, align 8
+  %208 = load i8*, i8** %arg0
+  %209 = getelementptr inbounds i8, i8* %208, i64 8
+  %210 = load i8*, i8** %arg1
+  %211 = getelementptr inbounds i8, i8* %210, i64 8
+  %212 = bitcast i8* %211 to i32*
+  %NullCheck52 = icmp ne i32* %212, null
+  br i1 %NullCheck52, label %213, label %ThrowNullRef51
+
+; <label>:213                                     ; preds = %207
+  %214 = load i32, i32* %212, align 8
+  %215 = bitcast i8* %209 to i32*
+  %NullCheck54 = icmp ne i32* %215, null
+  br i1 %NullCheck54, label %216, label %ThrowNullRef53
+
+; <label>:216                                     ; preds = %213
+  store i32 %214, i32* %215, align 8
   ret void
 
-; <label>:215                                     ; preds = %14
-  %216 = load i8*, i8** %arg0
-  %217 = load i8*, i8** %arg1
-  %218 = bitcast i8* %217 to i64*
-  %219 = load i64, i64* %218, align 8
-  %220 = bitcast i8* %216 to i64*
-  store i64 %219, i64* %220, align 8
-  %221 = load i8*, i8** %arg0
-  %222 = getelementptr inbounds i8, i8* %221, i64 8
-  %223 = load i8*, i8** %arg1
-  %224 = getelementptr inbounds i8, i8* %223, i64 8
-  %225 = bitcast i8* %224 to i32*
-  %226 = load i32, i32* %225, align 8
-  %227 = bitcast i8* %222 to i32*
-  store i32 %226, i32* %227, align 8
-  %228 = load i8*, i8** %arg0
-  %229 = getelementptr inbounds i8, i8* %228, i64 12
-  %230 = load i8*, i8** %arg1
-  %231 = getelementptr inbounds i8, i8* %230, i64 12
-  %232 = bitcast i8* %231 to i16*
-  %233 = load i16, i16* %232, align 8
-  %234 = sext i16 %233 to i32
-  %235 = bitcast i8* %229 to i16*
-  %236 = trunc i32 %234 to i16
-  store i16 %236, i16* %235, align 8
-  %237 = load i8*, i8** %arg0
-  %238 = getelementptr inbounds i8, i8* %237, i64 14
-  %239 = load i8*, i8** %arg1
-  %240 = getelementptr inbounds i8, i8* %239, i64 14
-  %241 = load i8, i8* %240, align 8
-  %242 = zext i8 %241 to i32
-  %243 = trunc i32 %242 to i8
-  store i8 %243, i8* %238, align 8
+; <label>:217                                     ; preds = %14
+  %218 = load i8*, i8** %arg0
+  %219 = load i8*, i8** %arg1
+  %220 = bitcast i8* %219 to i64*
+  %NullCheck36 = icmp ne i64* %220, null
+  br i1 %NullCheck36, label %221, label %ThrowNullRef35
+
+; <label>:221                                     ; preds = %217
+  %222 = load i64, i64* %220, align 8
+  %223 = bitcast i8* %218 to i64*
+  %NullCheck38 = icmp ne i64* %223, null
+  br i1 %NullCheck38, label %224, label %ThrowNullRef37
+
+; <label>:224                                     ; preds = %221
+  store i64 %222, i64* %223, align 8
+  %225 = load i8*, i8** %arg0
+  %226 = getelementptr inbounds i8, i8* %225, i64 8
+  %227 = load i8*, i8** %arg1
+  %228 = getelementptr inbounds i8, i8* %227, i64 8
+  %229 = bitcast i8* %228 to i32*
+  %NullCheck40 = icmp ne i32* %229, null
+  br i1 %NullCheck40, label %230, label %ThrowNullRef39
+
+; <label>:230                                     ; preds = %224
+  %231 = load i32, i32* %229, align 8
+  %232 = bitcast i8* %226 to i32*
+  %NullCheck42 = icmp ne i32* %232, null
+  br i1 %NullCheck42, label %233, label %ThrowNullRef41
+
+; <label>:233                                     ; preds = %230
+  store i32 %231, i32* %232, align 8
+  %234 = load i8*, i8** %arg0
+  %235 = getelementptr inbounds i8, i8* %234, i64 12
+  %236 = load i8*, i8** %arg1
+  %237 = getelementptr inbounds i8, i8* %236, i64 12
+  %NullCheck44 = icmp ne i8* %237, null
+  br i1 %NullCheck44, label %238, label %ThrowNullRef43
+
+; <label>:238                                     ; preds = %233
+  %239 = load i8, i8* %237, align 8
+  %240 = zext i8 %239 to i32
+  %241 = trunc i32 %240 to i8
+  %NullCheck46 = icmp ne i8* %235, null
+  br i1 %NullCheck46, label %242, label %ThrowNullRef45
+
+; <label>:242                                     ; preds = %238
+  store i8 %241, i8* %235, align 8
   ret void
 
-; <label>:244                                     ; preds = %14
-  %245 = load i8*, i8** %arg0
-  %246 = load i8*, i8** %arg1
-  %247 = bitcast i8* %246 to i64*
-  %248 = load i64, i64* %247, align 8
-  %249 = bitcast i8* %245 to i64*
+; <label>:243                                     ; preds = %14
+  %244 = load i8*, i8** %arg0
+  %245 = load i8*, i8** %arg1
+  %246 = bitcast i8* %245 to i64*
+  %NullCheck24 = icmp ne i64* %246, null
+  br i1 %NullCheck24, label %247, label %ThrowNullRef23
+
+; <label>:247                                     ; preds = %243
+  %248 = load i64, i64* %246, align 8
+  %249 = bitcast i8* %244 to i64*
+  %NullCheck26 = icmp ne i64* %249, null
+  br i1 %NullCheck26, label %250, label %ThrowNullRef25
+
+; <label>:250                                     ; preds = %247
   store i64 %248, i64* %249, align 8
-  %250 = load i8*, i8** %arg0
-  %251 = getelementptr inbounds i8, i8* %250, i64 8
-  %252 = load i8*, i8** %arg1
-  %253 = getelementptr inbounds i8, i8* %252, i64 8
-  %254 = bitcast i8* %253 to i64*
-  %255 = load i64, i64* %254, align 8
-  %256 = bitcast i8* %251 to i64*
-  store i64 %255, i64* %256, align 8
-  ret void
+  %251 = load i8*, i8** %arg0
+  %252 = getelementptr inbounds i8, i8* %251, i64 8
+  %253 = load i8*, i8** %arg1
+  %254 = getelementptr inbounds i8, i8* %253, i64 8
+  %255 = bitcast i8* %254 to i32*
+  %NullCheck28 = icmp ne i32* %255, null
+  br i1 %NullCheck28, label %256, label %ThrowNullRef27
 
-; <label>:257                                     ; preds = %7, %11, %17
-  %258 = load i64, i64* %arg2
-  %259 = icmp uge i64 %258, 512
-  br i1 %259, label %397, label %260
+; <label>:256                                     ; preds = %250
+  %257 = load i32, i32* %255, align 8
+  %258 = bitcast i8* %252 to i32*
+  %NullCheck30 = icmp ne i32* %258, null
+  br i1 %NullCheck30, label %259, label %ThrowNullRef29
 
-; <label>:260                                     ; preds = %257
-  %261 = load i8*, i8** %arg0
-  %262 = ptrtoint i8* %261 to i32
-  %263 = and i32 %262, 3
-  %264 = icmp eq i32 %263, 0
-  br i1 %264, label %300, label %265
+; <label>:259                                     ; preds = %256
+  store i32 %257, i32* %258, align 8
+  %260 = load i8*, i8** %arg0
+  %261 = getelementptr inbounds i8, i8* %260, i64 12
+  %262 = load i8*, i8** %arg1
+  %263 = getelementptr inbounds i8, i8* %262, i64 12
+  %264 = bitcast i8* %263 to i16*
+  %NullCheck32 = icmp ne i16* %264, null
+  br i1 %NullCheck32, label %265, label %ThrowNullRef31
 
-; <label>:265                                     ; preds = %260
-  %266 = load i8*, i8** %arg0
-  %267 = ptrtoint i8* %266 to i32
-  %268 = and i32 %267, 1
-  %269 = icmp eq i32 %268, 0
-  br i1 %269, label %286, label %270
+; <label>:265                                     ; preds = %259
+  %266 = load i16, i16* %264, align 8
+  %267 = sext i16 %266 to i32
+  %268 = bitcast i8* %261 to i16*
+  %269 = trunc i32 %267 to i16
+  %NullCheck34 = icmp ne i16* %268, null
+  br i1 %NullCheck34, label %270, label %ThrowNullRef33
 
 ; <label>:270                                     ; preds = %265
-  %271 = load i8*, i8** %arg0
-  %272 = load i8*, i8** %arg1
-  %273 = load i8, i8* %272, align 8
-  %274 = zext i8 %273 to i32
-  %275 = trunc i32 %274 to i8
-  store i8 %275, i8* %271, align 8
-  %276 = load i8*, i8** %arg1
-  %277 = getelementptr inbounds i8, i8* %276, i64 1
-  store i8* %277, i8** %arg1
-  %278 = load i8*, i8** %arg0
-  %279 = getelementptr inbounds i8, i8* %278, i64 1
-  store i8* %279, i8** %arg0
-  %280 = load i64, i64* %arg2
-  %281 = sub i64 %280, 1
-  store i64 %281, i64* %arg2
-  %282 = load i8*, i8** %arg0
-  %283 = ptrtoint i8* %282 to i32
-  %284 = and i32 %283, 2
-  %285 = icmp eq i32 %284, 0
-  br i1 %285, label %300, label %286
+  store i16 %269, i16* %268, align 8
+  ret void
 
-; <label>:286                                     ; preds = %265, %270
-  %287 = load i8*, i8** %arg0
-  %288 = load i8*, i8** %arg1
-  %289 = bitcast i8* %288 to i16*
-  %290 = load i16, i16* %289, align 8
-  %291 = sext i16 %290 to i32
-  %292 = bitcast i8* %287 to i16*
-  %293 = trunc i32 %291 to i16
-  store i16 %293, i16* %292, align 8
-  %294 = load i8*, i8** %arg1
-  %295 = getelementptr inbounds i8, i8* %294, i64 2
-  store i8* %295, i8** %arg1
-  %296 = load i8*, i8** %arg0
-  %297 = getelementptr inbounds i8, i8* %296, i64 2
-  store i8* %297, i8** %arg0
-  %298 = load i64, i64* %arg2
-  %299 = sub i64 %298, 2
-  store i64 %299, i64* %arg2
-  br label %300
+; <label>:271                                     ; preds = %14
+  %272 = load i8*, i8** %arg0
+  %273 = load i8*, i8** %arg1
+  %274 = bitcast i8* %273 to i64*
+  %NullCheck8 = icmp ne i64* %274, null
+  br i1 %NullCheck8, label %275, label %ThrowNullRef7
 
-; <label>:300                                     ; preds = %260, %270, %286
-  %301 = load i8*, i8** %arg0
-  %302 = ptrtoint i8* %301 to i32
-  %303 = and i32 %302, 4
-  %304 = icmp eq i32 %303, 0
-  br i1 %304, label %317, label %305
+; <label>:275                                     ; preds = %271
+  %276 = load i64, i64* %274, align 8
+  %277 = bitcast i8* %272 to i64*
+  %NullCheck10 = icmp ne i64* %277, null
+  br i1 %NullCheck10, label %278, label %ThrowNullRef9
 
-; <label>:305                                     ; preds = %300
-  %306 = load i8*, i8** %arg0
-  %307 = load i8*, i8** %arg1
-  %308 = bitcast i8* %307 to i32*
-  %309 = load i32, i32* %308, align 8
-  %310 = bitcast i8* %306 to i32*
-  store i32 %309, i32* %310, align 8
-  %311 = load i8*, i8** %arg1
-  %312 = getelementptr inbounds i8, i8* %311, i64 4
-  store i8* %312, i8** %arg1
-  %313 = load i8*, i8** %arg0
-  %314 = getelementptr inbounds i8, i8* %313, i64 4
-  store i8* %314, i8** %arg0
-  %315 = load i64, i64* %arg2
-  %316 = sub i64 %315, 4
-  store i64 %316, i64* %arg2
-  br label %317
+; <label>:278                                     ; preds = %275
+  store i64 %276, i64* %277, align 8
+  %279 = load i8*, i8** %arg0
+  %280 = getelementptr inbounds i8, i8* %279, i64 8
+  %281 = load i8*, i8** %arg1
+  %282 = getelementptr inbounds i8, i8* %281, i64 8
+  %283 = bitcast i8* %282 to i32*
+  %NullCheck12 = icmp ne i32* %283, null
+  br i1 %NullCheck12, label %284, label %ThrowNullRef11
 
-; <label>:317                                     ; preds = %300, %305
-  %318 = load i64, i64* %arg2
-  %319 = udiv i64 %318, 16
-  store i64 %319, i64* %loc0
-  br label %339
+; <label>:284                                     ; preds = %278
+  %285 = load i32, i32* %283, align 8
+  %286 = bitcast i8* %280 to i32*
+  %NullCheck14 = icmp ne i32* %286, null
+  br i1 %NullCheck14, label %287, label %ThrowNullRef13
 
-; <label>:320                                     ; preds = %339
-  %321 = load i8*, i8** %arg0
-  %322 = load i8*, i8** %arg1
-  %323 = bitcast i8* %322 to i64*
-  %324 = load i64, i64* %323, align 8
-  %325 = bitcast i8* %321 to i64*
-  store i64 %324, i64* %325, align 8
-  %326 = load i8*, i8** %arg0
-  %327 = getelementptr inbounds i8, i8* %326, i64 8
-  %328 = load i8*, i8** %arg1
-  %329 = getelementptr inbounds i8, i8* %328, i64 8
-  %330 = bitcast i8* %329 to i64*
-  %331 = load i64, i64* %330, align 8
-  %332 = bitcast i8* %327 to i64*
-  store i64 %331, i64* %332, align 8
-  %333 = load i8*, i8** %arg0
-  %334 = getelementptr inbounds i8, i8* %333, i64 16
-  store i8* %334, i8** %arg0
-  %335 = load i8*, i8** %arg1
-  %336 = getelementptr inbounds i8, i8* %335, i64 16
-  store i8* %336, i8** %arg1
-  %337 = load i64, i64* %loc0
-  %338 = sub i64 %337, 1
-  store i64 %338, i64* %loc0
-  br label %339
+; <label>:287                                     ; preds = %284
+  store i32 %285, i32* %286, align 8
+  %288 = load i8*, i8** %arg0
+  %289 = getelementptr inbounds i8, i8* %288, i64 12
+  %290 = load i8*, i8** %arg1
+  %291 = getelementptr inbounds i8, i8* %290, i64 12
+  %292 = bitcast i8* %291 to i16*
+  %NullCheck16 = icmp ne i16* %292, null
+  br i1 %NullCheck16, label %293, label %ThrowNullRef15
 
-; <label>:339                                     ; preds = %317, %320
-  %340 = load i64, i64* %loc0
-  %341 = icmp ugt i64 %340, 0
-  br i1 %341, label %320, label %342
+; <label>:293                                     ; preds = %287
+  %294 = load i16, i16* %292, align 8
+  %295 = sext i16 %294 to i32
+  %296 = bitcast i8* %289 to i16*
+  %297 = trunc i32 %295 to i16
+  %NullCheck18 = icmp ne i16* %296, null
+  br i1 %NullCheck18, label %298, label %ThrowNullRef17
 
-; <label>:342                                     ; preds = %339
-  %343 = load i64, i64* %arg2
-  %344 = and i64 %343, 8
-  %345 = icmp eq i64 %344, 0
-  br i1 %345, label %356, label %346
+; <label>:298                                     ; preds = %293
+  store i16 %297, i16* %296, align 8
+  %299 = load i8*, i8** %arg0
+  %300 = getelementptr inbounds i8, i8* %299, i64 14
+  %301 = load i8*, i8** %arg1
+  %302 = getelementptr inbounds i8, i8* %301, i64 14
+  %NullCheck20 = icmp ne i8* %302, null
+  br i1 %NullCheck20, label %303, label %ThrowNullRef19
 
-; <label>:346                                     ; preds = %342
-  %347 = load i8*, i8** %arg0
-  %348 = load i8*, i8** %arg1
-  %349 = bitcast i8* %348 to i64*
-  %350 = load i64, i64* %349, align 8
-  %351 = bitcast i8* %347 to i64*
-  store i64 %350, i64* %351, align 8
+; <label>:303                                     ; preds = %298
+  %304 = load i8, i8* %302, align 8
+  %305 = zext i8 %304 to i32
+  %306 = trunc i32 %305 to i8
+  %NullCheck22 = icmp ne i8* %300, null
+  br i1 %NullCheck22, label %307, label %ThrowNullRef21
+
+; <label>:307                                     ; preds = %303
+  store i8 %306, i8* %300, align 8
+  ret void
+
+; <label>:308                                     ; preds = %14
+  %309 = load i8*, i8** %arg0
+  %310 = load i8*, i8** %arg1
+  %311 = bitcast i8* %310 to i64*
+  %NullCheck = icmp ne i64* %311, null
+  br i1 %NullCheck, label %312, label %ThrowNullRef
+
+; <label>:312                                     ; preds = %308
+  %313 = load i64, i64* %311, align 8
+  %314 = bitcast i8* %309 to i64*
+  %NullCheck2 = icmp ne i64* %314, null
+  br i1 %NullCheck2, label %315, label %ThrowNullRef1
+
+; <label>:315                                     ; preds = %312
+  store i64 %313, i64* %314, align 8
+  %316 = load i8*, i8** %arg0
+  %317 = getelementptr inbounds i8, i8* %316, i64 8
+  %318 = load i8*, i8** %arg1
+  %319 = getelementptr inbounds i8, i8* %318, i64 8
+  %320 = bitcast i8* %319 to i64*
+  %NullCheck4 = icmp ne i64* %320, null
+  br i1 %NullCheck4, label %321, label %ThrowNullRef3
+
+; <label>:321                                     ; preds = %315
+  %322 = load i64, i64* %320, align 8
+  %323 = bitcast i8* %317 to i64*
+  %NullCheck6 = icmp ne i64* %323, null
+  br i1 %NullCheck6, label %324, label %ThrowNullRef5
+
+; <label>:324                                     ; preds = %321
+  store i64 %322, i64* %323, align 8
+  ret void
+
+; <label>:325                                     ; preds = %7, %11, %17
+  %326 = load i64, i64* %arg2
+  %327 = icmp uge i64 %326, 512
+  br i1 %327, label %483, label %328
+
+; <label>:328                                     ; preds = %325
+  %329 = load i8*, i8** %arg0
+  %330 = ptrtoint i8* %329 to i32
+  %331 = and i32 %330, 3
+  %332 = icmp eq i32 %331, 0
+  br i1 %332, label %372, label %333
+
+; <label>:333                                     ; preds = %328
+  %334 = load i8*, i8** %arg0
+  %335 = ptrtoint i8* %334 to i32
+  %336 = and i32 %335, 1
+  %337 = icmp eq i32 %336, 0
+  br i1 %337, label %356, label %338
+
+; <label>:338                                     ; preds = %333
+  %339 = load i8*, i8** %arg0
+  %340 = load i8*, i8** %arg1
+  %NullCheck136 = icmp ne i8* %340, null
+  br i1 %NullCheck136, label %341, label %ThrowNullRef135
+
+; <label>:341                                     ; preds = %338
+  %342 = load i8, i8* %340, align 8
+  %343 = zext i8 %342 to i32
+  %344 = trunc i32 %343 to i8
+  %NullCheck138 = icmp ne i8* %339, null
+  br i1 %NullCheck138, label %345, label %ThrowNullRef137
+
+; <label>:345                                     ; preds = %341
+  store i8 %344, i8* %339, align 8
+  %346 = load i8*, i8** %arg1
+  %347 = getelementptr inbounds i8, i8* %346, i64 1
+  store i8* %347, i8** %arg1
+  %348 = load i8*, i8** %arg0
+  %349 = getelementptr inbounds i8, i8* %348, i64 1
+  store i8* %349, i8** %arg0
+  %350 = load i64, i64* %arg2
+  %351 = sub i64 %350, 1
+  store i64 %351, i64* %arg2
   %352 = load i8*, i8** %arg0
-  %353 = getelementptr inbounds i8, i8* %352, i64 8
-  store i8* %353, i8** %arg0
-  %354 = load i8*, i8** %arg1
-  %355 = getelementptr inbounds i8, i8* %354, i64 8
-  store i8* %355, i8** %arg1
-  br label %356
+  %353 = ptrtoint i8* %352 to i32
+  %354 = and i32 %353, 2
+  %355 = icmp eq i32 %354, 0
+  br i1 %355, label %372, label %356
 
-; <label>:356                                     ; preds = %342, %346
-  %357 = load i64, i64* %arg2
-  %358 = and i64 %357, 4
-  %359 = icmp eq i64 %358, 0
-  br i1 %359, label %370, label %360
+; <label>:356                                     ; preds = %333, %345
+  %357 = load i8*, i8** %arg0
+  %358 = load i8*, i8** %arg1
+  %359 = bitcast i8* %358 to i16*
+  %NullCheck140 = icmp ne i16* %359, null
+  br i1 %NullCheck140, label %360, label %ThrowNullRef139
 
 ; <label>:360                                     ; preds = %356
-  %361 = load i8*, i8** %arg0
-  %362 = load i8*, i8** %arg1
-  %363 = bitcast i8* %362 to i32*
-  %364 = load i32, i32* %363, align 8
-  %365 = bitcast i8* %361 to i32*
-  store i32 %364, i32* %365, align 8
-  %366 = load i8*, i8** %arg0
-  %367 = getelementptr inbounds i8, i8* %366, i64 4
-  store i8* %367, i8** %arg0
-  %368 = load i8*, i8** %arg1
-  %369 = getelementptr inbounds i8, i8* %368, i64 4
-  store i8* %369, i8** %arg1
-  br label %370
+  %361 = load i16, i16* %359, align 8
+  %362 = sext i16 %361 to i32
+  %363 = bitcast i8* %357 to i16*
+  %364 = trunc i32 %362 to i16
+  %NullCheck142 = icmp ne i16* %363, null
+  br i1 %NullCheck142, label %365, label %ThrowNullRef141
 
-; <label>:370                                     ; preds = %356, %360
-  %371 = load i64, i64* %arg2
-  %372 = and i64 %371, 2
-  %373 = icmp eq i64 %372, 0
-  br i1 %373, label %386, label %374
+; <label>:365                                     ; preds = %360
+  store i16 %364, i16* %363, align 8
+  %366 = load i8*, i8** %arg1
+  %367 = getelementptr inbounds i8, i8* %366, i64 2
+  store i8* %367, i8** %arg1
+  %368 = load i8*, i8** %arg0
+  %369 = getelementptr inbounds i8, i8* %368, i64 2
+  store i8* %369, i8** %arg0
+  %370 = load i64, i64* %arg2
+  %371 = sub i64 %370, 2
+  store i64 %371, i64* %arg2
+  br label %372
 
-; <label>:374                                     ; preds = %370
-  %375 = load i8*, i8** %arg0
-  %376 = load i8*, i8** %arg1
-  %377 = bitcast i8* %376 to i16*
-  %378 = load i16, i16* %377, align 8
-  %379 = sext i16 %378 to i32
-  %380 = bitcast i8* %375 to i16*
-  %381 = trunc i32 %379 to i16
-  store i16 %381, i16* %380, align 8
-  %382 = load i8*, i8** %arg0
-  %383 = getelementptr inbounds i8, i8* %382, i64 2
-  store i8* %383, i8** %arg0
-  %384 = load i8*, i8** %arg1
-  %385 = getelementptr inbounds i8, i8* %384, i64 2
-  store i8* %385, i8** %arg1
-  br label %386
+; <label>:372                                     ; preds = %328, %345, %365
+  %373 = load i8*, i8** %arg0
+  %374 = ptrtoint i8* %373 to i32
+  %375 = and i32 %374, 4
+  %376 = icmp eq i32 %375, 0
+  br i1 %376, label %391, label %377
 
-; <label>:386                                     ; preds = %370, %374
-  %387 = load i64, i64* %arg2
-  %388 = and i64 %387, 1
-  %389 = icmp eq i64 %388, 0
-  br i1 %389, label %396, label %390
+; <label>:377                                     ; preds = %372
+  %378 = load i8*, i8** %arg0
+  %379 = load i8*, i8** %arg1
+  %380 = bitcast i8* %379 to i32*
+  %NullCheck144 = icmp ne i32* %380, null
+  br i1 %NullCheck144, label %381, label %ThrowNullRef143
 
-; <label>:390                                     ; preds = %386
-  %391 = load i8*, i8** %arg0
-  %392 = load i8*, i8** %arg1
-  %393 = load i8, i8* %392, align 8
-  %394 = zext i8 %393 to i32
-  %395 = trunc i32 %394 to i8
-  store i8 %395, i8* %391, align 8
-  br label %396
+; <label>:381                                     ; preds = %377
+  %382 = load i32, i32* %380, align 8
+  %383 = bitcast i8* %378 to i32*
+  %NullCheck146 = icmp ne i32* %383, null
+  br i1 %NullCheck146, label %384, label %ThrowNullRef145
 
-; <label>:396                                     ; preds = %386, %390
+; <label>:384                                     ; preds = %381
+  store i32 %382, i32* %383, align 8
+  %385 = load i8*, i8** %arg1
+  %386 = getelementptr inbounds i8, i8* %385, i64 4
+  store i8* %386, i8** %arg1
+  %387 = load i8*, i8** %arg0
+  %388 = getelementptr inbounds i8, i8* %387, i64 4
+  store i8* %388, i8** %arg0
+  %389 = load i64, i64* %arg2
+  %390 = sub i64 %389, 4
+  store i64 %390, i64* %arg2
+  br label %391
+
+; <label>:391                                     ; preds = %372, %384
+  %392 = load i64, i64* %arg2
+  %393 = udiv i64 %392, 16
+  store i64 %393, i64* %loc0
+  br label %417
+
+; <label>:394                                     ; preds = %417
+  %395 = load i8*, i8** %arg0
+  %396 = load i8*, i8** %arg1
+  %397 = bitcast i8* %396 to i64*
+  %NullCheck164 = icmp ne i64* %397, null
+  br i1 %NullCheck164, label %398, label %ThrowNullRef163
+
+; <label>:398                                     ; preds = %394
+  %399 = load i64, i64* %397, align 8
+  %400 = bitcast i8* %395 to i64*
+  %NullCheck166 = icmp ne i64* %400, null
+  br i1 %NullCheck166, label %401, label %ThrowNullRef165
+
+; <label>:401                                     ; preds = %398
+  store i64 %399, i64* %400, align 8
+  %402 = load i8*, i8** %arg0
+  %403 = getelementptr inbounds i8, i8* %402, i64 8
+  %404 = load i8*, i8** %arg1
+  %405 = getelementptr inbounds i8, i8* %404, i64 8
+  %406 = bitcast i8* %405 to i64*
+  %NullCheck168 = icmp ne i64* %406, null
+  br i1 %NullCheck168, label %407, label %ThrowNullRef167
+
+; <label>:407                                     ; preds = %401
+  %408 = load i64, i64* %406, align 8
+  %409 = bitcast i8* %403 to i64*
+  %NullCheck170 = icmp ne i64* %409, null
+  br i1 %NullCheck170, label %410, label %ThrowNullRef169
+
+; <label>:410                                     ; preds = %407
+  store i64 %408, i64* %409, align 8
+  %411 = load i8*, i8** %arg0
+  %412 = getelementptr inbounds i8, i8* %411, i64 16
+  store i8* %412, i8** %arg0
+  %413 = load i8*, i8** %arg1
+  %414 = getelementptr inbounds i8, i8* %413, i64 16
+  store i8* %414, i8** %arg1
+  %415 = load i64, i64* %loc0
+  %416 = sub i64 %415, 1
+  store i64 %416, i64* %loc0
+  br label %417
+
+; <label>:417                                     ; preds = %391, %410
+  %418 = load i64, i64* %loc0
+  %419 = icmp ugt i64 %418, 0
+  br i1 %419, label %394, label %420
+
+; <label>:420                                     ; preds = %417
+  %421 = load i64, i64* %arg2
+  %422 = and i64 %421, 8
+  %423 = icmp eq i64 %422, 0
+  br i1 %423, label %436, label %424
+
+; <label>:424                                     ; preds = %420
+  %425 = load i8*, i8** %arg0
+  %426 = load i8*, i8** %arg1
+  %427 = bitcast i8* %426 to i64*
+  %NullCheck148 = icmp ne i64* %427, null
+  br i1 %NullCheck148, label %428, label %ThrowNullRef147
+
+; <label>:428                                     ; preds = %424
+  %429 = load i64, i64* %427, align 8
+  %430 = bitcast i8* %425 to i64*
+  %NullCheck150 = icmp ne i64* %430, null
+  br i1 %NullCheck150, label %431, label %ThrowNullRef149
+
+; <label>:431                                     ; preds = %428
+  store i64 %429, i64* %430, align 8
+  %432 = load i8*, i8** %arg0
+  %433 = getelementptr inbounds i8, i8* %432, i64 8
+  store i8* %433, i8** %arg0
+  %434 = load i8*, i8** %arg1
+  %435 = getelementptr inbounds i8, i8* %434, i64 8
+  store i8* %435, i8** %arg1
+  br label %436
+
+; <label>:436                                     ; preds = %420, %431
+  %437 = load i64, i64* %arg2
+  %438 = and i64 %437, 4
+  %439 = icmp eq i64 %438, 0
+  br i1 %439, label %452, label %440
+
+; <label>:440                                     ; preds = %436
+  %441 = load i8*, i8** %arg0
+  %442 = load i8*, i8** %arg1
+  %443 = bitcast i8* %442 to i32*
+  %NullCheck152 = icmp ne i32* %443, null
+  br i1 %NullCheck152, label %444, label %ThrowNullRef151
+
+; <label>:444                                     ; preds = %440
+  %445 = load i32, i32* %443, align 8
+  %446 = bitcast i8* %441 to i32*
+  %NullCheck154 = icmp ne i32* %446, null
+  br i1 %NullCheck154, label %447, label %ThrowNullRef153
+
+; <label>:447                                     ; preds = %444
+  store i32 %445, i32* %446, align 8
+  %448 = load i8*, i8** %arg0
+  %449 = getelementptr inbounds i8, i8* %448, i64 4
+  store i8* %449, i8** %arg0
+  %450 = load i8*, i8** %arg1
+  %451 = getelementptr inbounds i8, i8* %450, i64 4
+  store i8* %451, i8** %arg1
+  br label %452
+
+; <label>:452                                     ; preds = %436, %447
+  %453 = load i64, i64* %arg2
+  %454 = and i64 %453, 2
+  %455 = icmp eq i64 %454, 0
+  br i1 %455, label %470, label %456
+
+; <label>:456                                     ; preds = %452
+  %457 = load i8*, i8** %arg0
+  %458 = load i8*, i8** %arg1
+  %459 = bitcast i8* %458 to i16*
+  %NullCheck156 = icmp ne i16* %459, null
+  br i1 %NullCheck156, label %460, label %ThrowNullRef155
+
+; <label>:460                                     ; preds = %456
+  %461 = load i16, i16* %459, align 8
+  %462 = sext i16 %461 to i32
+  %463 = bitcast i8* %457 to i16*
+  %464 = trunc i32 %462 to i16
+  %NullCheck158 = icmp ne i16* %463, null
+  br i1 %NullCheck158, label %465, label %ThrowNullRef157
+
+; <label>:465                                     ; preds = %460
+  store i16 %464, i16* %463, align 8
+  %466 = load i8*, i8** %arg0
+  %467 = getelementptr inbounds i8, i8* %466, i64 2
+  store i8* %467, i8** %arg0
+  %468 = load i8*, i8** %arg1
+  %469 = getelementptr inbounds i8, i8* %468, i64 2
+  store i8* %469, i8** %arg1
+  br label %470
+
+; <label>:470                                     ; preds = %452, %465
+  %471 = load i64, i64* %arg2
+  %472 = and i64 %471, 1
+  %473 = icmp eq i64 %472, 0
+  br i1 %473, label %482, label %474
+
+; <label>:474                                     ; preds = %470
+  %475 = load i8*, i8** %arg0
+  %476 = load i8*, i8** %arg1
+  %NullCheck160 = icmp ne i8* %476, null
+  br i1 %NullCheck160, label %477, label %ThrowNullRef159
+
+; <label>:477                                     ; preds = %474
+  %478 = load i8, i8* %476, align 8
+  %479 = zext i8 %478 to i32
+  %480 = trunc i32 %479 to i8
+  %NullCheck162 = icmp ne i8* %475, null
+  br i1 %NullCheck162, label %481, label %ThrowNullRef161
+
+; <label>:481                                     ; preds = %477
+  store i8 %480, i8* %475, align 8
+  br label %482
+
+; <label>:482                                     ; preds = %470, %481
   ret void
 
-; <label>:397                                     ; preds = %entry, %257
-  %398 = load i8*, i8** %arg0
-  %399 = load i8*, i8** %arg1
-  %400 = load i64, i64* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+; <label>:483                                     ; preds = %entry, %325
+  %484 = load i8*, i8** %arg0
+  %485 = load i8*, i8** %arg1
+  %486 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %484, i8* %485, i64 %486)
   ret void
+
+ThrowNullRef:                                     ; preds = %308
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %312
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %315
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %321
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %271
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %275
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %278
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %284
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %287
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %293
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %298
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %303
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %243
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %247
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %250
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %256
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %259
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %265
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %217
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %221
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %224
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %230
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %233
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %238
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %200
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %204
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %207
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %213
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %172
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %179
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %185
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %190
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %195
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %153
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef69:                                   ; preds = %157
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef71:                                   ; preds = %160
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef73:                                   ; preds = %166
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef75:                                   ; preds = %136
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef77:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef79:                                   ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef81:                                   ; preds = %148
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef83:                                   ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef85:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef87:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef89:                                   ; preds = %104
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef91:                                   ; preds = %107
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef93:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef95:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef97:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef99:                                   ; preds = %81
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef101:                                  ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef103:                                  ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef105:                                  ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef107:                                  ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef109:                                  ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef111:                                  ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef113:                                  ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef115:                                  ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef117:                                  ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef119:                                  ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef121:                                  ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef123:                                  ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef125:                                  ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef127:                                  ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef129:                                  ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef131:                                  ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef133:                                  ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef135:                                  ; preds = %338
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef137:                                  ; preds = %341
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef139:                                  ; preds = %356
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef141:                                  ; preds = %360
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef143:                                  ; preds = %377
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef145:                                  ; preds = %381
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef147:                                  ; preds = %424
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef149:                                  ; preds = %428
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef151:                                  ; preds = %440
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef153:                                  ; preds = %444
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef155:                                  ; preds = %456
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef157:                                  ; preds = %460
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef159:                                  ; preds = %474
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef161:                                  ; preds = %477
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef163:                                  ; preds = %394
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef165:                                  ; preds = %398
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef167:                                  ; preds = %401
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef169:                                  ; preds = %407
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::Concat using LLILCJit
@@ -1163,25 +1939,41 @@ entry:
 
 ; <label>:20                                      ; preds = %13
   %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  store i32 %23, i32* %loc0
-  %24 = load i32, i32* %loc0
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = add i32 %24, %27
-  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
-  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc1
-  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %30, i32 0, %System.String addrspace(1)* %31)
+  %NullCheck = icmp ne %System.String addrspace(1)* %21, null
+  br i1 %NullCheck, label %22, label %ThrowNullRef
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  store i32 %24, i32* %loc0
+  %25 = load i32, i32* %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck2, label %27, label %ThrowNullRef1
+
+; <label>:27                                      ; preds = %22
+  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = add i32 %25, %29
+  %31 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %30)
+  store %System.String addrspace(1)* %31, %System.String addrspace(1)** %loc1
   %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  %33 = load i32, i32* %loc0
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 %33, %System.String addrspace(1)* %34)
-  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
-  ret %System.String addrspace(1)* %35
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %32, i32 0, %System.String addrspace(1)* %33)
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  %35 = load i32, i32* %loc0
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %34, i32 %35, %System.String addrspace(1)* %36)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc1
+  ret %System.String addrspace(1)* %37
+
+ThrowNullRef:                                     ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::IsNullOrEmpty using LLILCJit
@@ -1193,19 +1985,27 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %1 = icmp eq %System.String addrspace(1)* %0, null
-  br i1 %1, label %9, label %2
+  br i1 %1, label %10, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = icmp eq i32 %5, 0
-  %7 = sext i1 %6 to i32
-  %8 = trunc i32 %7 to i8
-  ret i8 %8
+  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = icmp eq i32 %6, 0
+  %8 = sext i1 %7 to i32
+  %9 = trunc i32 %8 to i8
+  ret i8 %9
+
+; <label>:10                                      ; preds = %entry
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::FillStringChecked using LLILCJit
@@ -1222,62 +2022,86 @@ entry:
   store i32 %param1, i32* %arg1
   store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = load i32, i32* %arg1
-  %7 = sub i32 %5, %6
-  %8 = icmp sle i32 %2, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %10) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = load i32, i32* %arg1
+  %9 = sub i32 %7, %8
+  %10 = icmp sle i32 %3, %9
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = call %System.IndexOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IndexOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IndexOutOfRangeException addrspace(1)*)*)(%System.IndexOutOfRangeException addrspace(1)* %12) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
 
-; <label>:13                                      ; preds = %11
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 2
-  %15 = bitcast [0 x i16] addrspace(1)* %14 to i16 addrspace(1)*
-  store i16 addrspace(1)* %15, i16 addrspace(1)** %loc0
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
-  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %14, i32 0, i32 2
+  %17 = bitcast [0 x i16] addrspace(1)* %16 to i16 addrspace(1)*
+  store i16 addrspace(1)* %17, i16 addrspace(1)** %loc0
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck6, label %19, label %ThrowNullRef5
 
-; <label>:17                                      ; preds = %13
-  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2
-  %19 = bitcast [0 x i16] addrspace(1)* %18 to i16 addrspace(1)*
-  store i16 addrspace(1)* %19, i16 addrspace(1)** %loc1
-  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
-  %21 = ptrtoint i16 addrspace(1)* %20 to i64
-  %22 = load i32, i32* %arg1
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = add i64 %21, %24
-  %26 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %27 = ptrtoint i16 addrspace(1)* %26 to i64
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
-  %30 = load i32, i32 addrspace(1)* %29
-  %31 = inttoptr i64 %25 to i16*
-  %32 = inttoptr i64 %27 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %31, i16* %32, i32 %30)
+; <label>:19                                      ; preds = %15
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2
+  %21 = bitcast [0 x i16] addrspace(1)* %20 to i16 addrspace(1)*
+  store i16 addrspace(1)* %21, i16 addrspace(1)** %loc1
+  %22 = load i16 addrspace(1)*, i16 addrspace(1)** %loc0
+  %23 = ptrtoint i16 addrspace(1)* %22 to i64
+  %24 = load i32, i32* %arg1
+  %25 = sext i32 %24 to i64
+  %26 = mul i64 %25, 2
+  %27 = add i64 %23, %26
+  %28 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %29 = ptrtoint i16 addrspace(1)* %28 to i64
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %19
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 1
+  %33 = load i32, i32 addrspace(1)* %32
+  %34 = inttoptr i64 %27 to i16*
+  %35 = inttoptr i64 %29 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %34, i16* %35, i32 %33)
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc1
   store i16 addrspace(1)* null, i16 addrspace(1)** %loc0
   ret void
 
-ThrowNullRef:                                     ; preds = %11
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %13
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1290,9 +2114,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 11
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::PrepareDataForSetup using LLILCJit
@@ -1357,202 +2189,298 @@ entry:
   %22 = load i32, i32* %loc0
   switch i32 %22, label %23 [
     i32 0, label %24
-    i32 1, label %48
-    i32 2, label %72
-    i32 3, label %96
-    i32 4, label %120
-    i32 5, label %149
+    i32 1, label %50
+    i32 2, label %76
+    i32 3, label %102
+    i32 4, label %128
+    i32 5, label %161
   ]
 
 ; <label>:23                                      ; preds = %20
-  br label %169
+  br label %181
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
-  %28 = add i64 %27, 72
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
-  %31 = add i64 %30, 16
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
-  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
-  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
-  %39 = load i64, i64 addrspace(1)* %38
-  %40 = add i64 %39, 64
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = add i64 %42, 48
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
-  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
-  ret i32 %47
+  %NullCheck24 = icmp ne i64 addrspace(1)* %26, null
+  br i1 %NullCheck24, label %27, label %ThrowNullRef23
 
-; <label>:48                                      ; preds = %20
-  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
-  %51 = load i64, i64 addrspace(1)* %50
-  %52 = add i64 %51, 72
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
-  %55 = add i64 %54, 16
+; <label>:27                                      ; preds = %24
+  %28 = load i64, i64 addrspace(1)* %26
+  %29 = add i64 %28, 72
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = add i64 %31, 16
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %39, null
+  br i1 %NullCheck26, label %40, label %ThrowNullRef25
+
+; <label>:40                                      ; preds = %27
+  %41 = load i64, i64 addrspace(1)* %39
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
+  ret i32 %49
+
+; <label>:50                                      ; preds = %20
+  %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %52, null
+  br i1 %NullCheck20, label %53, label %ThrowNullRef19
+
+; <label>:53                                      ; preds = %50
+  %54 = load i64, i64 addrspace(1)* %52
+  %55 = add i64 %54, 72
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
-  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
-  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
-  %63 = load i64, i64 addrspace(1)* %62
-  %64 = add i64 %63, 64
-  %65 = inttoptr i64 %64 to i64*
-  %66 = load i64, i64* %65
-  %67 = add i64 %66, 48
-  %68 = inttoptr i64 %67 to i64*
-  %69 = load i64, i64* %68
-  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
-  ret i32 %71
+  %58 = add i64 %57, 16
+  %59 = inttoptr i64 %58 to i64*
+  %60 = load i64, i64* %59
+  %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
+  %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
 
-; <label>:72                                      ; preds = %20
-  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
-  %76 = add i64 %75, 72
-  %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
-  %79 = add i64 %78, 16
-  %80 = inttoptr i64 %79 to i64*
-  %81 = load i64, i64* %80
-  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
-  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
-  %87 = load i64, i64 addrspace(1)* %86
-  %88 = add i64 %87, 64
-  %89 = inttoptr i64 %88 to i64*
-  %90 = load i64, i64* %89
-  %91 = add i64 %90, 48
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
-  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
-  ret i32 %95
+; <label>:66                                      ; preds = %53
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 48
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
+  ret i32 %75
 
-; <label>:96                                      ; preds = %20
-  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
-  %99 = load i64, i64 addrspace(1)* %98
-  %100 = add i64 %99, 72
-  %101 = inttoptr i64 %100 to i64*
-  %102 = load i64, i64* %101
-  %103 = add i64 %102, 16
-  %104 = inttoptr i64 %103 to i64*
-  %105 = load i64, i64* %104
-  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
-  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
-  %111 = load i64, i64 addrspace(1)* %110
-  %112 = add i64 %111, 64
-  %113 = inttoptr i64 %112 to i64*
-  %114 = load i64, i64* %113
-  %115 = add i64 %114, 48
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
-  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
-  ret i32 %119
+; <label>:76                                      ; preds = %20
+  %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %78, null
+  br i1 %NullCheck16, label %79, label %ThrowNullRef15
 
-; <label>:120                                     ; preds = %20
-  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
-  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
-  %124 = load i16, i16 addrspace(1)* %123, align 8
-  %125 = zext i16 %124 to i32
-  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
-  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
-  %129 = load i16, i16 addrspace(1)* %128, align 8
-  %130 = zext i16 %129 to i32
-  %131 = sub i32 %125, %130
-  %132 = icmp eq i32 %131, 0
-  br i1 %132, label %145, label %133
+; <label>:79                                      ; preds = %76
+  %80 = load i64, i64 addrspace(1)* %78
+  %81 = add i64 %80, 72
+  %82 = inttoptr i64 %81 to i64*
+  %83 = load i64, i64* %82
+  %84 = add i64 %83, 16
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
+  %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %91, null
+  br i1 %NullCheck18, label %92, label %ThrowNullRef17
 
-; <label>:133                                     ; preds = %120
-  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
-  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
-  %137 = load i16, i16 addrspace(1)* %136, align 8
-  %138 = zext i16 %137 to i32
-  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
-  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
-  %142 = load i16, i16 addrspace(1)* %141, align 8
-  %143 = zext i16 %142 to i32
-  %144 = sub i32 %138, %143
-  ret i32 %144
+; <label>:92                                      ; preds = %79
+  %93 = load i64, i64 addrspace(1)* %91
+  %94 = add i64 %93, 64
+  %95 = inttoptr i64 %94 to i64*
+  %96 = load i64, i64* %95
+  %97 = add i64 %96, 48
+  %98 = inttoptr i64 %97 to i64*
+  %99 = load i64, i64* %98
+  %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
+  ret i32 %101
 
-; <label>:145                                     ; preds = %120
-  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
-  ret i32 %148
+; <label>:102                                     ; preds = %20
+  %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %104, null
+  br i1 %NullCheck12, label %105, label %ThrowNullRef11
 
-; <label>:149                                     ; preds = %20
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
-  br i1 %NullCheck, label %151, label %ThrowNullRef
+; <label>:105                                     ; preds = %102
+  %106 = load i64, i64 addrspace(1)* %104
+  %107 = add i64 %106, 72
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = add i64 %109, 16
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
+  %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %117, null
+  br i1 %NullCheck14, label %118, label %ThrowNullRef13
 
-; <label>:151                                     ; preds = %149
-  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
-  %153 = zext i8 %152 to i32
-  %154 = icmp eq i32 %153, 0
-  br i1 %154, label %165, label %155
+; <label>:118                                     ; preds = %105
+  %119 = load i64, i64 addrspace(1)* %117
+  %120 = add i64 %119, 64
+  %121 = inttoptr i64 %120 to i64*
+  %122 = load i64, i64* %121
+  %123 = add i64 %122, 48
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
+  ret i32 %127
 
-; <label>:155                                     ; preds = %151
-  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
-  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+; <label>:128                                     ; preds = %20
+  %129 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %129, null
+  br i1 %NullCheck4, label %130, label %ThrowNullRef3
 
-; <label>:157                                     ; preds = %155
-  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
-  %159 = zext i8 %158 to i32
-  %160 = icmp eq i32 %159, 0
-  br i1 %160, label %165, label %161
+; <label>:130                                     ; preds = %128
+  %131 = getelementptr inbounds %System.String, %System.String addrspace(1)* %129, i32 0, i32 2
+  %132 = bitcast [0 x i16] addrspace(1)* %131 to i16 addrspace(1)*
+  %133 = load i16, i16 addrspace(1)* %132, align 8
+  %134 = zext i16 %133 to i32
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %135, null
+  br i1 %NullCheck6, label %136, label %ThrowNullRef5
 
-; <label>:161                                     ; preds = %157
+; <label>:136                                     ; preds = %130
+  %137 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 2
+  %138 = bitcast [0 x i16] addrspace(1)* %137 to i16 addrspace(1)*
+  %139 = load i16, i16 addrspace(1)* %138, align 8
+  %140 = zext i16 %139 to i32
+  %141 = sub i32 %134, %140
+  %142 = icmp eq i32 %141, 0
+  br i1 %142, label %157, label %143
+
+; <label>:143                                     ; preds = %136
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %144, null
+  br i1 %NullCheck8, label %145, label %ThrowNullRef7
+
+; <label>:145                                     ; preds = %143
+  %146 = getelementptr inbounds %System.String, %System.String addrspace(1)* %144, i32 0, i32 2
+  %147 = bitcast [0 x i16] addrspace(1)* %146 to i16 addrspace(1)*
+  %148 = load i16, i16 addrspace(1)* %147, align 8
+  %149 = zext i16 %148 to i32
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck10, label %151, label %ThrowNullRef9
+
+; <label>:151                                     ; preds = %145
+  %152 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 2
+  %153 = bitcast [0 x i16] addrspace(1)* %152 to i16 addrspace(1)*
+  %154 = load i16, i16 addrspace(1)* %153, align 8
+  %155 = zext i16 %154 to i32
+  %156 = sub i32 %149, %155
+  ret i32 %156
+
+; <label>:157                                     ; preds = %136
+  %158 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %160 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %158, %System.String addrspace(1)* %159)
+  ret i32 %160
+
+; <label>:161                                     ; preds = %20
   %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
-  ret i32 %164
+  %NullCheck = icmp ne %System.String addrspace(1)* %162, null
+  br i1 %NullCheck, label %163, label %ThrowNullRef
 
-; <label>:165                                     ; preds = %151, %157
-  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
-  ret i32 %168
+; <label>:163                                     ; preds = %161
+  %164 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %162)
+  %165 = zext i8 %164 to i32
+  %166 = icmp eq i32 %165, 0
+  br i1 %166, label %177, label %167
 
-; <label>:169                                     ; preds = %23
-  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
-  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+; <label>:167                                     ; preds = %163
+  %168 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %168, null
+  br i1 %NullCheck2, label %169, label %ThrowNullRef1
+
+; <label>:169                                     ; preds = %167
+  %170 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %168)
+  %171 = zext i8 %170 to i32
+  %172 = icmp eq i32 %171, 0
+  br i1 %172, label %177, label %173
+
+; <label>:173                                     ; preds = %169
+  %174 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %175 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %176 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %174, %System.String addrspace(1)* %175)
+  ret i32 %176
+
+; <label>:177                                     ; preds = %163, %169
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  ret i32 %180
+
+; <label>:181                                     ; preds = %23
+  %182 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %183 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %182)
+  %184 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184, %System.String addrspace(1)* %183)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %184) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %149
+ThrowNullRef:                                     ; preds = %161
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %155
+ThrowNullRef1:                                    ; preds = %167
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %128
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %143
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %145
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %105
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %79
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %27
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1575,125 +2503,173 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
-  %5 = load i32, i32 addrspace(1)* %4
-  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %2, i32 %5)
-  store i32 %6, i32* %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck, label %8, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc1
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %11, null
-  br i1 %NullCheck2, label %12, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:12                                      ; preds = %8
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %11, i32 0, i32 2
-  %14 = bitcast [0 x i16] addrspace(1)* %13 to i16 addrspace(1)*
-  store i16 addrspace(1)* %14, i16 addrspace(1)** %loc2
-  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %16 = ptrtoint i16 addrspace(1)* %15 to i64
-  %17 = inttoptr i64 %16 to i16*
-  store i16* %17, i16** %loc3
-  %18 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %19 = ptrtoint i16 addrspace(1)* %18 to i64
-  %20 = inttoptr i64 %19 to i16*
-  store i16* %20, i16** %loc4
-  br label %60
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %3, i32 %7)
+  store i32 %8, i32* %loc0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
 
-; <label>:21                                      ; preds = %60
-  %22 = load i16*, i16** %loc3
-  %23 = load i16, i16* %22, align 8
-  %24 = zext i16 %23 to i32
-  store i32 %24, i32* %loc5
-  %25 = load i16*, i16** %loc4
-  %26 = load i16, i16* %25, align 8
+; <label>:10                                      ; preds = %5
+  %11 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 2
+  %12 = bitcast [0 x i16] addrspace(1)* %11 to i16 addrspace(1)*
+  store i16 addrspace(1)* %12, i16 addrspace(1)** %loc1
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 2
+  %16 = bitcast [0 x i16] addrspace(1)* %15 to i16 addrspace(1)*
+  store i16 addrspace(1)* %16, i16 addrspace(1)** %loc2
+  %17 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %18 = ptrtoint i16 addrspace(1)* %17 to i64
+  %19 = inttoptr i64 %18 to i16*
+  store i16* %19, i16** %loc3
+  %20 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %21 = ptrtoint i16 addrspace(1)* %20 to i64
+  %22 = inttoptr i64 %21 to i16*
+  store i16* %22, i16** %loc4
+  br label %64
+
+; <label>:23                                      ; preds = %64
+  %24 = load i16*, i16** %loc3
+  %NullCheck12 = icmp ne i16* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %23
+  %26 = load i16, i16* %24, align 8
   %27 = zext i16 %26 to i32
-  store i32 %27, i32* %loc6
-  %28 = load i32, i32* %loc5
-  %29 = sub i32 %28, 97
-  %30 = icmp ugt i32 %29, 25
-  br i1 %30, label %34, label %31
+  store i32 %27, i32* %loc5
+  %28 = load i16*, i16** %loc4
+  %NullCheck14 = icmp ne i16* %28, null
+  br i1 %NullCheck14, label %29, label %ThrowNullRef13
 
-; <label>:31                                      ; preds = %21
+; <label>:29                                      ; preds = %25
+  %30 = load i16, i16* %28, align 8
+  %31 = zext i16 %30 to i32
+  store i32 %31, i32* %loc6
   %32 = load i32, i32* %loc5
-  %33 = sub i32 %32, 32
-  store i32 %33, i32* %loc5
-  br label %34
+  %33 = sub i32 %32, 97
+  %34 = icmp ugt i32 %33, 25
+  br i1 %34, label %38, label %35
 
-; <label>:34                                      ; preds = %21, %31
-  %35 = load i32, i32* %loc6
-  %36 = sub i32 %35, 97
-  %37 = icmp ugt i32 %36, 25
-  br i1 %37, label %41, label %38
+; <label>:35                                      ; preds = %29
+  %36 = load i32, i32* %loc5
+  %37 = sub i32 %36, 32
+  store i32 %37, i32* %loc5
+  br label %38
 
-; <label>:38                                      ; preds = %34
+; <label>:38                                      ; preds = %29, %35
   %39 = load i32, i32* %loc6
-  %40 = sub i32 %39, 32
-  store i32 %40, i32* %loc6
-  br label %41
+  %40 = sub i32 %39, 97
+  %41 = icmp ugt i32 %40, 25
+  br i1 %41, label %45, label %42
 
-; <label>:41                                      ; preds = %34, %38
-  %42 = load i32, i32* %loc5
+; <label>:42                                      ; preds = %38
   %43 = load i32, i32* %loc6
-  %44 = icmp eq i32 %42, %43
-  br i1 %44, label %49, label %45
+  %44 = sub i32 %43, 32
+  store i32 %44, i32* %loc6
+  br label %45
 
-; <label>:45                                      ; preds = %41
+; <label>:45                                      ; preds = %38, %42
   %46 = load i32, i32* %loc5
   %47 = load i32, i32* %loc6
-  %48 = sub i32 %46, %47
-  store i32 %48, i32* %loc7
-  br label %71
+  %48 = icmp eq i32 %46, %47
+  br i1 %48, label %53, label %49
 
-; <label>:49                                      ; preds = %41
-  %50 = load i16*, i16** %loc3
-  %51 = bitcast i16* %50 to i8*
-  %52 = getelementptr inbounds i8, i8* %51, i64 2
-  %53 = bitcast i8* %52 to i16*
-  store i16* %53, i16** %loc3
-  %54 = load i16*, i16** %loc4
+; <label>:49                                      ; preds = %45
+  %50 = load i32, i32* %loc5
+  %51 = load i32, i32* %loc6
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc7
+  br label %77
+
+; <label>:53                                      ; preds = %45
+  %54 = load i16*, i16** %loc3
   %55 = bitcast i16* %54 to i8*
   %56 = getelementptr inbounds i8, i8* %55, i64 2
   %57 = bitcast i8* %56 to i16*
-  store i16* %57, i16** %loc4
-  %58 = load i32, i32* %loc0
-  %59 = sub i32 %58, 1
-  store i32 %59, i32* %loc0
-  br label %60
+  store i16* %57, i16** %loc3
+  %58 = load i16*, i16** %loc4
+  %59 = bitcast i16* %58 to i8*
+  %60 = getelementptr inbounds i8, i8* %59, i64 2
+  %61 = bitcast i8* %60 to i16*
+  store i16* %61, i16** %loc4
+  %62 = load i32, i32* %loc0
+  %63 = sub i32 %62, 1
+  store i32 %63, i32* %loc0
+  br label %64
 
-; <label>:60                                      ; preds = %12, %49
-  %61 = load i32, i32* %loc0
-  %62 = icmp ne i32 %61, 0
-  br i1 %62, label %21, label %63
+; <label>:64                                      ; preds = %14, %53
+  %65 = load i32, i32* %loc0
+  %66 = icmp ne i32 %65, 0
+  br i1 %66, label %23, label %67
 
-; <label>:63                                      ; preds = %60
-  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %65 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
-  %66 = load i32, i32 addrspace(1)* %65
-  %67 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %68 = getelementptr inbounds %System.String, %System.String addrspace(1)* %67, i32 0, i32 1
-  %69 = load i32, i32 addrspace(1)* %68
-  %70 = sub i32 %66, %69
-  store i32 %70, i32* %loc7
-  br label %71
+; <label>:67                                      ; preds = %64
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %68, null
+  br i1 %NullCheck8, label %69, label %ThrowNullRef7
 
-; <label>:71                                      ; preds = %45, %63
-  %72 = load i32, i32* %loc7
-  ret i32 %72
+; <label>:69                                      ; preds = %67
+  %70 = getelementptr inbounds %System.String, %System.String addrspace(1)* %68, i32 0, i32 1
+  %71 = load i32, i32 addrspace(1)* %70
+  %72 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %72, null
+  br i1 %NullCheck10, label %73, label %ThrowNullRef9
+
+; <label>:73                                      ; preds = %69
+  %74 = getelementptr inbounds %System.String, %System.String addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = sub i32 %71, %75
+  store i32 %76, i32* %loc7
+  br label %77
+
+; <label>:77                                      ; preds = %49, %73
+  %78 = load i32, i32* %loc7
+  ret i32 %78
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %8
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %69
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -1734,71 +2710,119 @@ entry:
   store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = zext i32 %4 to i64
-  %6 = trunc i64 %5 to i32
-  %7 = load i32, i32* %arg1
-  %8 = icmp sge i32 %6, %7
-  br i1 %8, label %42, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
-  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
-  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = zext i32 %14 to i64
-  %16 = trunc i64 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %27, label %18
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %"System.__Canon[]" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %9
-  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
-  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = zext i32 %23 to i64
-  %25 = trunc i64 %24 to i32
-  %26 = mul i32 %25, 2
-  br label %28
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  %7 = zext i32 %6 to i64
+  %8 = trunc i64 %7 to i32
+  %9 = load i32, i32* %arg1
+  %10 = icmp sge i32 %8, %9
+  br i1 %10, label %48, label %11
 
-; <label>:27                                      ; preds = %9
-  br label %28
+; <label>:11                                      ; preds = %4
+  %12 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:28                                      ; preds = %18, %27
-  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
-  store i32 %29, i32* %loc0
-  %30 = load i32, i32* %loc0
-  %31 = icmp ule i32 %30, 2146435071
-  br i1 %31, label %33, label %32
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %12, i32 0, i32 1
+  %15 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %"System.__Canon[]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:32                                      ; preds = %28
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %15, i32 0, i32 1
+  %18 = load i32, i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %33, label %22
+
+; <label>:22                                      ; preds = %16
+  %23 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %25, align 8
+  %NullCheck10 = icmp ne %"System.__Canon[]" addrspace(1)* %26, null
+  br i1 %NullCheck10, label %27, label %ThrowNullRef9
+
+; <label>:27                                      ; preds = %24
+  %28 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %26, i32 0, i32 1
+  %29 = load i32, i32 addrspace(1)* %28
+  %30 = zext i32 %29 to i64
+  %31 = trunc i64 %30 to i32
+  %32 = mul i32 %31, 2
+  br label %34
+
+; <label>:33                                      ; preds = %16
+  br label %34
+
+; <label>:34                                      ; preds = %27, %33
+  %35 = phi i32 [ %32, %27 ], [ 4, %33 ]
+  store i32 %35, i32* %loc0
+  %36 = load i32, i32* %loc0
+  %37 = icmp ule i32 %36, 2146435071
+  br i1 %37, label %39, label %38
+
+; <label>:38                                      ; preds = %34
   store i32 2146435071, i32* %loc0
-  br label %33
-
-; <label>:33                                      ; preds = %28, %32
-  %34 = load i32, i32* %loc0
-  %35 = load i32, i32* %arg1
-  %36 = icmp sge i32 %34, %35
-  br i1 %36, label %39, label %37
-
-; <label>:37                                      ; preds = %33
-  %38 = load i32, i32* %arg1
-  store i32 %38, i32* %loc0
   br label %39
 
-; <label>:39                                      ; preds = %33, %37
-  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
-  %41 = load i32, i32* %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
-  br label %42
+; <label>:39                                      ; preds = %34, %38
+  %40 = load i32, i32* %loc0
+  %41 = load i32, i32* %arg1
+  %42 = icmp sge i32 %40, %41
+  br i1 %42, label %45, label %43
 
-; <label>:42                                      ; preds = %entry, %39
+; <label>:43                                      ; preds = %39
+  %44 = load i32, i32* %arg1
+  store i32 %44, i32* %loc0
+  br label %45
+
+; <label>:45                                      ; preds = %39, %43
+  %46 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %47 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %46, i32 %47)
+  br label %48
+
+; <label>:48                                      ; preds = %4, %45
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
@@ -1880,9 +2904,17 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.cctor using LLILCJit
@@ -1957,7 +2989,7 @@ entry:
   %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
   %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
   %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
-  br i1 %4, label %13, label %5
+  br i1 %4, label %14, label %5
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
@@ -1965,39 +2997,47 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
   store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
   %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
-  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 1720
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
-  fence seq_cst
-  br label %13
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %entry, %5
-  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 1720
-  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
-  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
-  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %10
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8, i8 addrspace(1)* %12, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
   fence seq_cst
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %9
+  %15 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i64 1720
+  %17 = addrspacecast i8 addrspace(1)* %16 to %System.Globalization.CultureInfo addrspace(1)**
+  %18 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %17
+  %19 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 1712
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  %21 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %22, %System.Globalization.CultureInfo addrspace(1)* %18)
   fence seq_cst
-  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
-  %27 = getelementptr inbounds i8, i8 addrspace(1)* %26, i64 1728
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  %23 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %24 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %25, %System.Globalization.CultureInfo addrspace(1)* %23)
+  fence seq_cst
+  %26 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %27 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %28, %System.Globalization.CultureInfo addrspace(1)* %26)
   fence seq_cst
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
@@ -2019,39 +3059,63 @@ entry:
   %loc0 = alloca %System.String addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  store %System.String addrspace(1)* %2, %System.String addrspace(1)** %loc0
-  %3 = icmp eq %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %5, %System.String addrspace(1)* %6)
-  %8 = zext i8 %7 to i32
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %16, label %10
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  store %System.String addrspace(1)* %3, %System.String addrspace(1)** %loc0
+  %4 = icmp eq %System.String addrspace(1)* %3, null
+  br i1 %4, label %22, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %11, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %20, label %16
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %6, %System.String addrspace(1)* %7)
+  %9 = zext i8 %8 to i32
+  %10 = icmp ne i32 %9, 0
+  br i1 %10, label %17, label %11
 
-; <label>:16                                      ; preds = %4, %10
-  %17 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %18 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %17, i32 0, i32 3
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
-  ret %System.String addrspace(1)* %19
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %22, label %17
 
-; <label>:20                                      ; preds = %entry, %10
-  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %21, i32 0, i32 1
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+; <label>:17                                      ; preds = %5, %11
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck2, label %19, label %ThrowNullRef1
+
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 3
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %20, align 8
+  ret %System.String addrspace(1)* %21
+
+; <label>:22                                      ; preds = %1, %11
+  %23 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %23, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %23, i32 0, i32 1
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %25, align 8
+  ret %System.String addrspace(1)* %26
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
@@ -2103,24 +3167,40 @@ entry:
 
 ; <label>:11                                      ; preds = %7
   %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
-  %14 = load i32, i32 addrspace(1)* %13
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
-  %17 = load i32, i32 addrspace(1)* %16
-  %18 = icmp eq i32 %14, %17
-  br i1 %18, label %20, label %19
+  %NullCheck = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
 
-; <label>:19                                      ; preds = %11
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %15 = load i32, i32 addrspace(1)* %14
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %17, label %ThrowNullRef1
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 1
+  %19 = load i32, i32 addrspace(1)* %18
+  %20 = icmp eq i32 %15, %19
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %17
   ret i8 0
 
-; <label>:20                                      ; preds = %11
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  ret i8 %25
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %24 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %24)
+  %26 = zext i8 %25 to i32
+  %27 = trunc i32 %26 to i8
+  ret i8 %27
+
+ThrowNullRef:                                     ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
@@ -2152,10 +3232,18 @@ entry:
   %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
   store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
   %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %14
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
@@ -2224,87 +3312,119 @@ entry:
   %loc2 = alloca i16
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %3, i32 %2)
-  store %System.Text.StringBuilder addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %4, i32 %3)
+  store %System.Text.StringBuilder addrspace(1)* %4, %System.Text.StringBuilder addrspace(1)** %loc0
   store i32 0, i32* %loc1
-  br label %38
+  br label %40
 
-; <label>:4                                       ; preds = %38
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = load i32, i32* %loc1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 %6
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = trunc i32 %9 to i16
-  store i16 %10, i16* %loc2
-  %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %12 = load i16, i16* %loc2
-  %13 = zext i16 %12 to i32
-  %14 = icmp sgt i32 %13, 90
-  br i1 %14, label %19, label %15
+; <label>:5                                       ; preds = %43
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %7 = load i32, i32* %loc1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck6, label %8, label %ThrowNullRef5
 
-; <label>:15                                      ; preds = %4
-  %16 = load i16, i16* %loc2
-  %17 = zext i16 %16 to i32
-  %18 = icmp sge i32 %17, 65
-  br i1 %18, label %23, label %19
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 %7
+  %10 = load i16, i16 addrspace(1)* %9
+  %11 = zext i16 %10 to i32
+  %12 = trunc i32 %11 to i16
+  store i16 %12, i16* %loc2
+  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %14 = load i16, i16* %loc2
+  %15 = zext i16 %14 to i32
+  %16 = icmp sgt i32 %15, 90
+  br i1 %16, label %21, label %17
 
-; <label>:19                                      ; preds = %4, %15
-  %20 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %4 ], [ %11, %15 ]
-  %21 = load i16, i16* %loc2
-  %22 = zext i16 %21 to i32
-  br label %30
+; <label>:17                                      ; preds = %8
+  %18 = load i16, i16* %loc2
+  %19 = zext i16 %18 to i32
+  %20 = icmp sge i32 %19, 65
+  br i1 %20, label %25, label %21
 
-; <label>:23                                      ; preds = %15
-  %24 = load i16, i16* %loc2
-  %25 = zext i16 %24 to i32
-  %26 = sub i32 %25, 65
-  %27 = add i32 %26, 97
-  %28 = trunc i32 %27 to i16
-  %29 = zext i16 %28 to i32
-  br label %30
+; <label>:21                                      ; preds = %8, %17
+  %22 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %8 ], [ %13, %17 ]
+  %23 = load i16, i16* %loc2
+  %24 = zext i16 %23 to i32
+  br label %32
 
-; <label>:30                                      ; preds = %19, %23
-  %31 = phi %System.Text.StringBuilder addrspace(1)* [ %11, %23 ], [ %20, %19 ]
-  %32 = phi i32 [ %29, %23 ], [ %22, %19 ]
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
-  br i1 %NullCheck, label %33, label %ThrowNullRef
+; <label>:25                                      ; preds = %17
+  %26 = load i16, i16* %loc2
+  %27 = zext i16 %26 to i32
+  %28 = sub i32 %27, 65
+  %29 = add i32 %28, 97
+  %30 = trunc i32 %29 to i16
+  %31 = zext i16 %30 to i32
+  br label %32
 
-; <label>:33                                      ; preds = %30
-  %34 = trunc i32 %32 to i16
-  %35 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %31, i16 %34)
-  %36 = load i32, i32* %loc1
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %loc1
-  br label %38
+; <label>:32                                      ; preds = %21, %25
+  %33 = phi %System.Text.StringBuilder addrspace(1)* [ %13, %25 ], [ %22, %21 ]
+  %34 = phi i32 [ %31, %25 ], [ %24, %21 ]
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %33, null
+  br i1 %NullCheck8, label %35, label %ThrowNullRef7
 
-; <label>:38                                      ; preds = %entry, %33
-  %39 = load i32, i32* %loc1
-  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %41 = getelementptr inbounds %System.String, %System.String addrspace(1)* %40, i32 0, i32 1
-  %42 = load i32, i32 addrspace(1)* %41
-  %43 = icmp slt i32 %39, %42
-  br i1 %43, label %4, label %44
+; <label>:35                                      ; preds = %32
+  %36 = trunc i32 %34 to i16
+  %37 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %33, i16 %36)
+  %38 = load i32, i32* %loc1
+  %39 = add i32 %38, 1
+  store i32 %39, i32* %loc1
+  br label %40
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %46 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
-  %48 = add i64 %47, 64
-  %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
-  %51 = add i64 %50, 0
-  %52 = inttoptr i64 %51 to i64*
-  %53 = load i64, i64* %52
-  %54 = bitcast %System.Text.StringBuilder addrspace(1)* %45 to %System.Object addrspace(1)*
-  %55 = inttoptr i64 %53 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %56 = call %System.String addrspace(1)* %55(%System.Object addrspace(1)* %54)
-  ret %System.String addrspace(1)* %56
+; <label>:40                                      ; preds = %1, %35
+  %41 = load i32, i32* %loc1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %42, null
+  br i1 %NullCheck2, label %43, label %ThrowNullRef1
 
-ThrowNullRef:                                     ; preds = %30
+; <label>:43                                      ; preds = %40
+  %44 = getelementptr inbounds %System.String, %System.String addrspace(1)* %42, i32 0, i32 1
+  %45 = load i32, i32 addrspace(1)* %44
+  %46 = icmp slt i32 %41, %45
+  br i1 %46, label %5, label %47
+
+; <label>:47                                      ; preds = %43
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %49, null
+  br i1 %NullCheck4, label %50, label %ThrowNullRef3
+
+; <label>:50                                      ; preds = %47
+  %51 = load i64, i64 addrspace(1)* %49
+  %52 = add i64 %51, 64
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 0
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
+  %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
+  ret %System.String addrspace(1)* %60
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %32
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2343,22 +3463,30 @@ entry:
   br i1 %3, label %5, label %4
 
 ; <label>:4                                       ; preds = %entry
-  br label %9
+  br label %10
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
-  %8 = load i32, i32 addrspace(1)* %7
-  br label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %4, %5
-  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
-  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
-  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
-  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
-  %14 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  br label %10
+
+; <label>:10                                      ; preds = %4, %7
+  %11 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %7 ]
+  %12 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %7 ]
+  %13 = phi i32 [ 0, %4 ], [ 0, %7 ]
+  %14 = phi i32 [ 0, %4 ], [ %9, %7 ]
+  %15 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, %System.String addrspace(1)* %12, i32 %13, i32 %14, i32 %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
@@ -2386,30 +3514,46 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %7)
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:10                                      ; preds = %entry
-  %11 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %15, label %14
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 62
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
 
-; <label>:14                                      ; preds = %10
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %7, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %10, %System.String addrspace(1)* %8)
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %9
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %11)
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %12
   ret %System.Globalization.CultureData addrspace(1)* null
 
-; <label>:15                                      ; preds = %10
-  %16 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
-  ret %System.Globalization.CultureData addrspace(1)* %16
+; <label>:17                                      ; preds = %12
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %loc0
+  ret %System.Globalization.CultureData addrspace(1)* %18
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2422,30 +3566,86 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
-  store i32 -1, i32 addrspace(1)* %1
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
-  store i32 -1, i32 addrspace(1)* %3
-  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %2
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %3, i32 0, i32 53
   store i32 -1, i32 addrspace(1)* %5
   %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
-  store i32 -1, i32 addrspace(1)* %7
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
-  store i32 -1, i32 addrspace(1)* %9
-  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %8
+  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Globalization.CultureData addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 58
   store i32 -1, i32 addrspace(1)* %11
   %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
-  store i32 -1, i32 addrspace(1)* %13
-  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  %NullCheck8 = icmp ne %System.Globalization.CultureData addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %14
+  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %15, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %17
+  %18 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureData addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %18, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %20
+  %21 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %22 = bitcast %System.Globalization.CultureData addrspace(1)* %21 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
@@ -2494,19 +3694,35 @@ entry:
 
 ; <label>:3                                       ; preds = %entry
   %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
-  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 64
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 16
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
-  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
-  %16 = call i32 %15(%System.Object addrspace(1)* %14)
-  ret i32 %16
+  %NullCheck = icmp ne %System.__Canon addrspace(1)* addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %3
+  %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 64
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 16
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
+  %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
+  %18 = call i32 %17(%System.Object addrspace(1)* %16)
+  ret i32 %18
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::GetHashCode using LLILCJit
@@ -2529,94 +3745,118 @@ entry:
   %3 = load i8, i8* %2
   %4 = zext i8 %3 to i32
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %12, label %6
+  br i1 %5, label %13, label %6
 
 ; <label>:6                                       ; preds = %entry
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
-  %10 = load i32, i32 addrspace(1)* %9
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
-  ret i32 %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
-  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %21, label %17
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %11, i64 0)
+  ret i32 %12
 
-; <label>:17                                      ; preds = %12
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
-  %19 = sext i32 %18 to i64
-  %20 = add i64 %15, %19
-  br label %21
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %14, %System.String addrspace(1)** %loc6
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %16 = ptrtoint %System.String addrspace(1)* %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %22, label %18
 
-; <label>:21                                      ; preds = %12, %17
-  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
-  %23 = inttoptr i64 %22 to i16*
-  store i16* %23, i16** %loc0
+; <label>:18                                      ; preds = %13
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %20 = sext i32 %19 to i64
+  %21 = add i64 %16, %20
+  br label %22
+
+; <label>:22                                      ; preds = %13, %18
+  %23 = phi i64 [ %16, %13 ], [ %21, %18 ]
+  %24 = inttoptr i64 %23 to i16*
+  store i16* %24, i16** %loc0
   store i32 5381, i32* %loc1
-  %24 = load i32, i32* %loc1
-  store i32 %24, i32* %loc2
-  %25 = load i16*, i16** %loc0
-  store i16* %25, i16** %loc4
-  br label %52
+  %25 = load i32, i32* %loc1
+  store i32 %25, i32* %loc2
+  %26 = load i16*, i16** %loc0
+  store i16* %26, i16** %loc4
+  br label %54
 
-; <label>:26                                      ; preds = %52
-  %27 = load i32, i32* %loc1
-  %28 = shl i32 %27, 5
-  %29 = load i32, i32* %loc1
-  %30 = add i32 %28, %29
-  %31 = load i32, i32* %loc3
-  %32 = xor i32 %30, %31
-  store i32 %32, i32* %loc1
-  %33 = load i16*, i16** %loc4
-  %34 = bitcast i16* %33 to i8*
-  %35 = getelementptr inbounds i8, i8* %34, i64 2
-  %36 = bitcast i8* %35 to i16*
-  %37 = load i16, i16* %36, align 8
-  %38 = zext i16 %37 to i32
-  store i32 %38, i32* %loc3
-  %39 = load i32, i32* %loc3
-  %40 = icmp eq i32 %39, 0
-  br i1 %40, label %57, label %41
+; <label>:27                                      ; preds = %56
+  %28 = load i32, i32* %loc1
+  %29 = shl i32 %28, 5
+  %30 = load i32, i32* %loc1
+  %31 = add i32 %29, %30
+  %32 = load i32, i32* %loc3
+  %33 = xor i32 %31, %32
+  store i32 %33, i32* %loc1
+  %34 = load i16*, i16** %loc4
+  %35 = bitcast i16* %34 to i8*
+  %36 = getelementptr inbounds i8, i8* %35, i64 2
+  %37 = bitcast i8* %36 to i16*
+  %NullCheck4 = icmp ne i16* %37, null
+  br i1 %NullCheck4, label %38, label %ThrowNullRef3
 
-; <label>:41                                      ; preds = %26
-  %42 = load i32, i32* %loc2
-  %43 = shl i32 %42, 5
+; <label>:38                                      ; preds = %27
+  %39 = load i16, i16* %37, align 8
+  %40 = zext i16 %39 to i32
+  store i32 %40, i32* %loc3
+  %41 = load i32, i32* %loc3
+  %42 = icmp eq i32 %41, 0
+  br i1 %42, label %60, label %43
+
+; <label>:43                                      ; preds = %38
   %44 = load i32, i32* %loc2
-  %45 = add i32 %43, %44
-  %46 = load i32, i32* %loc3
-  %47 = xor i32 %45, %46
-  store i32 %47, i32* %loc2
-  %48 = load i16*, i16** %loc4
-  %49 = bitcast i16* %48 to i8*
-  %50 = getelementptr inbounds i8, i8* %49, i64 4
-  %51 = bitcast i8* %50 to i16*
-  store i16* %51, i16** %loc4
-  br label %52
+  %45 = shl i32 %44, 5
+  %46 = load i32, i32* %loc2
+  %47 = add i32 %45, %46
+  %48 = load i32, i32* %loc3
+  %49 = xor i32 %47, %48
+  store i32 %49, i32* %loc2
+  %50 = load i16*, i16** %loc4
+  %51 = bitcast i16* %50 to i8*
+  %52 = getelementptr inbounds i8, i8* %51, i64 4
+  %53 = bitcast i8* %52 to i16*
+  store i16* %53, i16** %loc4
+  br label %54
 
-; <label>:52                                      ; preds = %21, %41
-  %53 = load i16*, i16** %loc4
-  %54 = load i16, i16* %53, align 8
-  %55 = zext i16 %54 to i32
-  store i32 %55, i32* %loc3
-  %56 = icmp ne i32 %55, 0
-  br i1 %56, label %26, label %57
+; <label>:54                                      ; preds = %22, %43
+  %55 = load i16*, i16** %loc4
+  %NullCheck2 = icmp ne i16* %55, null
+  br i1 %NullCheck2, label %56, label %ThrowNullRef1
 
-; <label>:57                                      ; preds = %26, %52
-  %58 = load i32, i32* %loc1
-  %59 = load i32, i32* %loc2
-  %60 = mul i32 %59, 1566083941
-  %61 = add i32 %58, %60
-  store i32 %61, i32* %loc5
-  br label %62
+; <label>:56                                      ; preds = %54
+  %57 = load i16, i16* %55, align 8
+  %58 = zext i16 %57 to i32
+  store i32 %58, i32* %loc3
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %27, label %60
 
-; <label>:62                                      ; preds = %57
-  %63 = load i32, i32* %loc5
-  ret i32 %63
+; <label>:60                                      ; preds = %38, %56
+  %61 = load i32, i32* %loc1
+  %62 = load i32, i32* %loc2
+  %63 = mul i32 %62, 1566083941
+  %64 = add i32 %61, %63
+  store i32 %64, i32* %loc5
+  br label %65
+
+; <label>:65                                      ; preds = %60
+  %66 = load i32, i32* %loc5
+  ret i32 %66
+
+ThrowNullRef:                                     ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %27
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
@@ -2631,42 +3871,58 @@ entry:
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 64
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 40
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
-  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
-  %14 = zext i8 %13 to i32
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %18, label %16
+  %NullCheck = icmp ne i64 addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %17
+; <label>:4                                       ; preds = %entry
+  %5 = load i64, i64 addrspace(1)* %3
+  %6 = add i64 %5, 64
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %19, label %17
 
-; <label>:18                                      ; preds = %entry
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
-  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
-  br i1 %22, label %25, label %23
+; <label>:17                                      ; preds = %4
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %18
 
-; <label>:23                                      ; preds = %18
-  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  ret %System.Globalization.CultureInfo addrspace(1)* %24
+; <label>:19                                      ; preds = %4
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %21 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %20, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %23 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %22, null
+  br i1 %23, label %26, label %24
 
-; <label>:25                                      ; preds = %18
-  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
-  store i8 1, i8 addrspace(1)* %27
-  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
-  ret %System.Globalization.CultureInfo addrspace(1)* %28
+; <label>:24                                      ; preds = %19
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %25
+
+; <label>:26                                      ; preds = %19
+  %27 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %27, null
+  br i1 %NullCheck2, label %28, label %ThrowNullRef1
+
+; <label>:28                                      ; preds = %26
+  %29 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %27, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %29
+  %30 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
@@ -2716,43 +3972,91 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %20, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %25, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 8
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = icmp ne %System.String addrspace(1)* %14, null
-  br i1 %15, label %20, label %16
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %19 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %17, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %19, %System.String addrspace(1)* %18)
-  br label %20
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %entry, %9, %16
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %15, null
+  br i1 %NullCheck8, label %16, label %ThrowNullRef7
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %15, i32 0, i32 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %17, align 8
+  %19 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %19, label %25, label %20
+
+; <label>:20                                      ; preds = %16
   %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %22 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
-  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %22, align 8
-  ret %System.String addrspace(1)* %23
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:23                                      ; preds = %20
+  %24 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %21, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %24, %System.String addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %1, %16, %23
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %26, null
+  br i1 %NullCheck12, label %27, label %ThrowNullRef11
+
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 8
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %28, align 8
+  ret %System.String addrspace(1)* %29
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %25
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2765,23 +4069,47 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %7, %System.String addrspace(1)* %6)
-  br label %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry, %4
-  %9 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %9, i32 0, i32 3
-  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %10, align 8
-  ret %System.String addrspace(1)* %11
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %6, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %9, %System.String addrspace(1)* %7)
+  br label %10
+
+; <label>:10                                      ; preds = %1, %8
+  %11 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %11, i32 0, i32 3
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.String addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::EqualsHelper using LLILCJit
@@ -2800,161 +4128,233 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  store i32 %2, i32* %loc0
-  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %3, null
-  br i1 %NullCheck, label %4, label %ThrowNullRef
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 2
-  %6 = bitcast [0 x i16] addrspace(1)* %5 to i16 addrspace(1)*
-  store i16 addrspace(1)* %6, i16 addrspace(1)** %loc1
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %7, null
-  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  store i32 %3, i32* %loc0
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
 
-; <label>:8                                       ; preds = %4
-  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 2
-  %10 = bitcast [0 x i16] addrspace(1)* %9 to i16 addrspace(1)*
-  store i16 addrspace(1)* %10, i16 addrspace(1)** %loc2
-  %11 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
-  %12 = ptrtoint i16 addrspace(1)* %11 to i64
-  %13 = inttoptr i64 %12 to i16*
-  store i16* %13, i16** %loc3
-  %14 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
-  %15 = ptrtoint i16 addrspace(1)* %14 to i64
-  %16 = inttoptr i64 %15 to i16*
-  store i16* %16, i16** %loc4
-  br label %63
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 2
+  %7 = bitcast [0 x i16] addrspace(1)* %6 to i16 addrspace(1)*
+  store i16 addrspace(1)* %7, i16 addrspace(1)** %loc1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %NullCheck4, label %9, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %63
-  %18 = load i16*, i16** %loc3
-  %19 = bitcast i16* %18 to i64*
-  %20 = load i64, i64* %19, align 8
-  %21 = load i16*, i16** %loc4
-  %22 = bitcast i16* %21 to i64*
-  %23 = load i64, i64* %22, align 8
-  %24 = icmp eq i64 %20, %23
-  br i1 %24, label %26, label %25
+; <label>:9                                       ; preds = %5
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 2
+  %11 = bitcast [0 x i16] addrspace(1)* %10 to i16 addrspace(1)*
+  store i16 addrspace(1)* %11, i16 addrspace(1)** %loc2
+  %12 = load i16 addrspace(1)*, i16 addrspace(1)** %loc1
+  %13 = ptrtoint i16 addrspace(1)* %12 to i64
+  %14 = inttoptr i64 %13 to i16*
+  store i16* %14, i16** %loc3
+  %15 = load i16 addrspace(1)*, i16 addrspace(1)** %loc2
+  %16 = ptrtoint i16 addrspace(1)* %15 to i64
+  %17 = inttoptr i64 %16 to i16*
+  store i16* %17, i16** %loc4
+  br label %70
 
-; <label>:25                                      ; preds = %17
+; <label>:18                                      ; preds = %70
+  %19 = load i16*, i16** %loc3
+  %20 = bitcast i16* %19 to i64*
+  %NullCheck10 = icmp ne i64* %20, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = load i64, i64* %20, align 8
+  %23 = load i16*, i16** %loc4
+  %24 = bitcast i16* %23 to i64*
+  %NullCheck12 = icmp ne i64* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = load i64, i64* %24, align 8
+  %27 = icmp eq i64 %22, %26
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %25
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:26                                      ; preds = %17
-  %27 = load i16*, i16** %loc3
-  %28 = bitcast i16* %27 to i8*
-  %29 = getelementptr inbounds i8, i8* %28, i64 8
-  %30 = bitcast i8* %29 to i64*
-  %31 = load i64, i64* %30, align 8
-  %32 = load i16*, i16** %loc4
-  %33 = bitcast i16* %32 to i8*
-  %34 = getelementptr inbounds i8, i8* %33, i64 8
-  %35 = bitcast i8* %34 to i64*
-  %36 = load i64, i64* %35, align 8
-  %37 = icmp eq i64 %31, %36
-  br i1 %37, label %39, label %38
+; <label>:29                                      ; preds = %25
+  %30 = load i16*, i16** %loc3
+  %31 = bitcast i16* %30 to i8*
+  %32 = getelementptr inbounds i8, i8* %31, i64 8
+  %33 = bitcast i8* %32 to i64*
+  %NullCheck14 = icmp ne i64* %33, null
+  br i1 %NullCheck14, label %34, label %ThrowNullRef13
 
-; <label>:38                                      ; preds = %26
+; <label>:34                                      ; preds = %29
+  %35 = load i64, i64* %33, align 8
+  %36 = load i16*, i16** %loc4
+  %37 = bitcast i16* %36 to i8*
+  %38 = getelementptr inbounds i8, i8* %37, i64 8
+  %39 = bitcast i8* %38 to i64*
+  %NullCheck16 = icmp ne i64* %39, null
+  br i1 %NullCheck16, label %40, label %ThrowNullRef15
+
+; <label>:40                                      ; preds = %34
+  %41 = load i64, i64* %39, align 8
+  %42 = icmp eq i64 %35, %41
+  br i1 %42, label %44, label %43
+
+; <label>:43                                      ; preds = %40
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:39                                      ; preds = %26
-  %40 = load i16*, i16** %loc3
-  %41 = bitcast i16* %40 to i8*
-  %42 = getelementptr inbounds i8, i8* %41, i64 16
-  %43 = bitcast i8* %42 to i64*
-  %44 = load i64, i64* %43, align 8
-  %45 = load i16*, i16** %loc4
+; <label>:44                                      ; preds = %40
+  %45 = load i16*, i16** %loc3
   %46 = bitcast i16* %45 to i8*
   %47 = getelementptr inbounds i8, i8* %46, i64 16
   %48 = bitcast i8* %47 to i64*
-  %49 = load i64, i64* %48, align 8
-  %50 = icmp eq i64 %44, %49
-  br i1 %50, label %52, label %51
+  %NullCheck18 = icmp ne i64* %48, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
 
-; <label>:51                                      ; preds = %39
+; <label>:49                                      ; preds = %44
+  %50 = load i64, i64* %48, align 8
+  %51 = load i16*, i16** %loc4
+  %52 = bitcast i16* %51 to i8*
+  %53 = getelementptr inbounds i8, i8* %52, i64 16
+  %54 = bitcast i8* %53 to i64*
+  %NullCheck20 = icmp ne i64* %54, null
+  br i1 %NullCheck20, label %55, label %ThrowNullRef19
+
+; <label>:55                                      ; preds = %49
+  %56 = load i64, i64* %54, align 8
+  %57 = icmp eq i64 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %55
   store i8 0, i8* %loc5
-  br label %96
+  br label %105
 
-; <label>:52                                      ; preds = %39
-  %53 = load i16*, i16** %loc3
-  %54 = bitcast i16* %53 to i8*
-  %55 = getelementptr inbounds i8, i8* %54, i64 24
-  %56 = bitcast i8* %55 to i16*
-  store i16* %56, i16** %loc3
-  %57 = load i16*, i16** %loc4
-  %58 = bitcast i16* %57 to i8*
-  %59 = getelementptr inbounds i8, i8* %58, i64 24
-  %60 = bitcast i8* %59 to i16*
-  store i16* %60, i16** %loc4
-  %61 = load i32, i32* %loc0
-  %62 = sub i32 %61, 12
-  store i32 %62, i32* %loc0
-  br label %63
+; <label>:59                                      ; preds = %55
+  %60 = load i16*, i16** %loc3
+  %61 = bitcast i16* %60 to i8*
+  %62 = getelementptr inbounds i8, i8* %61, i64 24
+  %63 = bitcast i8* %62 to i16*
+  store i16* %63, i16** %loc3
+  %64 = load i16*, i16** %loc4
+  %65 = bitcast i16* %64 to i8*
+  %66 = getelementptr inbounds i8, i8* %65, i64 24
+  %67 = bitcast i8* %66 to i16*
+  store i16* %67, i16** %loc4
+  %68 = load i32, i32* %loc0
+  %69 = sub i32 %68, 12
+  store i32 %69, i32* %loc0
+  br label %70
 
-; <label>:63                                      ; preds = %8, %52
-  %64 = load i32, i32* %loc0
-  %65 = icmp sge i32 %64, 12
-  br i1 %65, label %17, label %66
+; <label>:70                                      ; preds = %9, %59
+  %71 = load i32, i32* %loc0
+  %72 = icmp sge i32 %71, 12
+  br i1 %72, label %18, label %73
 
-; <label>:66                                      ; preds = %63
-  br label %86
+; <label>:73                                      ; preds = %70
+  br label %95
 
-; <label>:67                                      ; preds = %86
-  %68 = load i16*, i16** %loc3
-  %69 = bitcast i16* %68 to i32*
-  %70 = load i32, i32* %69, align 8
-  %71 = load i16*, i16** %loc4
-  %72 = bitcast i16* %71 to i32*
-  %73 = load i32, i32* %72, align 8
-  %74 = icmp ne i32 %70, %73
-  br i1 %74, label %89, label %75
+; <label>:74                                      ; preds = %95
+  %75 = load i16*, i16** %loc3
+  %76 = bitcast i16* %75 to i32*
+  %NullCheck6 = icmp ne i32* %76, null
+  br i1 %NullCheck6, label %77, label %ThrowNullRef5
 
-; <label>:75                                      ; preds = %67
-  %76 = load i16*, i16** %loc3
-  %77 = bitcast i16* %76 to i8*
-  %78 = getelementptr inbounds i8, i8* %77, i64 4
-  %79 = bitcast i8* %78 to i16*
-  store i16* %79, i16** %loc3
-  %80 = load i16*, i16** %loc4
-  %81 = bitcast i16* %80 to i8*
-  %82 = getelementptr inbounds i8, i8* %81, i64 4
-  %83 = bitcast i8* %82 to i16*
-  store i16* %83, i16** %loc4
-  %84 = load i32, i32* %loc0
-  %85 = sub i32 %84, 2
-  store i32 %85, i32* %loc0
-  br label %86
+; <label>:77                                      ; preds = %74
+  %78 = load i32, i32* %76, align 8
+  %79 = load i16*, i16** %loc4
+  %80 = bitcast i16* %79 to i32*
+  %NullCheck8 = icmp ne i32* %80, null
+  br i1 %NullCheck8, label %81, label %ThrowNullRef7
 
-; <label>:86                                      ; preds = %66, %75
-  %87 = load i32, i32* %loc0
-  %88 = icmp sgt i32 %87, 0
-  br i1 %88, label %67, label %89
+; <label>:81                                      ; preds = %77
+  %82 = load i32, i32* %80, align 8
+  %83 = icmp ne i32 %78, %82
+  br i1 %83, label %98, label %84
 
-; <label>:89                                      ; preds = %67, %86
-  %90 = load i32, i32* %loc0
-  %91 = icmp sgt i32 %90, 0
-  %92 = sext i1 %91 to i32
-  %93 = icmp eq i32 %92, 0
-  %94 = sext i1 %93 to i32
-  %95 = trunc i32 %94 to i8
-  store i8 %95, i8* %loc5
-  br label %96
+; <label>:84                                      ; preds = %81
+  %85 = load i16*, i16** %loc3
+  %86 = bitcast i16* %85 to i8*
+  %87 = getelementptr inbounds i8, i8* %86, i64 4
+  %88 = bitcast i8* %87 to i16*
+  store i16* %88, i16** %loc3
+  %89 = load i16*, i16** %loc4
+  %90 = bitcast i16* %89 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  store i16* %92, i16** %loc4
+  %93 = load i32, i32* %loc0
+  %94 = sub i32 %93, 2
+  store i32 %94, i32* %loc0
+  br label %95
 
-; <label>:96                                      ; preds = %25, %38, %51, %89
-  %97 = load i8, i8* %loc5
-  %98 = zext i8 %97 to i32
-  %99 = trunc i32 %98 to i8
-  ret i8 %99
+; <label>:95                                      ; preds = %73, %84
+  %96 = load i32, i32* %loc0
+  %97 = icmp sgt i32 %96, 0
+  br i1 %97, label %74, label %98
+
+; <label>:98                                      ; preds = %81, %95
+  %99 = load i32, i32* %loc0
+  %100 = icmp sgt i32 %99, 0
+  %101 = sext i1 %100 to i32
+  %102 = icmp eq i32 %101, 0
+  %103 = sext i1 %102 to i32
+  %104 = trunc i32 %103 to i8
+  store i8 %104, i8* %loc5
+  br label %105
+
+; <label>:105                                     ; preds = %28, %43, %58, %98
+  %106 = load i8, i8* %loc5
+  %107 = zext i8 %106 to i32
+  %108 = trunc i32 %107 to i8
+  ret i8 %108
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %4
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %77
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -2976,24 +4376,48 @@ entry:
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
   %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 72
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %13 = call %System.Globalization.CompareInfo addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %3)
-  %14 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %14, %System.Globalization.CompareInfo addrspace(1)* %13)
-  %15 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %15, i32 0, i32 2
-  store i8 %18, i8 addrspace(1)* %19
+  %NullCheck = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 72
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 16
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
+  %NullCheck2 = icmp ne %System.CultureAwareComparer addrspace(1)* %2, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %5
+  %16 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %16, %System.Globalization.CompareInfo addrspace(1)* %14)
+  %17 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
+  %18 = load i8, i8* %arg2
+  %19 = zext i8 %18 to i32
+  %20 = trunc i32 %19 to i8
+  %NullCheck4 = icmp ne %System.CultureAwareComparer addrspace(1)* %17, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %15
+  %22 = getelementptr inbounds %System.CultureAwareComparer, %System.CultureAwareComparer addrspace(1)* %17, i32 0, i32 2
+  store i8 %20, i8 addrspace(1)* %22
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
@@ -3018,65 +4442,105 @@ entry:
   %loc0 = alloca %System.Globalization.CompareInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
-  br i1 %3, label %38, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %5)
-  %7 = zext i8 %6 to i32
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %12, label %9
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %3, null
+  br i1 %4, label %42, label %5
 
-; <label>:9                                       ; preds = %4
-  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %11 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)* %10)
-  br label %27
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %6)
+  %8 = zext i8 %7 to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %13, label %10
 
-; <label>:12                                      ; preds = %4
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 7
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
-  %17 = bitcast %System.Globalization.CultureInfo addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
-  %19 = add i64 %18, 72
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = add i64 %21, 16
+; <label>:10                                      ; preds = %5
+  %11 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %12 = call %System.Globalization.CompareInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CompareInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %11)
+  br label %30
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %13
+  %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 72
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
-  %25 = inttoptr i64 %24 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %26 = call %System.Globalization.CompareInfo addrspace(1)* %25(%System.Globalization.CultureInfo addrspace(1)* %16)
-  br label %27
+  %25 = add i64 %24, 16
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
+  br label %30
 
-; <label>:27                                      ; preds = %9, %12
-  %28 = phi %System.Globalization.CompareInfo addrspace(1)* [ %11, %9 ], [ %26, %12 ]
-  store %System.Globalization.CompareInfo addrspace(1)* %28, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %30 = zext i8 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %36, label %32
+; <label>:30                                      ; preds = %10, %20
+  %31 = phi %System.Globalization.CompareInfo addrspace(1)* [ %12, %10 ], [ %29, %20 ]
+  store %System.Globalization.CompareInfo addrspace(1)* %31, %System.Globalization.CompareInfo addrspace(1)** %loc0
+  %32 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %33 = zext i8 %32 to i32
+  %34 = icmp eq i32 %33, 0
+  br i1 %34, label %40, label %35
 
-; <label>:32                                      ; preds = %27
-  %33 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %34 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  %35 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %33, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %35, %System.Globalization.CompareInfo addrspace(1)* %34)
-  br label %38
-
-; <label>:36                                      ; preds = %27
+; <label>:35                                      ; preds = %30
+  %36 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
   %37 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
-  ret %System.Globalization.CompareInfo addrspace(1)* %37
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %36, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:38                                      ; preds = %entry, %32
-  %39 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %40 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %39, i32 0, i32 1
-  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %40, align 8
+; <label>:38                                      ; preds = %35
+  %39 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %36, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CompareInfo addrspace(1)* addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)*)*)(%System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %39, %System.Globalization.CompareInfo addrspace(1)* %37)
+  br label %42
+
+; <label>:40                                      ; preds = %30
+  %41 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %loc0
   ret %System.Globalization.CompareInfo addrspace(1)* %41
+
+; <label>:42                                      ; preds = %1, %38
+  %43 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %43, null
+  br i1 %NullCheck8, label %44, label %ThrowNullRef7
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %43, i32 0, i32 1
+  %46 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)* addrspace(1)* %45, align 8
+  ret %System.Globalization.CompareInfo addrspace(1)* %46
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
@@ -3087,18 +4551,26 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
-  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
-  br i1 %NullCheck, label %3, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:3                                       ; preds = %entry
-  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
-  %5 = zext i8 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %3)
+  %6 = zext i8 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3111,11 +4583,19 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
@@ -3133,34 +4613,82 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %6, %System.String addrspace(1)* %5)
-  %7 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %8 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %7, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %13 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %13, i32 0, i32 2
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  %16 = addrspacecast i64* %loc0 to i64 addrspace(1)*
-  %17 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %15, i64 addrspace(1)* %16)
-  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %12, i32 0, i32 3
-  store i64 %17, i64 addrspace(1)* %18
-  %19 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
-  %20 = load i64, i64* %loc0
-  %21 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %19, i32 0, i32 4
-  store i64 %20, i64 addrspace(1)* %21
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %3, i32 0, i32 7
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %2, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %8, %System.String addrspace(1)* %6)
+  %9 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %10 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*)(%System.Globalization.CultureInfo addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %9, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %16 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %16, i32 0, i32 2
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  %20 = addrspacecast i64* %loc0 to i64 addrspace(1)*
+  %21 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %19, i64 addrspace(1)* %20)
+  %NullCheck10 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %15, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %15, i32 0, i32 3
+  store i64 %21, i64 addrspace(1)* %23
+  %24 = load %System.Globalization.CompareInfo addrspace(1)*, %System.Globalization.CompareInfo addrspace(1)** %this
+  %25 = load i64, i64* %loc0
+  %NullCheck12 = icmp ne %System.Globalization.CompareInfo addrspace(1)* %24, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Globalization.CompareInfo, %System.Globalization.CompareInfo addrspace(1)* %24, i32 0, i32 4
+  store i64 %25, i64 addrspace(1)* %27
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %22
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3173,32 +4701,64 @@ entry:
   %this = alloca %System.Globalization.CultureInfo addrspace(1)*
   store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
   %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %12, label %4
+  %NullCheck = icmp ne %System.Globalization.CultureInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 9
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
+
+; <label>:5                                       ; preds = %1
   %6 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %4
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %5, i32 0, i32 9
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  br label %12
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %7, i32 0, i32 6
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:12                                      ; preds = %entry, %9
-  %13 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %13, i32 0, i32 9
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %14, align 8
-  ret %System.String addrspace(1)* %15
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %6, i32 0, i32 9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  br label %15
+
+; <label>:15                                      ; preds = %1, %13
+  %16 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %16, i32 0, i32 9
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %18, align 8
+  ret %System.String addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3211,9 +4771,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
@@ -3263,9 +4831,17 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
-  store i8 %5, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %2, i32 0, i32 1
+  store i8 %5, i8 addrspace(1)* %7
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
@@ -3306,47 +4882,71 @@ entry:
 
 ; <label>:15                                      ; preds = %11
   %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
-  %18 = load i8, i8 addrspace(1)* %17, align 8
-  %19 = zext i8 %18 to i32
-  %20 = icmp eq i32 %19, 0
-  br i1 %20, label %37, label %21
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %16, null
+  br i1 %NullCheck, label %17, label %ThrowNullRef
 
-; <label>:21                                      ; preds = %15
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
-  %27 = load i32, i32 addrspace(1)* %26
-  %28 = icmp eq i32 %24, %27
-  br i1 %28, label %30, label %29
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %40, label %22
 
-; <label>:29                                      ; preds = %21
+; <label>:22                                      ; preds = %17
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %23, null
+  br i1 %NullCheck2, label %24, label %ThrowNullRef1
+
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %System.String, %System.String addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %27, null
+  br i1 %NullCheck4, label %28, label %ThrowNullRef3
+
+; <label>:28                                      ; preds = %24
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = icmp eq i32 %26, %30
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
   ret i8 0
 
-; <label>:30                                      ; preds = %21
-  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
-  %34 = icmp eq i32 %33, 0
-  %35 = sext i1 %34 to i32
-  %36 = trunc i32 %35 to i8
-  ret i8 %36
+; <label>:33                                      ; preds = %28
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %36 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %34, %System.String addrspace(1)* %35, i32 5)
+  %37 = icmp eq i32 %36, 0
+  %38 = sext i1 %37 to i32
+  %39 = trunc i32 %38 to i8
+  ret i8 %39
 
-; <label>:37                                      ; preds = %15
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
-  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
-  br i1 %NullCheck, label %40, label %ThrowNullRef
+; <label>:40                                      ; preds = %17
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %42 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %41, null
+  br i1 %NullCheck6, label %43, label %ThrowNullRef5
 
-; <label>:40                                      ; preds = %37
-  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
-  %42 = zext i8 %41 to i32
-  %43 = trunc i32 %42 to i8
-  ret i8 %43
+; <label>:43                                      ; preds = %40
+  %44 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %41, %System.String addrspace(1)* %42)
+  %45 = zext i8 %44 to i32
+  %46 = trunc i32 %45 to i8
+  ret i8 %46
 
-ThrowNullRef:                                     ; preds = %37
+ThrowNullRef:                                     ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %24
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %40
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3378,40 +4978,88 @@ entry:
   store %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %3, i32 0, i32 0
-  %5 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5, i32 0, i32 4
-  %7 = load i32, i32 addrspace(1)* %6, align 8
-  %8 = icmp eq i32 %2, %7
-  br i1 %8, label %10, label %9
+  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %0, i32 0, i32 3
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %4, i32 0, i32 0
+  %7 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %6, align 8
+  %NullCheck4 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, null
+  br i1 %NullCheck4, label %8, label %ThrowNullRef3
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %7, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp eq i32 %3, %10
+  br i1 %11, label %13, label %12
+
+; <label>:12                                      ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 32)
-  br label %10
+  br label %13
 
-; <label>:10                                      ; preds = %entry, %9
-  %11 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %12 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %13 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %12, i32 0, i32 0
-  %14 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %13, align 8
-  %15 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %14, i32 0, i32 3
-  %16 = load i32, i32 addrspace(1)* %15, align 8
-  %17 = add i32 %16, 1
-  %18 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %11, i32 0, i32 2
-  store i32 %17, i32 addrspace(1)* %18
-  %19 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
-  %NullCheck = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, null
-  br i1 %NullCheck, label %20, label %ThrowNullRef
+; <label>:13                                      ; preds = %8, %12
+  %14 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %15 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck6 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
 
-; <label>:20                                      ; preds = %10
-  %21 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %21, i32 0, i32 8)
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %15, i32 0, i32 0
+  %18 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %18, i32 0, i32 3
+  %21 = load i32, i32 addrspace(1)* %20, align 8
+  %22 = add i32 %21, 1
+  %NullCheck10 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, null
+  br i1 %NullCheck10, label %23, label %ThrowNullRef9
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %14, i32 0, i32 2
+  store i32 %22, i32 addrspace(1)* %24
+  %25 = load %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)** %this
+  %NullCheck12 = icmp ne %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, null
+  br i1 %NullCheck12, label %26, label %ThrowNullRef11
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %"System.Collections.Generic.List`1+Enumerator[System.__Canon]", %"System.Collections.Generic.List`1+Enumerator[System.__Canon]" addrspace(1)* %25, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.__Canon addrspace(1)* addrspace(1)*, i32, i32)*)(%System.__Canon addrspace(1)* addrspace(1)* %27, i32 0, i32 8)
   ret i8 0
 
-ThrowNullRef:                                     ; preds = %10
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %23
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3460,28 +5108,44 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
-  %2 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %"System.Byte[]" addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 6
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %"System.Byte[]" addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %"System.Byte[]" addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 6
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %5
-  %10 = bitcast %"System.Byte[]" addrspace(1)* %8 to %System.Array addrspace(1)*
-  %11 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %10)
-  %12 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %11)
-  ret %"System.Byte[]" addrspace(1)* %12
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 6
+  %10 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %"System.Byte[]" addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-ThrowNullRef:                                     ; preds = %5
+; <label>:11                                      ; preds = %8
+  %12 = bitcast %"System.Byte[]" addrspace(1)* %10 to %System.Array addrspace(1)*
+  %13 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %12)
+  %14 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %13)
+  ret %"System.Byte[]" addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3509,9 +5173,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection[System.__Canon,System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method KeyCollection::System.Collections.Generic.IEnumerable<TKey>.GetEnumerator using LLILCJit
@@ -3528,9 +5200,17 @@ entry:
   store %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
   store %System.RuntimeTypeHandle* %param1, %System.RuntimeTypeHandle** %"$TypeArg"
   %0 = load %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
-  %2 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.__Canon addrspace(1)* %2
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %3 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.__Canon addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -3563,97 +5243,177 @@ entry:
   %arg0 = alloca %System.String addrspace(1)*
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %1 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
-  %2 = load i32, i32 addrspace(1)* %1
-  %3 = icmp slt i32 %2, 3
-  br i1 %3, label %50, label %4
+  %NullCheck = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 2, i32 1
-  %7 = load i16, i16 addrspace(1)* %6
-  %8 = zext i16 %7 to i32
-  %9 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i64 2380
-  %11 = addrspacecast i8 addrspace(1)* %10 to i16*
-  %12 = load i16, i16* %11
-  %13 = zext i16 %12 to i32
-  %14 = icmp ne i32 %8, %13
-  br i1 %14, label %50, label %15
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.String, %System.String addrspace(1)* %0, i32 0, i32 1
+  %3 = load i32, i32 addrspace(1)* %2
+  %4 = icmp slt i32 %3, 3
+  br i1 %4, label %57, label %5
 
-; <label>:15                                      ; preds = %4
-  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 2
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
-  %21 = getelementptr inbounds i8, i8 addrspace(1)* %20, i64 2376
-  %22 = addrspacecast i8 addrspace(1)* %21 to i16*
-  %23 = load i16, i16* %22
-  %24 = zext i16 %23 to i32
-  %25 = icmp ne i32 %19, %24
-  br i1 %25, label %50, label %26
+; <label>:5                                       ; preds = %1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:26                                      ; preds = %15
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %28 = getelementptr inbounds %System.String, %System.String addrspace(1)* %27, i32 0, i32 2, i32 0
-  %29 = load i16, i16 addrspace(1)* %28
-  %30 = zext i16 %29 to i32
-  %31 = icmp slt i32 %30, 97
-  br i1 %31, label %38, label %32
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 1
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %12 = getelementptr inbounds i8, i8 addrspace(1)* %11, i64 2380
+  %13 = addrspacecast i8 addrspace(1)* %12 to i16*
+  %14 = load i16, i16* %13
+  %15 = zext i16 %14 to i32
+  %16 = icmp ne i32 %10, %15
+  br i1 %16, label %57, label %17
 
-; <label>:32                                      ; preds = %26
-  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %34 = getelementptr inbounds %System.String, %System.String addrspace(1)* %33, i32 0, i32 2, i32 0
-  %35 = load i16, i16 addrspace(1)* %34
-  %36 = zext i16 %35 to i32
-  %37 = icmp sle i32 %36, 122
-  br i1 %37, label %67, label %38
+; <label>:17                                      ; preds = %7
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
 
-; <label>:38                                      ; preds = %26, %32
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %40 = getelementptr inbounds %System.String, %System.String addrspace(1)* %39, i32 0, i32 2, i32 0
-  %41 = load i16, i16 addrspace(1)* %40
-  %42 = zext i16 %41 to i32
-  %43 = icmp slt i32 %42, 65
-  br i1 %43, label %50, label %44
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 2, i32 2
+  %21 = load i16, i16 addrspace(1)* %20
+  %22 = zext i16 %21 to i32
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1421)
+  %24 = getelementptr inbounds i8, i8 addrspace(1)* %23, i64 2376
+  %25 = addrspacecast i8 addrspace(1)* %24 to i16*
+  %26 = load i16, i16* %25
+  %27 = zext i16 %26 to i32
+  %28 = icmp ne i32 %22, %27
+  br i1 %28, label %57, label %29
 
-; <label>:44                                      ; preds = %38
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 0
+; <label>:29                                      ; preds = %19
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck6, label %31, label %ThrowNullRef5
+
+; <label>:31                                      ; preds = %29
+  %32 = getelementptr inbounds %System.String, %System.String addrspace(1)* %30, i32 0, i32 2, i32 0
+  %33 = load i16, i16 addrspace(1)* %32
+  %34 = zext i16 %33 to i32
+  %35 = icmp slt i32 %34, 97
+  br i1 %35, label %43, label %36
+
+; <label>:36                                      ; preds = %31
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %37, null
+  br i1 %NullCheck8, label %38, label %ThrowNullRef7
+
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.String, %System.String addrspace(1)* %37, i32 0, i32 2, i32 0
+  %40 = load i16, i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %77, label %43
+
+; <label>:43                                      ; preds = %31, %38
+  %44 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %44, null
+  br i1 %NullCheck10, label %45, label %ThrowNullRef9
+
+; <label>:45                                      ; preds = %43
+  %46 = getelementptr inbounds %System.String, %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
   %47 = load i16, i16 addrspace(1)* %46
   %48 = zext i16 %47 to i32
-  %49 = icmp sle i32 %48, 90
-  br i1 %49, label %67, label %50
+  %49 = icmp slt i32 %48, 65
+  br i1 %49, label %57, label %50
 
-; <label>:50                                      ; preds = %entry, %4, %15, %38, %44
+; <label>:50                                      ; preds = %45
   %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %52 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 1
-  %53 = load i32, i32 addrspace(1)* %52
-  %54 = icmp slt i32 %53, 2
-  br i1 %54, label %68, label %55
+  %NullCheck12 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:55                                      ; preds = %50
-  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %57 = getelementptr inbounds %System.String, %System.String addrspace(1)* %56, i32 0, i32 2, i32 0
-  %58 = load i16, i16 addrspace(1)* %57
-  %59 = zext i16 %58 to i32
-  %60 = icmp ne i32 %59, 92
-  br i1 %60, label %68, label %61
+; <label>:52                                      ; preds = %50
+  %53 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 0
+  %54 = load i16, i16 addrspace(1)* %53
+  %55 = zext i16 %54 to i32
+  %56 = icmp sle i32 %55, 90
+  br i1 %56, label %77, label %57
 
-; <label>:61                                      ; preds = %55
-  %62 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %63 = getelementptr inbounds %System.String, %System.String addrspace(1)* %62, i32 0, i32 2, i32 1
-  %64 = load i16, i16 addrspace(1)* %63
-  %65 = zext i16 %64 to i32
-  %66 = icmp ne i32 %65, 92
-  br i1 %66, label %68, label %67
+; <label>:57                                      ; preds = %1, %7, %19, %45, %52
+  %58 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck14 = icmp ne %System.String addrspace(1)* %58, null
+  br i1 %NullCheck14, label %59, label %ThrowNullRef13
 
-; <label>:67                                      ; preds = %32, %44, %61
+; <label>:59                                      ; preds = %57
+  %60 = getelementptr inbounds %System.String, %System.String addrspace(1)* %58, i32 0, i32 1
+  %61 = load i32, i32 addrspace(1)* %60
+  %62 = icmp slt i32 %61, 2
+  br i1 %62, label %78, label %63
+
+; <label>:63                                      ; preds = %59
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 2, i32 0
+  %67 = load i16, i16 addrspace(1)* %66
+  %68 = zext i16 %67 to i32
+  %69 = icmp ne i32 %68, 92
+  br i1 %69, label %78, label %70
+
+; <label>:70                                      ; preds = %65
+  %71 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck18 = icmp ne %System.String addrspace(1)* %71, null
+  br i1 %NullCheck18, label %72, label %ThrowNullRef17
+
+; <label>:72                                      ; preds = %70
+  %73 = getelementptr inbounds %System.String, %System.String addrspace(1)* %71, i32 0, i32 2, i32 1
+  %74 = load i16, i16 addrspace(1)* %73
+  %75 = zext i16 %74 to i32
+  %76 = icmp ne i32 %75, 92
+  br i1 %76, label %78, label %77
+
+; <label>:77                                      ; preds = %38, %52, %72
   ret i8 0
 
-; <label>:68                                      ; preds = %50, %55, %61
+; <label>:78                                      ; preds = %59, %65, %72
   ret i8 1
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %50
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::NormalizePath using LLILCJit
@@ -3679,30 +5439,38 @@ entry:
   store i32 %3, i32* %loc0
   %4 = load i32, i32* %loc0
   %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
-  %7 = load i32, i32 addrspace(1)* %6
-  %8 = icmp ne i32 %4, %7
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  ret %System.String addrspace(1)* %10
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = icmp ne i32 %4, %8
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry
-  %12 = load i32, i32* %loc0
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+; <label>:10                                      ; preds = %6
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %11
 
-; <label>:14                                      ; preds = %11
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  ret %System.String addrspace(1)* %15
+; <label>:12                                      ; preds = %6
+  %13 = load i32, i32* %loc0
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
 
-; <label>:16                                      ; preds = %11
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %18 = load i32, i32* %arg1
-  %19 = load i32, i32* %loc0
-  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
-  ret %System.String addrspace(1)* %20
+; <label>:15                                      ; preds = %12
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %16
+
+; <label>:17                                      ; preds = %12
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = load i32, i32* %arg1
+  %20 = load i32, i32* %loc0
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %18, i32 %19, i32 %20)
+  ret %System.String addrspace(1)* %21
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
@@ -3818,10 +5586,18 @@ entry:
   %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
   %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
-  ret i32 %5
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %5)
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::Append using LLILCJit
@@ -3837,65 +5613,121 @@ entry:
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = add i32 %1, 1
   %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = icmp slt i32 %2, %5
-  br i1 %6, label %11, label %7
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %9 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10, %System.String addrspace(1)* %9)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %10) #0
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 2
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %7 = icmp slt i32 %2, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %9)
+  %11 = call %System.IO.PathTooLongException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.PathTooLongException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*, %System.String addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11, %System.String addrspace(1)* %10)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathTooLongException addrspace(1)*)*)(%System.IO.PathTooLongException addrspace(1)* %11) #0
   unreachable
 
-; <label>:11                                      ; preds = %entry
-  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %13 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 5
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %36, label %17
+; <label>:12                                      ; preds = %4
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
 
-; <label>:17                                      ; preds = %11
-  %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %19 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %18, i32 0, i32 1
-  %20 = load i16*, i16* addrspace(1)* %19, align 8
-  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %22 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %21)
-  %23 = sext i32 %22 to i64
-  %24 = mul i64 %23, 2
-  %25 = bitcast i16* %20 to i8*
-  %26 = getelementptr inbounds i8, i8* %25, i64 %24
-  %27 = load i16, i16* %arg1
-  %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i16*
-  %30 = trunc i32 %28 to i16
-  store i16 %30, i16* %29, align 8
-  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  %33 = load i32, i32 addrspace(1)* %32, align 8
-  %34 = add i32 %33, 1
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
-  store i32 %34, i32 addrspace(1)* %35
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 5
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %42, label %19
+
+; <label>:19                                      ; preds = %14
+  %20 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %20, null
+  br i1 %NullCheck4, label %21, label %ThrowNullRef3
+
+; <label>:21                                      ; preds = %19
+  %22 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %20, i32 0, i32 1
+  %23 = load i16*, i16* addrspace(1)* %22, align 8
+  %24 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %25 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %24)
+  %26 = sext i32 %25 to i64
+  %27 = mul i64 %26, 2
+  %28 = bitcast i16* %23 to i8*
+  %29 = getelementptr inbounds i8, i8* %28, i64 %27
+  %30 = load i16, i16* %arg1
+  %31 = zext i16 %30 to i32
+  %32 = bitcast i8* %29 to i16*
+  %33 = trunc i32 %31 to i16
+  %NullCheck6 = icmp ne i16* %32, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
+
+; <label>:34                                      ; preds = %21
+  store i16 %33, i16* %32, align 8
+  %35 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck8, label %36, label %ThrowNullRef7
+
+; <label>:36                                      ; preds = %34
+  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = add i32 %38, 1
+  %NullCheck10 = icmp ne %System.IO.PathHelper addrspace(1)* %35, null
+  br i1 %NullCheck10, label %40, label %ThrowNullRef9
+
+; <label>:40                                      ; preds = %36
+  %41 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %35, i32 0, i32 3
+  store i32 %39, i32 addrspace(1)* %41
   ret void
 
-; <label>:36                                      ; preds = %11
-  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
-  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
-  %40 = load i16, i16* %arg1
-  %41 = zext i16 %40 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
-  br i1 %NullCheck, label %42, label %ThrowNullRef
+; <label>:42                                      ; preds = %14
+  %43 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %43, null
+  br i1 %NullCheck12, label %44, label %ThrowNullRef11
 
-; <label>:42                                      ; preds = %36
-  %43 = trunc i32 %41 to i16
-  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %43, i32 0, i32 0
+  %46 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, align 8
+  %47 = load i16, i16* %arg1
+  %48 = zext i16 %47 to i32
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %46, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %44
+  %50 = trunc i32 %48 to i16
+  %51 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %46, i16 %50)
   ret void
 
-ThrowNullRef:                                     ; preds = %36
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %44
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3908,30 +5740,54 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %9, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  ret i32 %8
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %11, label %6
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
-  br i1 %NullCheck, label %13, label %ThrowNullRef
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %9
-  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
-  ret i32 %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 3
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  ret i32 %10
 
-ThrowNullRef:                                     ; preds = %9
+; <label>:11                                      ; preds = %1
+  %12 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %12, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %13
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
+  ret i32 %17
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -3952,159 +5808,255 @@ entry:
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
   %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
   %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  %5 = icmp sge i32 %1, %4
-  br i1 %5, label %7, label %6
+  %NullCheck = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
+; <label>:3                                       ; preds = %entry
+  %4 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %5 = load i32, i32 addrspace(1)* %4
+  %6 = icmp sge i32 %1, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %3
   ret i8 0
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
-  %10 = load i8, i8 addrspace(1)* %9, align 8
-  %11 = zext i8 %10 to i32
-  %12 = icmp eq i32 %11, 0
-  br i1 %12, label %62, label %13
+; <label>:8                                       ; preds = %3
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %32, label %18
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %9, i32 0, i32 5
+  %12 = load i8, i8 addrspace(1)* %11, align 8
+  %13 = zext i8 %12 to i32
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %70, label %15
 
-; <label>:18                                      ; preds = %13
-  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
-  %21 = load i16*, i16* addrspace(1)* %20, align 8
-  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
-  %24 = load i32, i32 addrspace(1)* %23
-  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
-  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
-  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
-  br i1 %NullCheck, label %28, label %ThrowNullRef
+; <label>:15                                      ; preds = %10
+  %16 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %16)
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %36, label %20
 
-; <label>:28                                      ; preds = %18
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:20                                      ; preds = %15
+  %21 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %21, null
+  br i1 %NullCheck4, label %22, label %ThrowNullRef3
 
-; <label>:32                                      ; preds = %13
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %21, i32 0, i32 1
+  %24 = load i16*, i16* addrspace(1)* %23, align 8
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %25, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %28 = load i32, i32 addrspace(1)* %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %24, i32 0, i32 %28)
+  store %System.String addrspace(1)* %29, %System.String addrspace(1)** %loc0
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %30, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %26
+  %33 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %30, %System.String addrspace(1)* %31, i32 5)
+  %34 = zext i8 %33 to i32
+  %35 = trunc i32 %34 to i8
+  ret i8 %35
+
+; <label>:36                                      ; preds = %15
   store i32 0, i32* %loc1
-  br label %55
+  br label %62
 
-; <label>:33                                      ; preds = %55
-  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
-  %36 = load i16*, i16* addrspace(1)* %35, align 8
-  %37 = load i32, i32* %loc1
-  %38 = sext i32 %37 to i64
-  %39 = mul i64 %38, 2
-  %40 = bitcast i16* %36 to i8*
-  %41 = getelementptr inbounds i8, i8* %40, i64 %39
-  %42 = bitcast i8* %41 to i16*
-  %43 = load i16, i16* %42, align 8
-  %44 = zext i16 %43 to i32
-  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %46 = load i32, i32* %loc1
-  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
-  %48 = load i16, i16 addrspace(1)* %47
-  %49 = zext i16 %48 to i32
-  %50 = icmp eq i32 %44, %49
-  br i1 %50, label %52, label %51
+; <label>:37                                      ; preds = %65
+  %38 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.PathHelper addrspace(1)* %38, null
+  br i1 %NullCheck12, label %39, label %ThrowNullRef11
 
-; <label>:51                                      ; preds = %33
+; <label>:39                                      ; preds = %37
+  %40 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %38, i32 0, i32 1
+  %41 = load i16*, i16* addrspace(1)* %40, align 8
+  %42 = load i32, i32* %loc1
+  %43 = sext i32 %42 to i64
+  %44 = mul i64 %43, 2
+  %45 = bitcast i16* %41 to i8*
+  %46 = getelementptr inbounds i8, i8* %45, i64 %44
+  %47 = bitcast i8* %46 to i16*
+  %NullCheck14 = icmp ne i16* %47, null
+  br i1 %NullCheck14, label %48, label %ThrowNullRef13
+
+; <label>:48                                      ; preds = %39
+  %49 = load i16, i16* %47, align 8
+  %50 = zext i16 %49 to i32
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %52 = load i32, i32* %loc1
+  %NullCheck16 = icmp ne %System.String addrspace(1)* %51, null
+  br i1 %NullCheck16, label %53, label %ThrowNullRef15
+
+; <label>:53                                      ; preds = %48
+  %54 = getelementptr inbounds %System.String, %System.String addrspace(1)* %51, i32 0, i32 2, i32 %52
+  %55 = load i16, i16 addrspace(1)* %54
+  %56 = zext i16 %55 to i32
+  %57 = icmp eq i32 %50, %56
+  br i1 %57, label %59, label %58
+
+; <label>:58                                      ; preds = %53
   ret i8 0
 
-; <label>:52                                      ; preds = %33
-  %53 = load i32, i32* %loc1
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %loc1
-  br label %55
+; <label>:59                                      ; preds = %53
+  %60 = load i32, i32* %loc1
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %loc1
+  br label %62
 
-; <label>:55                                      ; preds = %32, %52
-  %56 = load i32, i32* %loc1
-  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
-  %59 = load i32, i32 addrspace(1)* %58
-  %60 = icmp slt i32 %56, %59
-  br i1 %60, label %33, label %61
+; <label>:62                                      ; preds = %36, %59
+  %63 = load i32, i32* %loc1
+  %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %64, null
+  br i1 %NullCheck10, label %65, label %ThrowNullRef9
 
-; <label>:61                                      ; preds = %55
+; <label>:65                                      ; preds = %62
+  %66 = getelementptr inbounds %System.String, %System.String addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = icmp slt i32 %63, %67
+  br i1 %68, label %37, label %69
+
+; <label>:69                                      ; preds = %65
   ret i8 1
 
-; <label>:62                                      ; preds = %7
-  %63 = load i8, i8* %arg2
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %86, label %66
+; <label>:70                                      ; preds = %10
+  %71 = load i8, i8* %arg2
+  %72 = zext i8 %71 to i32
+  %73 = icmp eq i32 %72, 0
+  br i1 %73, label %96, label %74
 
-; <label>:66                                      ; preds = %62
-  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
-  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 64
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 0
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
-  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
-  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
-  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+; <label>:74                                      ; preds = %70
+  %75 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.IO.PathHelper addrspace(1)* %75, null
+  br i1 %NullCheck18, label %76, label %ThrowNullRef17
 
-; <label>:82                                      ; preds = %66
-  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
-  %84 = zext i8 %83 to i32
-  %85 = trunc i32 %84 to i8
-  ret i8 %85
+; <label>:76                                      ; preds = %74
+  %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %79, null
+  br i1 %NullCheck20, label %80, label %ThrowNullRef19
 
-; <label>:86                                      ; preds = %62
-  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
-  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
-  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
-  %92 = add i64 %91, 64
-  %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
-  %95 = add i64 %94, 0
-  %96 = inttoptr i64 %95 to i64*
-  %97 = load i64, i64* %96
-  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
-  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
-  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
-  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+; <label>:80                                      ; preds = %76
+  %81 = load i64, i64 addrspace(1)* %79
+  %82 = add i64 %81, 64
+  %83 = inttoptr i64 %82 to i64*
+  %84 = load i64, i64* %83
+  %85 = add i64 %84, 0
+  %86 = inttoptr i64 %85 to i64*
+  %87 = load i64, i64* %86
+  %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
+  %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
+  %91 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.String addrspace(1)* %90, null
+  br i1 %NullCheck22, label %92, label %ThrowNullRef21
 
-; <label>:102                                     ; preds = %86
-  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
-  %104 = zext i8 %103 to i32
-  %105 = trunc i32 %104 to i8
-  ret i8 %105
+; <label>:92                                      ; preds = %80
+  %93 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %90, %System.String addrspace(1)* %91, i32 5)
+  %94 = zext i8 %93 to i32
+  %95 = trunc i32 %94 to i8
+  ret i8 %95
 
-ThrowNullRef:                                     ; preds = %18
+; <label>:96                                      ; preds = %70
+  %97 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.PathHelper addrspace(1)* %97, null
+  br i1 %NullCheck24, label %98, label %ThrowNullRef23
+
+; <label>:98                                      ; preds = %96
+  %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %101, null
+  br i1 %NullCheck26, label %102, label %ThrowNullRef25
+
+; <label>:102                                     ; preds = %98
+  %103 = load i64, i64 addrspace(1)* %101
+  %104 = add i64 %103, 64
+  %105 = inttoptr i64 %104 to i64*
+  %106 = load i64, i64* %105
+  %107 = add i64 %106, 0
+  %108 = inttoptr i64 %107 to i64*
+  %109 = load i64, i64* %108
+  %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
+  %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
+  %113 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck28 = icmp ne %System.String addrspace(1)* %112, null
+  br i1 %NullCheck28, label %114, label %ThrowNullRef27
+
+; <label>:114                                     ; preds = %102
+  %115 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %112, %System.String addrspace(1)* %113, i32 4)
+  %116 = zext i8 %115 to i32
+  %117 = trunc i32 %116 to i8
+  ret i8 %117
+
+ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %66
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %86
+ThrowNullRef3:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %48
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %74
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %98
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %102
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4117,18 +6069,42 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %4 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sext i32 %5 to i64
-  %7 = mul i64 %6, 2
-  %8 = bitcast i16* %2 to i8*
-  %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i16*
-  store i16 0, i16* %10, align 8
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 1
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sext i32 %7 to i64
+  %9 = mul i64 %8, 2
+  %10 = bitcast i16* %3 to i8*
+  %11 = getelementptr inbounds i8, i8* %10, i64 %9
+  %12 = bitcast i8* %11 to i16*
+  %NullCheck4 = icmp ne i16* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %5
+  store i16 0, i16* %12, align 8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
@@ -4143,37 +6119,69 @@ entry:
   %this = alloca %System.IO.PathHelper addrspace(1)*
   store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
   %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.IO.PathHelper addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
-  %8 = load i16*, i16* addrspace(1)* %7, align 8
-  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
-  ret %System.String addrspace(1)* %11
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %14, label %6
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
-  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 0
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
-  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
-  ret %System.String addrspace(1)* %26
+; <label>:6                                       ; preds = %1
+  %7 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.PathHelper addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %7, i32 0, i32 1
+  %10 = load i16*, i16* addrspace(1)* %9, align 8
+  %11 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %11)
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %10, i32 0, i32 %12)
+  ret %System.String addrspace(1)* %13
+
+; <label>:14                                      ; preds = %1
+  %15 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.PathHelper addrspace(1)* %15, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
+
+; <label>:16                                      ; preds = %14
+  %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %16
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 0
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
+  %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
+  ret %System.String addrspace(1)* %30
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -4360,220 +6368,316 @@ entry:
   %24 = load i32, i32* %loc0
   switch i32 %24, label %25 [
     i32 0, label %26
-    i32 1, label %53
-    i32 2, label %80
-    i32 3, label %107
-    i32 4, label %134
-    i32 5, label %149
+    i32 1, label %55
+    i32 2, label %84
+    i32 3, label %113
+    i32 4, label %142
+    i32 5, label %159
   ]
 
 ; <label>:25                                      ; preds = %22
-  br label %184
+  br label %196
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
   %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %29 = load i64, i64 addrspace(1)* %28
-  %30 = add i64 %29, 72
-  %31 = inttoptr i64 %30 to i64*
-  %32 = load i64, i64* %31
-  %33 = add i64 %32, 16
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load i64, i64* %34
-  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
-  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
-  %41 = load i64, i64 addrspace(1)* %40
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
-  %45 = add i64 %44, 48
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
-  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
-  %50 = icmp eq i32 %49, 0
-  %51 = sext i1 %50 to i32
-  %52 = trunc i32 %51 to i8
-  ret i8 %52
+  %NullCheck24 = icmp ne i64 addrspace(1)* %28, null
+  br i1 %NullCheck24, label %29, label %ThrowNullRef23
 
-; <label>:53                                      ; preds = %22
-  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
-  %56 = load i64, i64 addrspace(1)* %55
-  %57 = add i64 %56, 72
-  %58 = inttoptr i64 %57 to i64*
-  %59 = load i64, i64* %58
-  %60 = add i64 %59, 16
+; <label>:29                                      ; preds = %26
+  %30 = load i64, i64 addrspace(1)* %28
+  %31 = add i64 %30, 72
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = add i64 %33, 16
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %41, null
+  br i1 %NullCheck26, label %42, label %ThrowNullRef25
+
+; <label>:42                                      ; preds = %29
+  %43 = load i64, i64 addrspace(1)* %41
+  %44 = add i64 %43, 64
+  %45 = inttoptr i64 %44 to i64*
+  %46 = load i64, i64* %45
+  %47 = add i64 %46, 48
+  %48 = inttoptr i64 %47 to i64*
+  %49 = load i64, i64* %48
+  %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
+  %52 = icmp eq i32 %51, 0
+  %53 = sext i1 %52 to i32
+  %54 = trunc i32 %53 to i8
+  ret i8 %54
+
+; <label>:55                                      ; preds = %22
+  %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
+  %NullCheck20 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck20, label %58, label %ThrowNullRef19
+
+; <label>:58                                      ; preds = %55
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 72
   %61 = inttoptr i64 %60 to i64*
   %62 = load i64, i64* %61
-  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
-  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
-  %68 = load i64, i64 addrspace(1)* %67
-  %69 = add i64 %68, 64
-  %70 = inttoptr i64 %69 to i64*
-  %71 = load i64, i64* %70
-  %72 = add i64 %71, 48
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
-  %77 = icmp eq i32 %76, 0
-  %78 = sext i1 %77 to i32
-  %79 = trunc i32 %78 to i8
-  ret i8 %79
+  %63 = add i64 %62, 16
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
+  %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck22, label %71, label %ThrowNullRef21
 
-; <label>:80                                      ; preds = %22
-  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
-  %84 = add i64 %83, 72
-  %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
-  %87 = add i64 %86, 16
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
-  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
-  %95 = load i64, i64 addrspace(1)* %94
-  %96 = add i64 %95, 64
-  %97 = inttoptr i64 %96 to i64*
-  %98 = load i64, i64* %97
-  %99 = add i64 %98, 48
-  %100 = inttoptr i64 %99 to i64*
-  %101 = load i64, i64* %100
-  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
-  %104 = icmp eq i32 %103, 0
-  %105 = sext i1 %104 to i32
-  %106 = trunc i32 %105 to i8
-  ret i8 %106
+; <label>:71                                      ; preds = %58
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 64
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 48
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
+  %81 = icmp eq i32 %80, 0
+  %82 = sext i1 %81 to i32
+  %83 = trunc i32 %82 to i8
+  ret i8 %83
 
-; <label>:107                                     ; preds = %22
-  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
-  %110 = load i64, i64 addrspace(1)* %109
-  %111 = add i64 %110, 72
-  %112 = inttoptr i64 %111 to i64*
-  %113 = load i64, i64* %112
-  %114 = add i64 %113, 16
-  %115 = inttoptr i64 %114 to i64*
-  %116 = load i64, i64* %115
-  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
-  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
-  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
-  %123 = add i64 %122, 64
-  %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
-  %126 = add i64 %125, 48
-  %127 = inttoptr i64 %126 to i64*
-  %128 = load i64, i64* %127
-  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
-  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
-  %131 = icmp eq i32 %130, 0
-  %132 = sext i1 %131 to i32
-  %133 = trunc i32 %132 to i8
-  ret i8 %133
+; <label>:84                                      ; preds = %22
+  %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
+  %NullCheck16 = icmp ne i64 addrspace(1)* %86, null
+  br i1 %NullCheck16, label %87, label %ThrowNullRef15
 
-; <label>:134                                     ; preds = %22
-  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
-  %137 = load i32, i32 addrspace(1)* %136
-  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
-  %140 = load i32, i32 addrspace(1)* %139
-  %141 = icmp eq i32 %137, %140
-  br i1 %141, label %143, label %142
+; <label>:87                                      ; preds = %84
+  %88 = load i64, i64 addrspace(1)* %86
+  %89 = add i64 %88, 72
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = add i64 %91, 16
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
+  %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck18, label %100, label %ThrowNullRef17
 
-; <label>:142                                     ; preds = %134
+; <label>:100                                     ; preds = %87
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 48
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
+  %110 = icmp eq i32 %109, 0
+  %111 = sext i1 %110 to i32
+  %112 = trunc i32 %111 to i8
+  ret i8 %112
+
+; <label>:113                                     ; preds = %22
+  %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
+  %NullCheck12 = icmp ne i64 addrspace(1)* %115, null
+  br i1 %NullCheck12, label %116, label %ThrowNullRef11
+
+; <label>:116                                     ; preds = %113
+  %117 = load i64, i64 addrspace(1)* %115
+  %118 = add i64 %117, 72
+  %119 = inttoptr i64 %118 to i64*
+  %120 = load i64, i64* %119
+  %121 = add i64 %120, 16
+  %122 = inttoptr i64 %121 to i64*
+  %123 = load i64, i64* %122
+  %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %128, null
+  br i1 %NullCheck14, label %129, label %ThrowNullRef13
+
+; <label>:129                                     ; preds = %116
+  %130 = load i64, i64 addrspace(1)* %128
+  %131 = add i64 %130, 64
+  %132 = inttoptr i64 %131 to i64*
+  %133 = load i64, i64* %132
+  %134 = add i64 %133, 48
+  %135 = inttoptr i64 %134 to i64*
+  %136 = load i64, i64* %135
+  %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
+  %139 = icmp eq i32 %138, 0
+  %140 = sext i1 %139 to i32
+  %141 = trunc i32 %140 to i8
+  ret i8 %141
+
+; <label>:142                                     ; preds = %22
+  %143 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %143, null
+  br i1 %NullCheck8, label %144, label %ThrowNullRef7
+
+; <label>:144                                     ; preds = %142
+  %145 = getelementptr inbounds %System.String, %System.String addrspace(1)* %143, i32 0, i32 1
+  %146 = load i32, i32 addrspace(1)* %145
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck10 = icmp ne %System.String addrspace(1)* %147, null
+  br i1 %NullCheck10, label %148, label %ThrowNullRef9
+
+; <label>:148                                     ; preds = %144
+  %149 = getelementptr inbounds %System.String, %System.String addrspace(1)* %147, i32 0, i32 1
+  %150 = load i32, i32 addrspace(1)* %149
+  %151 = icmp eq i32 %146, %150
+  br i1 %151, label %153, label %152
+
+; <label>:152                                     ; preds = %148
   ret i8 0
 
-; <label>:143                                     ; preds = %134
-  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
-  %147 = zext i8 %146 to i32
-  %148 = trunc i32 %147 to i8
-  ret i8 %148
+; <label>:153                                     ; preds = %148
+  %154 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %155 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %156 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %154, %System.String addrspace(1)* %155)
+  %157 = zext i8 %156 to i32
+  %158 = trunc i32 %157 to i8
+  ret i8 %158
 
-; <label>:149                                     ; preds = %22
-  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
-  %152 = load i32, i32 addrspace(1)* %151
-  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
-  %155 = load i32, i32 addrspace(1)* %154
-  %156 = icmp eq i32 %152, %155
-  br i1 %156, label %158, label %157
+; <label>:159                                     ; preds = %22
+  %160 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %160, null
+  br i1 %NullCheck, label %161, label %ThrowNullRef
 
-; <label>:157                                     ; preds = %149
+; <label>:161                                     ; preds = %159
+  %162 = getelementptr inbounds %System.String, %System.String addrspace(1)* %160, i32 0, i32 1
+  %163 = load i32, i32 addrspace(1)* %162
+  %164 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %164, null
+  br i1 %NullCheck2, label %165, label %ThrowNullRef1
+
+; <label>:165                                     ; preds = %161
+  %166 = getelementptr inbounds %System.String, %System.String addrspace(1)* %164, i32 0, i32 1
+  %167 = load i32, i32 addrspace(1)* %166
+  %168 = icmp eq i32 %163, %167
+  br i1 %168, label %170, label %169
+
+; <label>:169                                     ; preds = %165
   ret i8 0
 
-; <label>:158                                     ; preds = %149
-  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
-  br i1 %NullCheck, label %160, label %ThrowNullRef
-
-; <label>:160                                     ; preds = %158
-  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
-  %162 = zext i8 %161 to i32
-  %163 = icmp eq i32 %162, 0
-  br i1 %163, label %177, label %164
-
-; <label>:164                                     ; preds = %160
-  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
-  br i1 %NullCheck2, label %166, label %ThrowNullRef1
-
-; <label>:166                                     ; preds = %164
-  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
-  %168 = zext i8 %167 to i32
-  %169 = icmp eq i32 %168, 0
-  br i1 %169, label %177, label %170
-
-; <label>:170                                     ; preds = %166
+; <label>:170                                     ; preds = %165
   %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
-  %174 = icmp eq i32 %173, 0
-  %175 = sext i1 %174 to i32
-  %176 = trunc i32 %175 to i8
-  ret i8 %176
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %171, null
+  br i1 %NullCheck4, label %172, label %ThrowNullRef3
 
-; <label>:177                                     ; preds = %160, %166
-  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+; <label>:172                                     ; preds = %170
+  %173 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %171)
+  %174 = zext i8 %173 to i32
+  %175 = icmp eq i32 %174, 0
+  br i1 %175, label %189, label %176
+
+; <label>:176                                     ; preds = %172
+  %177 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %177, null
+  br i1 %NullCheck6, label %178, label %ThrowNullRef5
+
+; <label>:178                                     ; preds = %176
+  %179 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %177)
+  %180 = zext i8 %179 to i32
   %181 = icmp eq i32 %180, 0
-  %182 = sext i1 %181 to i32
-  %183 = trunc i32 %182 to i8
-  ret i8 %183
+  br i1 %181, label %189, label %182
 
-; <label>:184                                     ; preds = %25
-  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
-  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+; <label>:182                                     ; preds = %178
+  %183 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %184 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %185 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %183, %System.String addrspace(1)* %184)
+  %186 = icmp eq i32 %185, 0
+  %187 = sext i1 %186 to i32
+  %188 = trunc i32 %187 to i8
+  ret i8 %188
+
+; <label>:189                                     ; preds = %172, %178
+  %190 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %191 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %192 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %190, %System.String addrspace(1)* %191)
+  %193 = icmp eq i32 %192, 0
+  %194 = sext i1 %193 to i32
+  %195 = trunc i32 %194 to i8
+  ret i8 %195
+
+; <label>:196                                     ; preds = %25
+  %197 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %198 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %197)
+  %199 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %200 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200, %System.String addrspace(1)* %198, %System.String addrspace(1)* %199)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %200) #0
   unreachable
 
-ThrowNullRef:                                     ; preds = %158
+ThrowNullRef:                                     ; preds = %159
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %164
+ThrowNullRef1:                                    ; preds = %161
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %170
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %176
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %113
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %84
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %87
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %29
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -4611,11 +6715,19 @@ entry:
   %11 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %12 = load i16*, i16** %loc0
   %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
-  %15 = load i32, i32 addrspace(1)* %14
-  %16 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %15)
+  %NullCheck = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck, label %14, label %ThrowNullRef
+
+; <label>:14                                      ; preds = %8
+  %15 = getelementptr inbounds %System.String, %System.String addrspace(1)* %13, i32 0, i32 1
+  %16 = load i32, i32 addrspace(1)* %15
+  %17 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %11, i16* %12, i32 %16)
   store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
   ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -4648,105 +6760,233 @@ entry:
 ; <label>:7                                       ; preds = %entry
   %8 = load i32, i32* %arg2
   %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
-  %11 = load i32, i32 addrspace(1)* %10, align 8
-  %12 = add i32 %8, %11
-  store i32 %12, i32* %loc0
-  %13 = load i32, i32* %loc0
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
-  %16 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
-  %18 = load i32, i32 addrspace(1)* %17
-  %19 = zext i32 %18 to i64
-  %20 = trunc i64 %19 to i32
-  %21 = icmp sgt i32 %13, %20
-  br i1 %21, label %34, label %22
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
 
-; <label>:22                                      ; preds = %7
-  %23 = load i16*, i16** %arg1
-  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
-  %26 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = add i32 %8, %12
+  store i32 %13, i32* %loc0
+  %14 = load i32, i32* %loc0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %15, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %10
+  %17 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %15, i32 0, i32 1
+  %18 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck4 = icmp ne %"System.Char[]" addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = zext i32 %21 to i64
+  %23 = trunc i64 %22 to i32
+  %24 = icmp sgt i32 %14, %23
+  br i1 %24, label %40, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i16*, i16** %arg1
   %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = load i32, i32* %arg2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %27, null
+  br i1 %NullCheck6, label %28, label %ThrowNullRef5
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 1
+  %30 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %29, align 8
   %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = load i32, i32* %loc0
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck8, label %32, label %ThrowNullRef7
+
+; <label>:32                                      ; preds = %28
   %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 %32, i32 addrspace(1)* %33
-  br label %86
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %35 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %26, %"System.Char[]" addrspace(1)* %30, i32 %34, i32 %35)
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %37 = load i32, i32* %loc0
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %38, label %ThrowNullRef9
 
-; <label>:34                                      ; preds = %7
-  %35 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
-  %37 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
-  %38 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
-  %39 = load i32, i32 addrspace(1)* %38
-  %40 = zext i32 %39 to i64
-  %41 = trunc i64 %40 to i32
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = sub i32 %41, %44
-  store i32 %45, i32* %loc1
-  %46 = load i32, i32* %loc1
-  %47 = icmp sle i32 %46, 0
-  br i1 %47, label %66, label %48
+; <label>:38                                      ; preds = %32
+  %39 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 %37, i32 addrspace(1)* %39
+  br label %102
 
-; <label>:48                                      ; preds = %34
-  %49 = load i16*, i16** %arg1
+; <label>:40                                      ; preds = %19
+  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
+
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
+  %44 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %43, align 8
+  %NullCheck14 = icmp ne %"System.Char[]" addrspace(1)* %44, null
+  br i1 %NullCheck14, label %45, label %ThrowNullRef13
+
+; <label>:45                                      ; preds = %42
+  %46 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %44, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
   %50 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %51 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
-  %52 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = load i32, i32* %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %58 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
-  %60 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
-  %61 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
-  %62 = load i32, i32 addrspace(1)* %61
-  %63 = zext i32 %62 to i64
-  %64 = trunc i64 %63 to i32
-  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  store i32 %64, i32 addrspace(1)* %65
-  br label %66
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %50, null
+  br i1 %NullCheck16, label %51, label %ThrowNullRef15
 
-; <label>:66                                      ; preds = %34, %48
-  %67 = load i32, i32* %arg2
-  %68 = load i32, i32* %loc1
-  %69 = sub i32 %67, %68
-  store i32 %69, i32* %loc2
-  %70 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %71 = load i32, i32* %loc2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
-  %72 = load i16*, i16** %arg1
-  %73 = load i32, i32* %loc1
-  %74 = sext i32 %73 to i64
-  %75 = mul i64 %74, 2
-  %76 = bitcast i16* %72 to i8*
-  %77 = getelementptr inbounds i8, i8* %76, i64 %75
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 1
-  %80 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %79, align 8
-  %81 = load i32, i32* %loc2
-  %82 = bitcast i8* %77 to i16*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %82, %"System.Char[]" addrspace(1)* %80, i32 0, i32 %81)
-  %83 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %84 = load i32, i32* %loc2
-  %85 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %83, i32 0, i32 3
-  store i32 %84, i32 addrspace(1)* %85
-  br label %86
+; <label>:51                                      ; preds = %45
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 3
+  %53 = load i32, i32 addrspace(1)* %52, align 8
+  %54 = sub i32 %49, %53
+  store i32 %54, i32* %loc1
+  %55 = load i32, i32* %loc1
+  %56 = icmp sle i32 %55, 0
+  br i1 %56, label %80, label %57
 
-; <label>:86                                      ; preds = %22, %66
-  %87 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  ret %System.Text.StringBuilder addrspace(1)* %87
+; <label>:57                                      ; preds = %51
+  %58 = load i16*, i16** %arg1
+  %59 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %59, null
+  br i1 %NullCheck18, label %60, label %ThrowNullRef17
+
+; <label>:60                                      ; preds = %57
+  %61 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %59, i32 0, i32 1
+  %62 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %63, null
+  br i1 %NullCheck20, label %64, label %ThrowNullRef19
+
+; <label>:64                                      ; preds = %60
+  %65 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %63, i32 0, i32 3
+  %66 = load i32, i32 addrspace(1)* %65, align 8
+  %67 = load i32, i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %58, %"System.Char[]" addrspace(1)* %62, i32 %66, i32 %67)
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* %69, null
+  br i1 %NullCheck22, label %70, label %ThrowNullRef21
+
+; <label>:70                                      ; preds = %64
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %69, i32 0, i32 1
+  %72 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %71, align 8
+  %NullCheck24 = icmp ne %"System.Char[]" addrspace(1)* %72, null
+  br i1 %NullCheck24, label %73, label %ThrowNullRef23
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %72, i32 0, i32 1
+  %75 = load i32, i32 addrspace(1)* %74
+  %76 = zext i32 %75 to i64
+  %77 = trunc i64 %76 to i32
+  %NullCheck26 = icmp ne %System.Text.StringBuilder addrspace(1)* %68, null
+  br i1 %NullCheck26, label %78, label %ThrowNullRef25
+
+; <label>:78                                      ; preds = %73
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %77, i32 addrspace(1)* %79
+  br label %80
+
+; <label>:80                                      ; preds = %51, %78
+  %81 = load i32, i32* %arg2
+  %82 = load i32, i32* %loc1
+  %83 = sub i32 %81, %82
+  store i32 %83, i32* %loc2
+  %84 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %85 = load i32, i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %84, i32 %85)
+  %86 = load i16*, i16** %arg1
+  %87 = load i32, i32* %loc1
+  %88 = sext i32 %87 to i64
+  %89 = mul i64 %88, 2
+  %90 = bitcast i16* %86 to i8*
+  %91 = getelementptr inbounds i8, i8* %90, i64 %89
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck28, label %93, label %ThrowNullRef27
+
+; <label>:93                                      ; preds = %80
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 1
+  %95 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %94, align 8
+  %96 = load i32, i32* %loc2
+  %97 = bitcast i8* %91 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %97, %"System.Char[]" addrspace(1)* %95, i32 0, i32 %96)
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %99 = load i32, i32* %loc2
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck30, label %100, label %ThrowNullRef29
+
+; <label>:100                                     ; preds = %93
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 3
+  store i32 %99, i32 addrspace(1)* %101
+  br label %102
+
+; <label>:102                                     ; preds = %38, %100
+  %103 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %103
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %93
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ExpandByABlock using LLILCJit
@@ -4764,71 +7004,143 @@ entry:
   %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %1)
   %3 = add i32 %0, %2
   %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
-  %6 = load i32, i32 addrspace(1)* %5, align 8
-  %7 = icmp sle i32 %3, %6
-  br i1 %7, label %13, label %8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 5
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = icmp sle i32 %3, %7
+  br i1 %8, label %14, label %9
+
+; <label>:9                                       ; preds = %5
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
-  %12 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12, %System.String addrspace(1)* %9, %System.String addrspace(1)* %11)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %12) #0
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %10, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
   unreachable
 
-; <label>:13                                      ; preds = %entry
-  %14 = load i32, i32* %arg1
-  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %16 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %15)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %16, i32 8000)
-  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %14, i32 %17)
-  store i32 %18, i32* %loc0
-  %19 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+; <label>:14                                      ; preds = %5
+  %15 = load i32, i32* %arg1
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %16)
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %17, i32 8000)
+  %19 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 %15, i32 %18)
+  store i32 %19, i32* %loc0
   %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %21 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %19, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %26, i32 0, i32 3
-  %28 = load i32, i32 addrspace(1)* %27, align 8
-  %29 = add i32 %25, %28
-  %30 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
-  store i32 %29, i32 addrspace(1)* %30
-  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %32 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %32
-  %33 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %33, i32 0, i32 4
-  %35 = load i32, i32 addrspace(1)* %34, align 8
-  %36 = load i32, i32* %loc0
-  %37 = add i32 %35, %36
-  %38 = load i32, i32* %loc0
-  %39 = icmp sge i32 %37, %38
-  br i1 %39, label %44, label %40
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %22 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %22, %System.Text.StringBuilder addrspace(1)* %21)
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %20, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
 
-; <label>:40                                      ; preds = %13
-  %41 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %42 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %41, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %42, %"System.Char[]" addrspace(1)* null)
-  %43 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %43) #0
+; <label>:23                                      ; preds = %14
+  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %24, %System.Text.StringBuilder addrspace(1)* %22)
+  %25 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck4, label %26, label %ThrowNullRef3
+
+; <label>:26                                      ; preds = %23
+  %27 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  %28 = load i32, i32 addrspace(1)* %27, align 8
+  %29 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %29, null
+  br i1 %NullCheck6, label %30, label %ThrowNullRef5
+
+; <label>:30                                      ; preds = %26
+  %31 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %29, i32 0, i32 3
+  %32 = load i32, i32 addrspace(1)* %31, align 8
+  %33 = add i32 %28, %32
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %25, null
+  br i1 %NullCheck8, label %34, label %ThrowNullRef7
+
+; <label>:34                                      ; preds = %30
+  %35 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %25, i32 0, i32 4
+  store i32 %33, i32 addrspace(1)* %35
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %36, null
+  br i1 %NullCheck10, label %37, label %ThrowNullRef9
+
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %38
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck12, label %40, label %ThrowNullRef11
+
+; <label>:40                                      ; preds = %37
+  %41 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %39, i32 0, i32 4
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load i32, i32* %loc0
+  %44 = add i32 %42, %43
+  %45 = load i32, i32* %loc0
+  %46 = icmp sge i32 %44, %45
+  br i1 %46, label %52, label %47
+
+; <label>:47                                      ; preds = %40
+  %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %48, null
+  br i1 %NullCheck14, label %49, label %ThrowNullRef13
+
+; <label>:49                                      ; preds = %47
+  %50 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %48, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %50, %"System.Char[]" addrspace(1)* null)
+  %51 = call %System.OutOfMemoryException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.OutOfMemoryException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.OutOfMemoryException addrspace(1)*)*)(%System.OutOfMemoryException addrspace(1)* %51) #0
   unreachable
 
-; <label>:44                                      ; preds = %13
-  %45 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %46 = load i32, i32* %loc0
-  %47 = sext i32 %46 to i64
-  %48 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %47)
-  %49 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %45, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %49, %"System.Char[]" addrspace(1)* %48)
+; <label>:52                                      ; preds = %40
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %54 = load i32, i32* %loc0
+  %55 = sext i32 %54 to i64
+  %56 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %55)
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %53, null
+  br i1 %NullCheck16, label %57, label %ThrowNullRef15
+
+; <label>:57                                      ; preds = %52
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %58, %"System.Char[]" addrspace(1)* %56)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %47
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::get_Length using LLILCJit
@@ -4839,13 +7151,29 @@ entry:
   %this = alloca %System.Text.StringBuilder addrspace(1)*
   store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
   %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = add i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %4, i32 0, i32 3
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = add i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Math::Max using LLILCJit
@@ -4885,35 +7213,115 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
   %3 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
-  store i32 %5, i32 addrspace(1)* %6
-  %7 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %7, i32 0, i32 4
-  store i32 %10, i32 addrspace(1)* %11
-  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %13 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %14 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %13, i32 0, i32 1
-  %15 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %14, align 8
-  %16 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %12, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %16, %"System.Char[]" addrspace(1)* %15)
-  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %18, i32 0, i32 2
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)* %20)
-  %22 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
-  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
-  %24 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 5
-  %25 = load i32, i32 addrspace(1)* %24, align 8
-  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %22, i32 0, i32 5
-  store i32 %25, i32 addrspace(1)* %26
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %6 = load i32, i32 addrspace(1)* %5, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %2, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %2, i32 0, i32 3
+  store i32 %6, i32 addrspace(1)* %8
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %10 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %10, i32 0, i32 4
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %11
+  %15 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  store i32 %13, i32 addrspace(1)* %15
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %17 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* %17, null
+  br i1 %NullCheck8, label %18, label %ThrowNullRef7
+
+; <label>:18                                      ; preds = %14
+  %19 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %17, i32 0, i32 1
+  %20 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %19, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %NullCheck10, label %21, label %ThrowNullRef9
+
+; <label>:21                                      ; preds = %18
+  %22 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %16, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %22, %"System.Char[]" addrspace(1)* %20)
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %24 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* %24, null
+  br i1 %NullCheck12, label %25, label %ThrowNullRef11
+
+; <label>:25                                      ; preds = %21
+  %26 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 2
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck14, label %28, label %ThrowNullRef13
+
+; <label>:28                                      ; preds = %25
+  %29 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %29, %System.Text.StringBuilder addrspace(1)* %27)
+  %30 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %31 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Text.StringBuilder addrspace(1)* %31, null
+  br i1 %NullCheck16, label %32, label %ThrowNullRef15
+
+; <label>:32                                      ; preds = %28
+  %33 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 5
+  %34 = load i32, i32 addrspace(1)* %33, align 8
+  %NullCheck18 = icmp ne %System.Text.StringBuilder addrspace(1)* %30, null
+  br i1 %NullCheck18, label %35, label %ThrowNullRef17
+
+; <label>:35                                      ; preds = %32
+  %36 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %30, i32 0, i32 5
+  store i32 %34, i32 addrspace(1)* %36
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::Append using LLILCJit
@@ -5044,163 +7452,443 @@ entry:
   store i32 0, i32* %loc2
   br label %5
 
-; <label>:5                                       ; preds = %48, %entry
+; <label>:5                                       ; preds = %65, %entry
   %6 = load i32, i32* %loc0
   %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
-  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
-  %10 = load i32, i32 addrspace(1)* %9, align 8
-  %11 = sub i32 %6, %10
-  %12 = icmp slt i32 %11, 0
-  br i1 %12, label %40, label %13
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:13                                      ; preds = %5
-  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
-  br i1 %15, label %24, label %16
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck2 = icmp ne %System.Text.StringBuilder addrspace(1)* %9, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
 
-; <label>:16                                      ; preds = %13
-  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
-  %19 = load i32, i32* %loc0
-  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
-  %22 = load i32, i32 addrspace(1)* %21, align 8
-  %23 = sub i32 %19, %22
-  store i32 %23, i32* %loc2
-  br label %24
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 4
+  %12 = load i32, i32 addrspace(1)* %11, align 8
+  %13 = sub i32 %6, %12
+  %14 = icmp slt i32 %13, 0
+  br i1 %14, label %49, label %15
 
-; <label>:24                                      ; preds = %13, %16
-  %25 = load i32, i32* %arg1
-  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
-  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
-  %29 = load i32, i32 addrspace(1)* %28, align 8
-  %30 = sub i32 %25, %29
-  %31 = icmp slt i32 %30, 0
-  br i1 %31, label %48, label %32
+; <label>:15                                      ; preds = %10
+  %16 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %17 = icmp ne %System.Text.StringBuilder addrspace(1)* %16, null
+  br i1 %17, label %28, label %18
 
-; <label>:32                                      ; preds = %24
-  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %34 = load i32, i32* %arg1
-  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
-  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
-  %38 = load i32, i32 addrspace(1)* %37, align 8
-  %39 = sub i32 %34, %38
-  store i32 %39, i32 addrspace(1)* %33, align 8
-  br label %54
+; <label>:18                                      ; preds = %15
+  %19 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck4 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
 
-; <label>:40                                      ; preds = %5
+; <label>:20                                      ; preds = %18
+  %21 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %19, align 8
+  store %System.Text.StringBuilder addrspace(1)* %21, %System.Text.StringBuilder addrspace(1)** %loc1
+  %22 = load i32, i32* %loc0
+  %23 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck6 = icmp ne %System.Text.StringBuilder addrspace(1)* %23, null
+  br i1 %NullCheck6, label %24, label %ThrowNullRef5
+
+; <label>:24                                      ; preds = %20
+  %25 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %23, i32 0, i32 4
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %22, %26
+  store i32 %27, i32* %loc2
+  br label %28
+
+; <label>:28                                      ; preds = %15, %24
+  %29 = load i32, i32* %arg1
+  %30 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck8 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, null
+  br i1 %NullCheck8, label %31, label %ThrowNullRef7
+
+; <label>:31                                      ; preds = %28
+  %32 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %30, align 8
+  %NullCheck10 = icmp ne %System.Text.StringBuilder addrspace(1)* %32, null
+  br i1 %NullCheck10, label %33, label %ThrowNullRef9
+
+; <label>:33                                      ; preds = %31
+  %34 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %32, i32 0, i32 4
+  %35 = load i32, i32 addrspace(1)* %34, align 8
+  %36 = sub i32 %29, %35
+  %37 = icmp slt i32 %36, 0
+  br i1 %37, label %60, label %38
+
+; <label>:38                                      ; preds = %33
+  %39 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %40 = load i32, i32* %arg1
   %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
-  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  %44 = load i32, i32 addrspace(1)* %43, align 8
-  %45 = load i32, i32* %arg2
-  %46 = sub i32 %44, %45
-  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
-  store i32 %46, i32 addrspace(1)* %47
-  br label %48
+  %NullCheck12 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, null
+  br i1 %NullCheck12, label %42, label %ThrowNullRef11
 
-; <label>:48                                      ; preds = %24, %40
-  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:42                                      ; preds = %38
+  %43 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %NullCheck14 = icmp ne %System.Text.StringBuilder addrspace(1)* %43, null
+  br i1 %NullCheck14, label %44, label %ThrowNullRef13
+
+; <label>:44                                      ; preds = %42
+  %45 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %43, i32 0, i32 4
+  %46 = load i32, i32 addrspace(1)* %45, align 8
+  %47 = sub i32 %40, %46
+  %NullCheck16 = icmp ne i32 addrspace(1)* %39, null
+  br i1 %NullCheck16, label %48, label %ThrowNullRef15
+
+; <label>:48                                      ; preds = %44
+  store i32 %47, i32 addrspace(1)* %39, align 8
+  br label %68
+
+; <label>:49                                      ; preds = %10
   %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
-  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
-  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  %NullCheck64 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, null
+  br i1 %NullCheck64, label %51, label %ThrowNullRef63
+
+; <label>:51                                      ; preds = %49
+  %52 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %NullCheck66 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck66, label %53, label %ThrowNullRef65
+
+; <label>:53                                      ; preds = %51
+  %54 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = load i32, i32* %arg2
+  %57 = sub i32 %55, %56
+  %NullCheck68 = icmp ne %System.Text.StringBuilder addrspace(1)* %52, null
+  br i1 %NullCheck68, label %58, label %ThrowNullRef67
+
+; <label>:58                                      ; preds = %53
+  %59 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %52, i32 0, i32 4
+  store i32 %57, i32 addrspace(1)* %59
+  br label %60
+
+; <label>:60                                      ; preds = %33, %58
+  %61 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %62 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck60 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, null
+  br i1 %NullCheck60, label %63, label %ThrowNullRef59
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %62, align 8
+  %NullCheck62 = icmp ne %System.Text.StringBuilder addrspace(1)* %64, null
+  br i1 %NullCheck62, label %65, label %ThrowNullRef61
+
+; <label>:65                                      ; preds = %63
+  %66 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %64, i32 0, i32 2
+  %67 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %66, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %61, %System.Text.StringBuilder addrspace(1)* %67)
   br label %5
 
-; <label>:54                                      ; preds = %32
-  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %56 = load i32, i32 addrspace(1)* %55, align 8
-  store i32 %56, i32* %loc3
-  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
-  %59 = load i32, i32 addrspace(1)* %58, align 8
-  %60 = load i32, i32* %loc2
-  %61 = sub i32 %59, %60
-  store i32 %61, i32* %loc4
-  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
-  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
-  br i1 %65, label %99, label %66
-
-; <label>:66                                      ; preds = %54
-  store i32 0, i32* %loc3
-  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+; <label>:68                                      ; preds = %48
   %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %70 = load i32, i32 addrspace(1)* %69, align 8
-  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
-  store i32 %70, i32 addrspace(1)* %71
+  %NullCheck18 = icmp ne i32 addrspace(1)* %69, null
+  br i1 %NullCheck18, label %70, label %ThrowNullRef17
+
+; <label>:70                                      ; preds = %68
+  %71 = load i32, i32 addrspace(1)* %69, align 8
+  store i32 %71, i32* %loc3
   %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
-  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
-  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
-  %80 = load i32, i32 addrspace(1)* %79, align 8
-  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
-  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
-  %84 = load i32, i32 addrspace(1)* %83, align 8
-  %85 = add i32 %80, %84
-  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
-  store i32 %85, i32 addrspace(1)* %86
+  %NullCheck20 = icmp ne %System.Text.StringBuilder addrspace(1)* %72, null
+  br i1 %NullCheck20, label %73, label %ThrowNullRef19
+
+; <label>:73                                      ; preds = %70
+  %74 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %75 = load i32, i32 addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc2
+  %77 = sub i32 %75, %76
+  store i32 %77, i32* %loc4
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %79 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck22 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, null
+  br i1 %NullCheck22, label %80, label %ThrowNullRef21
+
+; <label>:80                                      ; preds = %73
+  %81 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %79, align 8
+  %82 = icmp eq %System.Text.StringBuilder addrspace(1)* %78, %81
+  br i1 %82, label %130, label %83
+
+; <label>:83                                      ; preds = %80
+  store i32 0, i32* %loc3
+  %84 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck24 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, null
+  br i1 %NullCheck24, label %85, label %ThrowNullRef23
+
+; <label>:85                                      ; preds = %83
+  %86 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %84, align 8
   %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %88 = load i32, i32 addrspace(1)* %87, align 8
-  %89 = icmp ne i32 %88, 0
-  br i1 %89, label %99, label %90
+  %NullCheck26 = icmp ne i32 addrspace(1)* %87, null
+  br i1 %NullCheck26, label %88, label %ThrowNullRef25
 
-; <label>:90                                      ; preds = %66
-  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
-  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
-  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
-  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
-  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
-  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+; <label>:88                                      ; preds = %85
+  %89 = load i32, i32 addrspace(1)* %87, align 8
+  %NullCheck28 = icmp ne %System.Text.StringBuilder addrspace(1)* %86, null
+  br i1 %NullCheck28, label %90, label %ThrowNullRef27
+
+; <label>:90                                      ; preds = %88
+  %91 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %86, i32 0, i32 3
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %93 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck30 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, null
+  br i1 %NullCheck30, label %94, label %ThrowNullRef29
+
+; <label>:94                                      ; preds = %90
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %93, align 8
+  %NullCheck32 = icmp ne %System.Text.StringBuilder addrspace(1)* %92, null
+  br i1 %NullCheck32, label %96, label %ThrowNullRef31
+
+; <label>:96                                      ; preds = %94
+  %97 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %92, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %95)
   %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
-  br label %99
+  %99 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck34 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, null
+  br i1 %NullCheck34, label %100, label %ThrowNullRef33
 
-; <label>:99                                      ; preds = %54, %66, %90
-  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  %102 = load i32, i32 addrspace(1)* %101, align 8
-  %103 = load i32, i32* %loc2
-  %104 = load i32, i32* %loc3
-  %105 = sub i32 %103, %104
-  %106 = sub i32 %102, %105
-  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
-  store i32 %106, i32 addrspace(1)* %107
-  %108 = load i32, i32* %loc3
-  %109 = load i32, i32* %loc2
-  %110 = icmp eq i32 %108, %109
-  br i1 %110, label %121, label %111
+; <label>:100                                     ; preds = %96
+  %101 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
+  %NullCheck36 = icmp ne %System.Text.StringBuilder addrspace(1)* %101, null
+  br i1 %NullCheck36, label %102, label %ThrowNullRef35
 
-; <label>:111                                     ; preds = %99
-  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
-  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
-  %115 = load i32, i32* %loc2
-  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
-  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
-  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
-  %119 = load i32, i32* %loc3
-  %120 = load i32, i32* %loc4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
-  br label %121
+; <label>:102                                     ; preds = %100
+  %103 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %101, i32 0, i32 4
+  %104 = load i32, i32 addrspace(1)* %103, align 8
+  %105 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck38 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, null
+  br i1 %NullCheck38, label %106, label %ThrowNullRef37
 
-; <label>:121                                     ; preds = %99, %111
+; <label>:106                                     ; preds = %102
+  %107 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %105, align 8
+  %NullCheck40 = icmp ne %System.Text.StringBuilder addrspace(1)* %107, null
+  br i1 %NullCheck40, label %108, label %ThrowNullRef39
+
+; <label>:108                                     ; preds = %106
+  %109 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %107, i32 0, i32 3
+  %110 = load i32, i32 addrspace(1)* %109, align 8
+  %111 = add i32 %104, %110
+  %NullCheck42 = icmp ne %System.Text.StringBuilder addrspace(1)* %98, null
+  br i1 %NullCheck42, label %112, label %ThrowNullRef41
+
+; <label>:112                                     ; preds = %108
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %98, i32 0, i32 4
+  store i32 %111, i32 addrspace(1)* %113
+  %114 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %NullCheck44 = icmp ne i32 addrspace(1)* %114, null
+  br i1 %NullCheck44, label %115, label %ThrowNullRef43
+
+; <label>:115                                     ; preds = %112
+  %116 = load i32, i32 addrspace(1)* %114, align 8
+  %117 = icmp ne i32 %116, 0
+  br i1 %117, label %130, label %118
+
+; <label>:118                                     ; preds = %115
+  %119 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %120 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %NullCheck46 = icmp ne %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, null
+  br i1 %NullCheck46, label %121, label %ThrowNullRef45
+
+; <label>:121                                     ; preds = %118
+  %122 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %120, align 8
+  %NullCheck48 = icmp ne %System.Text.StringBuilder addrspace(1)* %122, null
+  br i1 %NullCheck48, label %123, label %ThrowNullRef47
+
+; <label>:123                                     ; preds = %121
+  %124 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %122, i32 0, i32 2
+  %125 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %124, align 8
+  %NullCheck50 = icmp ne %System.Text.StringBuilder addrspace(1)* %119, null
+  br i1 %NullCheck50, label %126, label %ThrowNullRef49
+
+; <label>:126                                     ; preds = %123
+  %127 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %119, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %127, %System.Text.StringBuilder addrspace(1)* %125)
+  %128 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %129 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %128, %System.Text.StringBuilder addrspace(1)* %129)
+  br label %130
+
+; <label>:130                                     ; preds = %80, %115, %126
+  %131 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck52 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck52, label %132, label %ThrowNullRef51
+
+; <label>:132                                     ; preds = %130
+  %133 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  %134 = load i32, i32 addrspace(1)* %133, align 8
+  %135 = load i32, i32* %loc2
+  %136 = load i32, i32* %loc3
+  %137 = sub i32 %135, %136
+  %138 = sub i32 %134, %137
+  %NullCheck54 = icmp ne %System.Text.StringBuilder addrspace(1)* %131, null
+  br i1 %NullCheck54, label %139, label %ThrowNullRef53
+
+; <label>:139                                     ; preds = %132
+  %140 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %131, i32 0, i32 3
+  store i32 %138, i32 addrspace(1)* %140
+  %141 = load i32, i32* %loc3
+  %142 = load i32, i32* %loc2
+  %143 = icmp eq i32 %141, %142
+  br i1 %143, label %156, label %144
+
+; <label>:144                                     ; preds = %139
+  %145 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck56 = icmp ne %System.Text.StringBuilder addrspace(1)* %145, null
+  br i1 %NullCheck56, label %146, label %ThrowNullRef55
+
+; <label>:146                                     ; preds = %144
+  %147 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %145, i32 0, i32 1
+  %148 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %147, align 8
+  %149 = load i32, i32* %loc2
+  %150 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %NullCheck58 = icmp ne %System.Text.StringBuilder addrspace(1)* %150, null
+  br i1 %NullCheck58, label %151, label %ThrowNullRef57
+
+; <label>:151                                     ; preds = %146
+  %152 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %150, i32 0, i32 1
+  %153 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %152, align 8
+  %154 = load i32, i32* %loc3
+  %155 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %148, i32 %149, %"System.Char[]" addrspace(1)* %153, i32 %154, i32 %155)
+  br label %156
+
+; <label>:156                                     ; preds = %139, %151
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %28
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %70
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %88
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %96
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %106
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %108
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef43:                                   ; preds = %112
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef45:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef47:                                   ; preds = %121
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef49:                                   ; preds = %123
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef51:                                   ; preds = %130
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef53:                                   ; preds = %132
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef55:                                   ; preds = %144
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef57:                                   ; preds = %146
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef59:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef61:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef63:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef65:                                   ; preds = %51
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef67:                                   ; preds = %53
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -5235,28 +7923,60 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %6 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %5, i32 0, i32 2
-  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
-  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
-  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
-  %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 2
-  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+; <label>:5                                       ; preds = %1
+  %6 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %6, i32 0, i32 2
+  %9 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %8, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %9
+
+; <label>:10                                      ; preds = %1
+  %11 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %12 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12)
+  %13 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %11, null
+  br i1 %NullCheck4, label %14, label %ThrowNullRef3
+
+; <label>:14                                      ; preds = %10
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %11, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %15, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %13)
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck6, label %17, label %ThrowNullRef5
+
+; <label>:17                                      ; preds = %14
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 2
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %18, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %19
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -5338,9 +8058,17 @@ entry:
   %this = alloca %System.AppDomain addrspace(1)*
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.AppDomainSetup addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainSetup addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::GetData using LLILCJit
@@ -5363,25 +8091,33 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
-  %8 = load i16, i16 addrspace(1)* %7
-  %9 = zext i16 %8 to i32
-  %10 = icmp ne i32 %9, 65
-  br i1 %10, label %18, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %12, %System.String addrspace(1)* %13)
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %18, label %17
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %9 = load i16, i16 addrspace(1)* %8
+  %10 = zext i16 %9 to i32
+  %11 = icmp ne i32 %10, 65
+  br i1 %11, label %19, label %12
 
-; <label>:17                                      ; preds = %11
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %19, label %18
+
+; <label>:18                                      ; preds = %12
   ret i32 0
 
-; <label>:18                                      ; preds = %5, %11
+; <label>:19                                      ; preds = %7, %12
   ret i32 -1
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
@@ -5435,24 +8171,40 @@ entry:
 
 ; <label>:17                                      ; preds = %8
   %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
-  %20 = load i32, i32 addrspace(1)* %19
-  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
-  %23 = load i32, i32 addrspace(1)* %22
-  %24 = icmp eq i32 %20, %23
-  br i1 %24, label %26, label %25
+  %NullCheck = icmp ne %System.String addrspace(1)* %18, null
+  br i1 %NullCheck, label %19, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %17
+; <label>:19                                      ; preds = %17
+  %20 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %21 = load i32, i32 addrspace(1)* %20
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck2, label %23, label %ThrowNullRef1
+
+; <label>:23                                      ; preds = %19
+  %24 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %25 = load i32, i32 addrspace(1)* %24
+  %26 = icmp eq i32 %21, %25
+  br i1 %26, label %28, label %27
+
+; <label>:27                                      ; preds = %23
   ret i8 0
 
-; <label>:26                                      ; preds = %17
-  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
-  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
-  %30 = zext i8 %29 to i32
-  %31 = trunc i32 %30 to i8
-  ret i8 %31
+; <label>:28                                      ; preds = %23
+  %29 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %31 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %30)
+  %32 = zext i8 %31 to i32
+  %33 = trunc i32 %32 to i8
+  ret i8 %33
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
@@ -5517,16 +8269,24 @@ entry:
 
 ; <label>:12                                      ; preds = %2
   %13 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %14 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
-  %15 = load i64, i64 addrspace(1)* %14, align 8
-  %16 = bitcast %System.AppDomainHandle* %0 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %16, i8 0, i64 8, i32 0, i1 false)
-  %17 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %17, i64 %15)
-  %18 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
-  ret %System.AppDomainHandle %18
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %13, null
+  br i1 %NullCheck2, label %14, label %ThrowNullRef1
+
+; <label>:14                                      ; preds = %12
+  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %13, i32 0, i32 15
+  %16 = load i64, i64 addrspace(1)* %15, align 8
+  %17 = bitcast %System.AppDomainHandle* %0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %17, i8 0, i64 8, i32 0, i1 false)
+  %18 = addrspacecast %System.AppDomainHandle* %0 to %System.AppDomainHandle addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.AppDomainHandle addrspace(1)*, i64)*)(%System.AppDomainHandle addrspace(1)* %18, i64 %16)
+  %19 = load %System.AppDomainHandle, %System.AppDomainHandle* %0
+  ret %System.AppDomainHandle %19
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #1
   unreachable
 }
@@ -5539,13 +8299,21 @@ entry:
   %this = alloca %System.IntPtr addrspace(1)*
   store %System.IntPtr addrspace(1)* %param0, %System.IntPtr addrspace(1)** %this
   %0 = load %System.IntPtr addrspace(1)*, %System.IntPtr addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  %2 = load i16*, i16* addrspace(1)* %1, align 8
-  %3 = ptrtoint i16* %2 to i64
-  %4 = icmp eq i64 %3, 0
-  %5 = sext i1 %4 to i32
-  %6 = trunc i32 %5 to i8
-  ret i8 %6
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  %3 = load i16*, i16* addrspace(1)* %2, align 8
+  %4 = ptrtoint i16* %3 to i64
+  %5 = icmp eq i64 %4, 0
+  %6 = sext i1 %5 to i32
+  %7 = trunc i32 %6 to i8
+  ret i8 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomainHandle::.ctor using LLILCJit
@@ -5559,9 +8327,17 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.AppDomainHandle addrspace(1)*, %System.AppDomainHandle addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
-  store i64 %1, i64 addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainHandle addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.AppDomainHandle, %System.AppDomainHandle addrspace(1)* %0, i32 0, i32 0
+  store i64 %1, i64 addrspace(1)* %3
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
@@ -5582,7 +8358,7 @@ entry:
 ; <label>:3                                       ; preds = %entry
   %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
   %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
-  br i1 %5, label %17, label %6
+  br i1 %5, label %18, label %6
 
 ; <label>:6                                       ; preds = %3
   %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
@@ -5598,14 +8374,22 @@ entry:
   %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
   %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
-  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
-  br label %17
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %7, null
+  br i1 %NullCheck4, label %16, label %ThrowNullRef3
 
-; <label>:17                                      ; preds = %3, %9
-  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
-  store i8 1, i8 addrspace(1)* %19
+; <label>:16                                      ; preds = %9
+  %17 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %17, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.AppDomain addrspace(1)* %19, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %18
+  %21 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %19, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %21
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
   ret void
 
@@ -5614,6 +8398,14 @@ ThrowNullRef:                                     ; preds = %entry
   unreachable
 
 ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %18
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5626,9 +8418,17 @@ entry:
   %this = alloca %System.AppDomainSetup addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
-  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
-  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %3 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %2, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
@@ -5653,13 +8453,29 @@ entry:
   %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
   store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
   %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  %3 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
-  %4 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %3, i32 0, i32 10
-  %5 = load i32, i32 addrspace(1)* %4, align 8
-  %6 = sub i32 %2, %5
-  ret i32 %6
+  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i32, i32 addrspace(1)* %2, align 8
+  %4 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = getelementptr inbounds %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]", %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %4, i32 0, i32 10
+  %7 = load i32, i32 addrspace(1)* %6, align 8
+  %8 = sub i32 %3, %7
+  ret i32 %8
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Dictionary`2::System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator using LLILCJit
@@ -5690,31 +8506,47 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
-  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
-  %8 = load i8, i8 addrspace(1)* %7, align 8
-  %9 = zext i8 %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.OrdinalComparer addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  ret i32 %13
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %15, label %12
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
-  %18 = add i64 %17, 64
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = add i64 %20, 16
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
-  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
-  %26 = call i32 %25(%System.Object addrspace(1)* %24)
-  ret i32 %26
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
+  %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %28 = call i32 %27(%System.Object addrspace(1)* %26)
+  ret i32 %28
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
@@ -5802,37 +8634,77 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
   %3 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %4, %System.Globalization.CultureData addrspace(1)* %3)
-  %5 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureData addrspace(1)* addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* addrspace(1)* %5, %System.Globalization.CultureData addrspace(1)* %3)
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %7 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %5, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %11, %System.String addrspace(1)* %10)
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %13, i32 0, i32 3
-  %15 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %14, align 8
-  %NullCheck2 = icmp ne %System.Globalization.CultureData addrspace(1)* %15, null
-  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Globalization.CultureData addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
 
-; <label>:16                                      ; preds = %9
-  %17 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %15)
-  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %18, %System.String addrspace(1)* %17)
+; <label>:11                                      ; preds = %8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %14, %System.String addrspace(1)* %12)
+  %15 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %16 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.Globalization.TextInfo addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %16, i32 0, i32 3
+  %19 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %18, align 8
+  %NullCheck10 = icmp ne %System.Globalization.CultureData addrspace(1)* %19, null
+  br i1 %NullCheck10, label %20, label %ThrowNullRef9
+
+; <label>:20                                      ; preds = %17
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %19)
+  %NullCheck12 = icmp ne %System.Globalization.TextInfo addrspace(1)* %15, null
+  br i1 %NullCheck12, label %22, label %ThrowNullRef11
+
+; <label>:22                                      ; preds = %20
+  %23 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %15, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %23, %System.String addrspace(1)* %21)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %9
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %20
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -5845,9 +8717,17 @@ entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.String addrspace(1)* %2
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.String addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
@@ -5876,21 +8756,45 @@ entry:
 
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
-  %8 = load i64, i64 addrspace(1)* %7, align 8
-  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
-  %11 = load i64, i64 addrspace(1)* %10, align 8
-  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %16 = load i8, i8* %arg2
-  %17 = zext i8 %16 to i32
-  %18 = load i64, i64* %arg3
-  %19 = trunc i32 %17 to i8
-  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
-  ret i32 %20
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %6, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
+
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %9 = load i64, i64 addrspace(1)* %8, align 8
+  %10 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Globalization.TextInfo addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %7
+  %12 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %10, i32 0, i32 7
+  %13 = load i64, i64 addrspace(1)* %12, align 8
+  %14 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %11
+  %16 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %14, i32 0, i32 4
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %19 = load i8, i8* %arg2
+  %20 = zext i8 %19 to i32
+  %21 = load i64, i64* %arg3
+  %22 = trunc i32 %20 to i8
+  %23 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %9, i64 %13, %System.String addrspace(1)* %17, %System.String addrspace(1)* %18, i8 %22, i64 %21)
+  ret i32 %23
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Enumerator::Dispose using LLILCJit
@@ -5978,55 +8882,79 @@ entry:
   store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp ne i32 %3, 0
-  br i1 %4, label %7, label %5
+  %NullCheck = icmp ne %System.AppDomain addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 2)
-  br label %28
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %0, i32 0, i32 18
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %8, label %6
 
-; <label>:7                                       ; preds = %entry
-  %8 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
-  %9 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %10 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %9, i32 0, i32 14
-  %11 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %10, align 8
-  %12 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %11, null
-  br i1 %12, label %23, label %13
+; <label>:6                                       ; preds = %1
+  %7 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i32, i32)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %7, i32 0, i32 2)
+  br label %31
 
-; <label>:13                                      ; preds = %7
-  %14 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
-  %15 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %14, i32 0, i32 14
-  %16 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %15, align 8
-  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %NullCheck = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16, null
-  br i1 %NullCheck, label %18, label %ThrowNullRef
+; <label>:8                                       ; preds = %1
+  %9 = addrspacecast %"System.Nullable`1[System.Boolean]"* %loc0 to %"System.Nullable`1[System.Boolean]" addrspace(1)*
+  %10 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomain addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
 
-; <label>:18                                      ; preds = %13
-  %19 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %16 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
-  %20 = bitcast %System.String addrspace(1)* %17 to %System.__Canon addrspace(1)*
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %19, %System.__Canon addrspace(1)* %20)
-  %22 = zext i8 %21 to i32
-  br label %24
+; <label>:11                                      ; preds = %8
+  %12 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %10, i32 0, i32 14
+  %13 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %12, align 8
+  %14 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %13, null
+  br i1 %14, label %26, label %15
 
-; <label>:23                                      ; preds = %7
-  br label %24
+; <label>:15                                      ; preds = %11
+  %16 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.AppDomain addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
 
-; <label>:24                                      ; preds = %18, %23
-  %25 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %8, %18 ], [ %8, %23 ]
-  %26 = phi i32 [ %22, %18 ], [ 0, %23 ]
-  %27 = trunc i32 %26 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %25, i8 %27)
-  br label %28
+; <label>:17                                      ; preds = %15
+  %18 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %16, i32 0, i32 14
+  %19 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %18, align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck6 = icmp ne %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19, null
+  br i1 %NullCheck6, label %21, label %ThrowNullRef5
 
-; <label>:28                                      ; preds = %5, %24
-  %29 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
-  ret %"System.Nullable`1[System.Boolean]" %29
+; <label>:21                                      ; preds = %17
+  %22 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %19 to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %23 = bitcast %System.String addrspace(1)* %20 to %System.__Canon addrspace(1)*
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %System.__Canon addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %22, %System.__Canon addrspace(1)* %23)
+  %25 = zext i8 %24 to i32
+  br label %27
 
-ThrowNullRef:                                     ; preds = %13
+; <label>:26                                      ; preds = %11
+  br label %27
+
+; <label>:27                                      ; preds = %21, %26
+  %28 = phi %"System.Nullable`1[System.Boolean]" addrspace(1)* [ %9, %21 ], [ %9, %26 ]
+  %29 = phi i32 [ %25, %21 ], [ 0, %26 ]
+  %30 = trunc i32 %29 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Nullable`1[System.Boolean]" addrspace(1)*, i8)*)(%"System.Nullable`1[System.Boolean]" addrspace(1)* %28, i8 %30)
+  br label %31
+
+; <label>:31                                      ; preds = %6, %27
+  %32 = load %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]"* %loc0
+  ret %"System.Nullable`1[System.Boolean]" %32
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6064,12 +8992,28 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %5, i32 0, i32 0
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %0, i32 0, i32 1
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load %"System.Nullable`1[System.Boolean]" addrspace(1)*, %"System.Nullable`1[System.Boolean]" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %"System.Nullable`1[System.Boolean]", %"System.Nullable`1[System.Boolean]" addrspace(1)* %6, i32 0, i32 0
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
@@ -6083,24 +9027,40 @@ entry:
   %loc0 = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
   store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
   %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.String addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
-  %7 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %7, align 8
-  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
-  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
-  store %System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
-  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %7, i32 0, i32 5
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %9, align 8
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %10)
+  %12 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.PermissionSet addrspace(1)* %11)
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %12, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  %13 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %loc0
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %13
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
@@ -6283,9 +9243,17 @@ entry:
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
   %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %4
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Reset using LLILCJit
@@ -6296,30 +9264,94 @@ entry:
   %this = alloca %System.Security.PermissionSet addrspace(1)*
   store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
   %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 0, i8 addrspace(1)* %1
-  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %3
-  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %2
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %5
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
-  store i8 0, i8 addrspace(1)* %7
-  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
-  store i8 0, i8 addrspace(1)* %9
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck4, label %7, label %ThrowNullRef3
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %8, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %9, null
+  br i1 %NullCheck6, label %10, label %ThrowNullRef5
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 8
   store i8 0, i8 addrspace(1)* %11
   %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
-  store i8 0, i8 addrspace(1)* %13
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %12, null
+  br i1 %NullCheck8, label %13, label %ThrowNullRef7
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck10, label %16, label %ThrowNullRef9
+
+; <label>:16                                      ; preds = %13
+  %17 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %17
+  %18 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %18, null
+  br i1 %NullCheck12, label %19, label %ThrowNullRef11
+
+; <label>:19                                      ; preds = %16
+  %20 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %18, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %20
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %21, null
+  br i1 %NullCheck14, label %22, label %ThrowNullRef13
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %23, %System.Security.Util.TokenBasedSet addrspace(1)* null)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
@@ -6335,21 +9367,37 @@ entry:
   %1 = load i8, i8* %arg1
   %2 = zext i8 %1 to i32
   %3 = trunc i32 %2 to i8
-  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
-  store i8 %3, i8 addrspace(1)* %4
-  %5 = load i8, i8* %arg1
-  %6 = zext i8 %5 to i32
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %11, label %8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
-  br label %11
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %13, label %9
 
-; <label>:11                                      ; preds = %entry, %8
+; <label>:9                                       ; preds = %4
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %10, null
+  br i1 %NullCheck2, label %11, label %ThrowNullRef1
+
+; <label>:11                                      ; preds = %9
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %12, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %13
+
+; <label>:13                                      ; preds = %4, %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
@@ -6372,9 +9420,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
   %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
-  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %4, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
@@ -6450,49 +9506,81 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
   %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
   %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
-  br i1 %3, label %8, label %4
+  br i1 %3, label %9, label %4
 
 ; <label>:4                                       ; preds = %entry
   %5 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
-  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
-  br label %22
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %5, null
+  br i1 %NullCheck, label %7, label %ThrowNullRef
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
-  %13 = add i64 %12, 72
-  %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
-  %16 = add i64 %15, 32
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
-  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
-  br label %22
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %25
 
-; <label>:22                                      ; preds = %4, %8
-  %23 = load i32, i32* %arg2
-  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
-  %25 = zext i8 %24 to i32
-  %26 = icmp eq i32 %25, 0
-  br i1 %26, label %31, label %27
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %12, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
 
-; <label>:27                                      ; preds = %22
-  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %29 = load i32, i32* %arg2
-  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
-  store i32 %29, i32 addrspace(1)* %30
-  br label %31
+; <label>:13                                      ; preds = %9
+  %14 = load i64, i64 addrspace(1)* %12
+  %15 = add i64 %14, 72
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
+  %NullCheck6 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
 
-; <label>:31                                      ; preds = %22, %27
+; <label>:23                                      ; preds = %13
+  %24 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %24, %System.Security.PermissionSet addrspace(1)* %22)
+  br label %25
+
+; <label>:25                                      ; preds = %7, %23
+  %26 = load i32, i32* %arg2
+  %27 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %26)
+  %28 = zext i8 %27 to i32
+  %29 = icmp eq i32 %28, 0
+  br i1 %29, label %35, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %32 = load i32, i32* %arg2
+  %NullCheck2 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %31, null
+  br i1 %NullCheck2, label %33, label %ThrowNullRef1
+
+; <label>:33                                      ; preds = %30
+  %34 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %31, i32 0, i32 2
+  store i32 %32, i32 addrspace(1)* %34
+  br label %35
+
+; <label>:35                                      ; preds = %25, %33
   ret void
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method PermissionSet::Copy using LLILCJit
@@ -6534,148 +9622,284 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
   %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
-  %9 = load i8, i8 addrspace(1)* %8, align 8
-  %10 = zext i8 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
-  store i8 %11, i8 addrspace(1)* %12
-  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
-  %16 = load i8, i8 addrspace(1)* %15, align 8
-  %17 = zext i8 %16 to i32
-  %18 = trunc i32 %17 to i8
-  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
-  store i8 %18, i8 addrspace(1)* %19
-  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
-  %23 = load i8, i8 addrspace(1)* %22, align 8
-  %24 = zext i8 %23 to i32
-  %25 = trunc i32 %24 to i8
-  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
-  store i8 %25, i8 addrspace(1)* %26
-  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
-  %30 = load i8, i8 addrspace(1)* %29, align 8
-  %31 = zext i8 %30 to i32
-  %32 = trunc i32 %31 to i8
-  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
-  store i8 %32, i8 addrspace(1)* %33
-  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %NullCheck = icmp ne %System.Security.PermissionSet addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %System.Security.PermissionSet addrspace(1)* %6, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %8
+  %14 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %12, i8 addrspace(1)* %14
+  %15 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %16 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.PermissionSet addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %16, i32 0, i32 9
+  %19 = load i8, i8 addrspace(1)* %18, align 8
+  %20 = zext i8 %19 to i32
+  %21 = trunc i32 %20 to i8
+  %NullCheck6 = icmp ne %System.Security.PermissionSet addrspace(1)* %15, null
+  br i1 %NullCheck6, label %22, label %ThrowNullRef5
+
+; <label>:22                                      ; preds = %17
+  %23 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %15, i32 0, i32 9
+  store i8 %21, i8 addrspace(1)* %23
+  %24 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck8 = icmp ne %System.Security.PermissionSet addrspace(1)* %25, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %22
+  %27 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %25, i32 0, i32 10
+  %28 = load i8, i8 addrspace(1)* %27, align 8
+  %29 = zext i8 %28 to i32
+  %30 = trunc i32 %29 to i8
+  %NullCheck10 = icmp ne %System.Security.PermissionSet addrspace(1)* %24, null
+  br i1 %NullCheck10, label %31, label %ThrowNullRef9
+
+; <label>:31                                      ; preds = %26
+  %32 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %24, i32 0, i32 10
+  store i8 %30, i8 addrspace(1)* %32
+  %33 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck12 = icmp ne %System.Security.PermissionSet addrspace(1)* %34, null
+  br i1 %NullCheck12, label %35, label %ThrowNullRef11
+
+; <label>:35                                      ; preds = %31
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 11
   %37 = load i8, i8 addrspace(1)* %36, align 8
   %38 = zext i8 %37 to i32
   %39 = trunc i32 %38 to i8
-  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
-  store i8 %39, i8 addrspace(1)* %40
-  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
-  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
-  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
-  br i1 %44, label %91, label %45
+  %NullCheck14 = icmp ne %System.Security.PermissionSet addrspace(1)* %33, null
+  br i1 %NullCheck14, label %40, label %ThrowNullRef13
 
-; <label>:45                                      ; preds = %5
-  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
-  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
-  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
-  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
-  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+; <label>:40                                      ; preds = %35
+  %41 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %33, i32 0, i32 11
+  store i8 %39, i8 addrspace(1)* %41
+  %42 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %43 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck16 = icmp ne %System.Security.PermissionSet addrspace(1)* %43, null
+  br i1 %NullCheck16, label %44, label %ThrowNullRef15
+
+; <label>:44                                      ; preds = %40
+  %45 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %43, i32 0, i32 8
+  %46 = load i8, i8 addrspace(1)* %45, align 8
+  %47 = zext i8 %46 to i32
+  %48 = trunc i32 %47 to i8
+  %NullCheck18 = icmp ne %System.Security.PermissionSet addrspace(1)* %42, null
+  br i1 %NullCheck18, label %49, label %ThrowNullRef17
+
+; <label>:49                                      ; preds = %44
+  %50 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %42, i32 0, i32 8
+  store i8 %48, i8 addrspace(1)* %50
+  %51 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck20 = icmp ne %System.Security.PermissionSet addrspace(1)* %51, null
+  br i1 %NullCheck20, label %52, label %ThrowNullRef19
+
+; <label>:52                                      ; preds = %49
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %51, i32 0, i32 1
   %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
-  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
-  br i1 %NullCheck, label %55, label %ThrowNullRef
+  %55 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %55, label %108, label %56
 
-; <label>:55                                      ; preds = %45
-  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
-  store i32 %56, i32* %loc0
-  br label %83
+; <label>:56                                      ; preds = %52
+  %57 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %NullCheck22 = icmp ne %System.Security.PermissionSet addrspace(1)* %58, null
+  br i1 %NullCheck22, label %59, label %ThrowNullRef21
 
-; <label>:57                                      ; preds = %88
-  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
-  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
-  %61 = load i32, i32* %loc0
-  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
-  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+; <label>:59                                      ; preds = %56
+  %60 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %61 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %60, align 8
+  %62 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %62, %System.Security.Util.TokenBasedSet addrspace(1)* %61)
+  %NullCheck24 = icmp ne %System.Security.PermissionSet addrspace(1)* %57, null
+  br i1 %NullCheck24, label %63, label %ThrowNullRef23
 
-; <label>:62                                      ; preds = %57
-  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
-  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
-  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
-  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
-  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
-  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
-  br i1 %67, label %80, label %68
+; <label>:63                                      ; preds = %59
+  %64 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %57, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %64, %System.Security.Util.TokenBasedSet addrspace(1)* %62)
+  %65 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.Security.PermissionSet addrspace(1)* %65, null
+  br i1 %NullCheck26, label %66, label %ThrowNullRef25
 
-; <label>:68                                      ; preds = %62
-  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
-  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
-  %72 = load i32, i32* %loc0
-  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
-  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+; <label>:66                                      ; preds = %63
+  %67 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %65, i32 0, i32 1
+  %68 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %67, align 8
+  %NullCheck28 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %68, null
+  br i1 %NullCheck28, label %69, label %ThrowNullRef27
 
-; <label>:75                                      ; preds = %68
-  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
-  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
-  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
-  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+; <label>:69                                      ; preds = %66
+  %70 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %68)
+  store i32 %70, i32* %loc0
+  br label %99
 
-; <label>:78                                      ; preds = %75
-  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
-  br label %80
+; <label>:71                                      ; preds = %105
+  %72 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.Security.PermissionSet addrspace(1)* %72, null
+  br i1 %NullCheck34, label %73, label %ThrowNullRef33
 
-; <label>:80                                      ; preds = %62, %78
-  %81 = load i32, i32* %loc0
-  %82 = add i32 %81, 1
-  store i32 %82, i32* %loc0
-  br label %83
+; <label>:73                                      ; preds = %71
+  %74 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %72, i32 0, i32 1
+  %75 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %74, align 8
+  %76 = load i32, i32* %loc0
+  %NullCheck36 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %75, null
+  br i1 %NullCheck36, label %77, label %ThrowNullRef35
 
-; <label>:83                                      ; preds = %55, %80
-  %84 = load i32, i32* %loc0
-  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
-  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+; <label>:77                                      ; preds = %73
+  %78 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %75, i32 %76)
+  store %System.Object addrspace(1)* %78, %System.Object addrspace(1)** %loc1
+  %79 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %80 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %79)
+  store %System.Security.IPermission addrspace(1)* %80, %System.Security.IPermission addrspace(1)** %loc2
+  %81 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %82 = icmp eq %System.Security.IPermission addrspace(1)* %81, null
+  br i1 %82, label %96, label %83
+
+; <label>:83                                      ; preds = %77
+  %84 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.Security.PermissionSet addrspace(1)* %84, null
+  br i1 %NullCheck38, label %85, label %ThrowNullRef37
+
+; <label>:85                                      ; preds = %83
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %84, i32 0, i32 1
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
-  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
-  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+  %88 = load i32, i32* %loc0
+  %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck40 = icmp ne %System.Security.IPermission addrspace(1)* %89, null
+  br i1 %NullCheck40, label %91, label %ThrowNullRef39
 
-; <label>:88                                      ; preds = %83
-  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
-  %90 = icmp sle i32 %84, %89
-  br i1 %90, label %57, label %91
+; <label>:91                                      ; preds = %85
+  %92 = inttoptr i64 %90 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %93 = call %System.Security.IPermission addrspace(1)* %92(%System.Security.IPermission addrspace(1)* %89)
+  %NullCheck42 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck42, label %94, label %ThrowNullRef41
 
-; <label>:91                                      ; preds = %5, %88
+; <label>:94                                      ; preds = %91
+  %95 = bitcast %System.Security.IPermission addrspace(1)* %93 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87, i32 %88, %System.Object addrspace(1)* %95)
+  br label %96
+
+; <label>:96                                      ; preds = %77, %94
+  %97 = load i32, i32* %loc0
+  %98 = add i32 %97, 1
+  store i32 %98, i32* %loc0
+  br label %99
+
+; <label>:99                                      ; preds = %69, %96
+  %100 = load i32, i32* %loc0
+  %101 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.Security.PermissionSet addrspace(1)* %101, null
+  br i1 %NullCheck30, label %102, label %ThrowNullRef29
+
+; <label>:102                                     ; preds = %99
+  %103 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %101, i32 0, i32 1
+  %104 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %103, align 8
+  %NullCheck32 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %104, null
+  br i1 %NullCheck32, label %105, label %ThrowNullRef31
+
+; <label>:105                                     ; preds = %102
+  %106 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %104)
+  %107 = icmp sle i32 %100, %106
+  br i1 %107, label %71, label %108
+
+; <label>:108                                     ; preds = %52, %105
   ret void
 
-ThrowNullRef:                                     ; preds = %45
+ThrowNullRef:                                     ; preds = %5
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef1:                                    ; preds = %83
+ThrowNullRef1:                                    ; preds = %8
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef3:                                    ; preds = %57
+ThrowNullRef3:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef5:                                    ; preds = %68
+ThrowNullRef5:                                    ; preds = %17
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 
-ThrowNullRef7:                                    ; preds = %75
+ThrowNullRef7:                                    ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %31
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %35
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %44
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %56
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %63
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %102
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %71
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %73
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef41:                                   ; preds = %91
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6715,37 +9939,77 @@ entry:
   store %System.Security.Policy.PolicyStatement addrspace(1)* %param1, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
   %1 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %0, null
-  br i1 %1, label %7, label %2
+  br i1 %1, label %9, label %2
 
 ; <label>:2                                       ; preds = %entry
   %3 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %4, %System.Security.Policy.PolicyStatement addrspace(1)* null)
-  %5 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %5, i32 0, i32 3
-  store i32 0, i32 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %2
+  %5 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %3, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %5, %System.Security.Policy.PolicyStatement addrspace(1)* null)
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %6, i32 0, i32 3
+  store i32 0, i32 addrspace(1)* %8
   ret void
 
-; <label>:7                                       ; preds = %entry
-  %8 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
-  %10 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %8, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %10, %System.Security.Policy.PolicyStatement addrspace(1)* %9)
-  %11 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %12 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %12, i32 0, i32 1
-  %14 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, align 8
-  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %14, null
-  br i1 %NullCheck, label %15, label %ThrowNullRef
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %11 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %10, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
 
-; <label>:15                                      ; preds = %7
-  %16 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %14)
-  %17 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)* null)
-  %18 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %11, i32 0, i32 3
-  store i32 %17, i32 addrspace(1)* %18
+; <label>:12                                      ; preds = %9
+  %13 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %10, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %13, %System.Security.Policy.PolicyStatement addrspace(1)* %11)
+  %14 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %15 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %15, null
+  br i1 %NullCheck6, label %16, label %ThrowNullRef5
+
+; <label>:16                                      ; preds = %12
+  %17 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %15, i32 0, i32 1
+  %18 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)* addrspace(1)* %17, align 8
+  %NullCheck8 = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %18, null
+  br i1 %NullCheck8, label %19, label %ThrowNullRef7
+
+; <label>:19                                      ; preds = %16
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %18)
+  %21 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %20, %System.Security.PermissionSet addrspace(1)* null)
+  %NullCheck10 = icmp ne %System.Security.Policy.ApplicationTrust addrspace(1)* %14, null
+  br i1 %NullCheck10, label %22, label %ThrowNullRef9
+
+; <label>:22                                      ; preds = %19
+  %23 = getelementptr inbounds %System.Security.Policy.ApplicationTrust, %System.Security.Policy.ApplicationTrust addrspace(1)* %14, i32 0, i32 3
+  store i32 %21, i32 addrspace(1)* %23
   ret void
 
-ThrowNullRef:                                     ; preds = %7
+ThrowNullRef:                                     ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %19
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -6767,39 +10031,55 @@ entry:
   %2 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %2, i8 addrspace(1)* %1)
   %3 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
-  %4 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
-  %5 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %4, align 8
-  %6 = bitcast %System.Security.PermissionSet addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = add i64 %10, 32
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = inttoptr i64 %13 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
-  %15 = call %System.Security.PermissionSet addrspace(1)* %14(%System.Security.PermissionSet addrspace(1)* %5)
-  store %System.Security.PermissionSet addrspace(1)* %15, %System.Security.PermissionSet addrspace(1)** %loc1
-  br label %16
+  %NullCheck = icmp ne %System.Security.Policy.PolicyStatement addrspace(1)* %3, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
-  %17 = load i8, i8* %loc0
-  %18 = zext i8 %17 to i32
-  %19 = icmp eq i32 %18, 0
-  br i1 %19, label %23, label %20
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:20                                      ; preds = %16
-  %21 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
-  %22 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %21 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %22)
-  br label %23
+; <label>:8                                       ; preds = %4
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 72
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 32
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
+  br label %18
 
-; <label>:23                                      ; preds = %16, %20
-  br label %24
+; <label>:18                                      ; preds = %8
+  %19 = load i8, i8* %loc0
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %25, label %22
 
-; <label>:24                                      ; preds = %23
-  %25 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
-  ret %System.Security.PermissionSet addrspace(1)* %25
+; <label>:22                                      ; preds = %18
+  %23 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %loc2
+  %24 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %23 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %24)
+  br label %25
+
+; <label>:25                                      ; preds = %18, %22
+  br label %26
+
+; <label>:26                                      ; preds = %25
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %loc1
+  ret %System.Security.PermissionSet addrspace(1)* %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
@@ -6831,9 +10111,17 @@ entry:
 ; <label>:5                                       ; preds = %entry, %4
   %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
   %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
-  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  %NullCheck = icmp ne %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]", %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %9, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
   ret void
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -6875,16 +10163,24 @@ entry:
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 104
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 8
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %10(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 104
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %11(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Console::get_Out using LLILCJit
@@ -7002,19 +10298,35 @@ entry:
   store i64 %param0, i64* %arg0
   store i64 %param1, i64* %arg1
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  %5 = addrspacecast i64* %arg1 to i64 addrspace(1)*
-  %6 = bitcast i64 addrspace(1)* %5 to i8 addrspace(1)*
-  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i64 0
-  %8 = bitcast i8 addrspace(1)* %7 to i16* addrspace(1)*
-  %9 = load i16*, i16* addrspace(1)* %8, align 8
-  %10 = icmp eq i16* %4, %9
-  %11 = sext i1 %10 to i32
-  %12 = trunc i32 %11 to i8
-  ret i8 %12
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  %6 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = bitcast i64 addrspace(1)* %6 to i8 addrspace(1)*
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i64 0
+  %10 = bitcast i8 addrspace(1)* %9 to i16* addrspace(1)*
+  %11 = load i16*, i16* addrspace(1)* %10, align 8
+  %12 = icmp eq i16* %5, %11
+  %13 = sext i1 %12 to i32
+  %14 = trunc i32 %13 to i8
+  ret i8 %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Interop::.cctor using LLILCJit
@@ -7046,9 +10358,17 @@ entry:
   %1 = load i32, i32* %arg1
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to i16*
-  %4 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
-  store i16* %3, i16* addrspace(1)* %4
+  %NullCheck = icmp ne %System.IntPtr addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.IntPtr, %System.IntPtr addrspace(1)* %0, i32 0, i32 0
+  store i16* %3, i16* addrspace(1)* %5
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsolePal::ConsoleHandleIsWritable using LLILCJit
@@ -7092,17 +10412,33 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, i32)*)(%System.IO.ConsoleStream addrspace(1)* %2, i32 %1)
   %3 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %4 = load i64, i64* %arg1
-  %5 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
-  store i64 %4, i64 addrspace(1)* %5
-  %6 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %7 = load i64, i64* %arg1
-  %8 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %7)
-  %9 = icmp eq i32 %8, 3
-  %10 = sext i1 %9 to i32
-  %11 = trunc i32 %10 to i8
-  %12 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %6, i32 0, i32 5
-  store i8 %11, i8 addrspace(1)* %12
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %3, i32 0, i32 7
+  store i64 %4, i64 addrspace(1)* %6
+  %7 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %8 = load i64, i64* %arg1
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64)*)(i64 %8)
+  %10 = icmp eq i32 %9, 3
+  %11 = sext i1 %10 to i32
+  %12 = trunc i32 %11 to i8
+  %NullCheck2 = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %5
+  %14 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %7, i32 0, i32 5
+  store i8 %12, i8 addrspace(1)* %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::.ctor using LLILCJit
@@ -7123,17 +10459,33 @@ entry:
   %5 = icmp eq i32 %4, 1
   %6 = sext i1 %5 to i32
   %7 = trunc i32 %6 to i8
-  %8 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
-  store i8 %7, i8 addrspace(1)* %8
-  %9 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %10 = load i32, i32* %arg1
-  %11 = and i32 %10, 2
-  %12 = icmp eq i32 %11, 2
-  %13 = sext i1 %12 to i32
-  %14 = trunc i32 %13 to i8
-  %15 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %9, i32 0, i32 4
-  store i8 %14, i8 addrspace(1)* %15
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %2, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
+
+; <label>:8                                       ; preds = %entry
+  %9 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %2, i32 0, i32 3
+  store i8 %7, i8 addrspace(1)* %9
+  %10 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = and i32 %11, 2
+  %13 = icmp eq i32 %12, 2
+  %14 = sext i1 %13 to i32
+  %15 = trunc i32 %14 to i8
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %10, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %8
+  %17 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %10, i32 0, i32 4
+  store i8 %15, i8 addrspace(1)* %17
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
@@ -7170,11 +10522,19 @@ entry:
   %arg0 = alloca i64
   store i64 %param0, i64* %arg0
   %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
-  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
-  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
-  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
-  %4 = load i16*, i16* addrspace(1)* %3, align 8
-  ret i16* %4
+  %NullCheck = icmp ne i64 addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %3 = getelementptr inbounds i8, i8 addrspace(1)* %2, i64 0
+  %4 = bitcast i8 addrspace(1)* %3 to i16* addrspace(1)*
+  %5 = load i16*, i16* addrspace(1)* %4, align 8
+  ret i16* %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -7190,7 +10550,7 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
   %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
-  br i1 %2, label %16, label %3
+  br i1 %2, label %17, label %3
 
 ; <label>:3                                       ; preds = %entry
   %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
@@ -7198,27 +10558,35 @@ entry:
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
   %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
-  %9 = add i64 %8, 120
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = add i64 %11, 0
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
-  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
-  br label %18
+  %NullCheck = icmp ne i64 addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:16                                      ; preds = %entry
+; <label>:8                                       ; preds = %3
+  %9 = load i64, i64 addrspace(1)* %7
+  %10 = add i64 %9, 120
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64, i64* %14
+  %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %19
+
+; <label>:17                                      ; preds = %entry
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
-  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
-  br label %18
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %19
 
-; <label>:18                                      ; preds = %3, %16
-  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
-  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
-  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
-  ret %System.IO.TextWriter addrspace(1)* %21
+; <label>:19                                      ; preds = %8, %17
+  %20 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %8 ], [ %18, %17 ]
+  %21 = bitcast %System.IO.StreamWriter addrspace(1)* %20 to %System.IO.TextWriter addrspace(1)*
+  %22 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %21)
+  ret %System.IO.TextWriter addrspace(1)* %22
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Stream::.cctor using LLILCJit
@@ -7334,31 +10702,63 @@ entry:
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
   %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %3 = load i64, i64 addrspace(1)* %2
-  %4 = add i64 %3, 72
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
-  %7 = add i64 %6, 40
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = inttoptr i64 %9 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
-  %11 = call i32 %10(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
-  %12 = and i32 %11, 2147483647
-  store i32 %12, i32* %loc0
-  %13 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %14 = load i32, i32* %loc0
-  store i32 %14, i32 addrspace(1)* %13, align 8
-  %15 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
-  %16 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
-  %17 = load i32, i32 addrspace(1)* %16, align 8
-  %18 = mul i32 %17, 101
-  %19 = load i32, i32* %arg2
-  %20 = sub i32 %19, 1
-  %21 = urem i32 %18, %20
-  %22 = add i32 1, %21
-  store i32 %22, i32 addrspace(1)* %15, align 8
-  %23 = load i32, i32* %loc0
-  ret i32 %23
+  %NullCheck = icmp ne i64 addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i64, i64 addrspace(1)* %2
+  %5 = add i64 %4, 72
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
+  %13 = and i32 %12, 2147483647
+  store i32 %13, i32* %loc0
+  %14 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %15 = load i32, i32* %loc0
+  %NullCheck2 = icmp ne i32 addrspace(1)* %14, null
+  br i1 %NullCheck2, label %16, label %ThrowNullRef1
+
+; <label>:16                                      ; preds = %3
+  store i32 %15, i32 addrspace(1)* %14, align 8
+  %17 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %18 = load i32 addrspace(1)*, i32 addrspace(1)** %arg3
+  %NullCheck4 = icmp ne i32 addrspace(1)* %18, null
+  br i1 %NullCheck4, label %19, label %ThrowNullRef3
+
+; <label>:19                                      ; preds = %16
+  %20 = load i32, i32 addrspace(1)* %18, align 8
+  %21 = mul i32 %20, 101
+  %22 = load i32, i32* %arg2
+  %23 = sub i32 %22, 1
+  %24 = urem i32 %21, %23
+  %25 = add i32 1, %24
+  %NullCheck6 = icmp ne i32 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %26, label %ThrowNullRef5
+
+; <label>:26                                      ; preds = %19
+  store i32 %25, i32 addrspace(1)* %17, align 8
+  %27 = load i32, i32* %loc0
+  ret i32 %27
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %16
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
@@ -7371,40 +10771,64 @@ entry:
   store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
   store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
-  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
-  br i1 %3, label %13, label %4
+  %NullCheck = icmp ne %System.Collections.Hashtable addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
-  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
-  br i1 %NullCheck, label %10, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %3 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %3, null
+  br i1 %4, label %15, label %5
 
-; <label>:10                                      ; preds = %4
-  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
-  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
-  ret i32 %12
+; <label>:5                                       ; preds = %1
+  %6 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Collections.Hashtable addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:13                                      ; preds = %entry
-  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
-  %20 = add i64 %19, 16
+; <label>:7                                       ; preds = %5
+  %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck4 = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %9, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = inttoptr i64 %11 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %14 = call i32 %13(%System.Collections.IEqualityComparer addrspace(1)* %9, %System.Object addrspace(1)* %10)
+  ret i32 %14
+
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %17, null
+  br i1 %NullCheck6, label %18, label %ThrowNullRef5
+
+; <label>:18                                      ; preds = %15
+  %19 = load i64, i64 addrspace(1)* %17
+  %20 = add i64 %19, 64
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
-  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
-  %24 = call i32 %23(%System.Object addrspace(1)* %14)
-  ret i32 %24
+  %23 = add i64 %22, 16
+  %24 = inttoptr i64 %23 to i64*
+  %25 = load i64, i64* %24
+  %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
+  %27 = call i32 %26(%System.Object addrspace(1)* %16)
+  ret i32 %27
 
-ThrowNullRef:                                     ; preds = %4
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -7418,8 +10842,16 @@ entry:
   store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
   %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
   %1 = bitcast %System.Int32 addrspace(1)* %0 to i32 addrspace(1)*
-  %2 = load i32, i32 addrspace(1)* %1, align 8
-  ret i32 %2
+  %NullCheck = icmp ne i32 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32 addrspace(1)* %1, align 8
+  ret i32 %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
@@ -7487,38 +10919,70 @@ entry:
   %3 = load i8, i8* %arg1
   %4 = zext i8 %3 to i32
   %5 = trunc i32 %4 to i8
-  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
-  store i8 %5, i8 addrspace(1)* %6
-  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %8 = load i8, i8* %arg2
-  %9 = zext i8 %8 to i32
-  %10 = trunc i32 %9 to i8
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
-  store i8 %10, i8 addrspace(1)* %11
-  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
-  %14 = load i8, i8 addrspace(1)* %13, align 8
-  %15 = zext i8 %14 to i32
-  %16 = icmp eq i32 %15, 0
-  br i1 %16, label %29, label %17
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:17                                      ; preds = %entry
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 32
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
-  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %28(%System.Text.Encoding addrspace(1)* %27)
-  br label %29
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %7
+  %8 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %9 = load i8, i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %8, null
+  br i1 %NullCheck2, label %12, label %ThrowNullRef1
 
-; <label>:29                                      ; preds = %entry, %17
+; <label>:12                                      ; preds = %6
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %8, i32 0, i32 8
+  store i8 %11, i8 addrspace(1)* %13
+  %14 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %14, null
+  br i1 %NullCheck4, label %15, label %ThrowNullRef3
+
+; <label>:15                                      ; preds = %12
+  %16 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %14, i32 0, i32 8
+  %17 = load i8, i8 addrspace(1)* %16, align 8
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %33, label %20
+
+; <label>:20                                      ; preds = %15
+  %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %22, null
+  br i1 %NullCheck6, label %23, label %ThrowNullRef5
+
+; <label>:23                                      ; preds = %20
+  %24 = load i64, i64 addrspace(1)* %22
+  %25 = add i64 %24, 64
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = add i64 %27, 32
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
+  %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %32(%System.Text.Encoding addrspace(1)* %31)
+  br label %33
+
+; <label>:33                                      ; preds = %15, %23
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7531,39 +10995,63 @@ entry:
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
-  store i8 1, i8 addrspace(1)* %1
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
-  %4 = load i32, i32* %arg1
-  %5 = icmp sge i32 %4, 0
-  br i1 %5, label %9, label %6
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %2
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %4)
+  %5 = load i32, i32* %arg1
+  %6 = icmp sge i32 %5, 0
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %9) #0
   unreachable
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %11 = load i32, i32* %arg1
-  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
-  store i32 %11, i32 addrspace(1)* %12
-  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 32
+; <label>:10                                      ; preds = %1
+  %11 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %12 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %11, null
+  br i1 %NullCheck2, label %13, label %ThrowNullRef1
+
+; <label>:13                                      ; preds = %10
+  %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
+  store i32 %12, i32 addrspace(1)* %14
+  %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck4, label %17, label %ThrowNullRef3
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
-  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %13
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
@@ -7574,39 +11062,79 @@ entry:
   %this = alloca %System.Text.UTF8Encoding addrspace(1)*
   store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
   %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = icmp eq i32 %3, 0
-  br i1 %4, label %12, label %5
+  %NullCheck = icmp ne %System.Text.UTF8Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %7 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
-  %8 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %6, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %8, %System.Text.EncoderFallback addrspace(1)* %7)
-  %9 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %10 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
-  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %9, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %10)
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %15, label %6
+
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %7, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %10, %System.Text.EncoderFallback addrspace(1)* %8)
+  %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %12 = call %System.Text.DecoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderFallback addrspace(1)* ()*)()
+  %NullCheck4 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %11, null
+  br i1 %NullCheck4, label %13, label %ThrowNullRef3
+
+; <label>:13                                      ; preds = %9
+  %14 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %11, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.DecoderFallback addrspace(1)* %12)
   ret void
 
-; <label>:12                                      ; preds = %entry
-  %13 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %15 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %15, %System.String addrspace(1)* %14)
-  %16 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %15 to %System.Text.EncoderFallback addrspace(1)*
-  %17 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %13, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %17, %System.Text.EncoderFallback addrspace(1)* %16)
-  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %20 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %20, %System.String addrspace(1)* %19)
-  %21 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %20 to %System.Text.DecoderFallback addrspace(1)*
-  %22 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %18, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %22, %System.Text.DecoderFallback addrspace(1)* %21)
+; <label>:15                                      ; preds = %1
+  %16 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.Text.EncoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.EncoderReplacementFallback addrspace(1)* %18, %System.String addrspace(1)* %17)
+  %19 = bitcast %System.Text.EncoderReplacementFallback addrspace(1)* %18 to %System.Text.EncoderFallback addrspace(1)*
+  %NullCheck6 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %16, null
+  br i1 %NullCheck6, label %20, label %ThrowNullRef5
+
+; <label>:20                                      ; preds = %15
+  %21 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %16, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %21, %System.Text.EncoderFallback addrspace(1)* %19)
+  %22 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.Text.DecoderReplacementFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.DecoderReplacementFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderReplacementFallback addrspace(1)*, %System.String addrspace(1)*)*)(%System.Text.DecoderReplacementFallback addrspace(1)* %24, %System.String addrspace(1)* %23)
+  %25 = bitcast %System.Text.DecoderReplacementFallback addrspace(1)* %24 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck8 = icmp ne %System.Text.UTF8Encoding addrspace(1)* %22, null
+  br i1 %NullCheck8, label %26, label %ThrowNullRef7
+
+; <label>:26                                      ; preds = %20
+  %27 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %22, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %27, %System.Text.DecoderFallback addrspace(1)* %25)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %20
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
@@ -7634,29 +11162,45 @@ entry:
 ; <label>:5                                       ; preds = %entry
   %6 = load i32, i32* %arg1
   %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
-  %9 = load i32, i32 addrspace(1)* %8
-  %10 = icmp ult i32 %6, %9
-  br i1 %10, label %14, label %11
+  %NullCheck = icmp ne %System.String addrspace(1)* %7, null
+  br i1 %NullCheck, label %8, label %ThrowNullRef
 
-; <label>:11                                      ; preds = %5
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+; <label>:8                                       ; preds = %5
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = icmp ult i32 %6, %10
+  br i1 %11, label %15, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
   unreachable
 
-; <label>:14                                      ; preds = %5
-  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %16 = load i32, i32* %arg1
-  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
-  %18 = load i16, i16 addrspace(1)* %17
-  %19 = zext i16 %18 to i32
-  %20 = trunc i32 %19 to i16
-  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
-  %22 = zext i8 %21 to i32
-  %23 = trunc i32 %22 to i8
-  ret i8 %23
+; <label>:15                                      ; preds = %8
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = load i32, i32* %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %16, null
+  br i1 %NullCheck2, label %18, label %ThrowNullRef1
+
+; <label>:18                                      ; preds = %15
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %16, i32 0, i32 2, i32 %17
+  %20 = load i16, i16 addrspace(1)* %19
+  %21 = zext i16 %20 to i32
+  %22 = trunc i32 %21 to i16
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+
+ThrowNullRef:                                     ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %15
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Char::IsSurrogate using LLILCJit
@@ -7721,9 +11265,17 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %1)
   %2 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %2, i32 0, i32 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
@@ -7750,16 +11302,32 @@ entry:
   %2 = call %System.Text.InternalEncoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalEncoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %1)
   %3 = bitcast %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2 to %System.Text.EncoderFallback addrspace(1)*
-  %4 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %4, %System.Text.EncoderFallback addrspace(1)* %3)
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %5, %System.Text.EncoderFallback addrspace(1)* %3)
   %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %7 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %6)
-  %8 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7 to %System.Text.DecoderFallback addrspace(1)*
-  %9 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %5, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %9, %System.Text.DecoderFallback addrspace(1)* %8)
+  %7 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %8 = call %System.Text.InternalDecoderBestFitFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.InternalDecoderBestFitFallback addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.InternalDecoderBestFitFallback addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %7)
+  %9 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %8 to %System.Text.DecoderFallback addrspace(1)*
+  %NullCheck2 = icmp ne %System.Text.Encoding addrspace(1)* %6, null
+  br i1 %NullCheck2, label %10, label %ThrowNullRef1
+
+; <label>:10                                      ; preds = %4
+  %11 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %6, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)* addrspace(1)*, %System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.DecoderFallback addrspace(1)* %9)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method InternalEncoderBestFitFallback::.ctor using LLILCJit
@@ -7776,12 +11344,28 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* %1)
   %2 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
-  %6 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %5, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %6
+  %NullCheck = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
+
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.InternalEncoderBestFitFallback addrspace(1)*, %System.Text.InternalEncoderBestFitFallback addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %4
+  %8 = getelementptr inbounds %System.Text.InternalEncoderBestFitFallback, %System.Text.InternalEncoderBestFitFallback addrspace(1)* %6, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %8
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
@@ -7807,19 +11391,43 @@ entry:
   store %System.Text.InternalDecoderBestFitFallback addrspace(1)* %param0, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
   store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
   %0 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
-  store i16 63, i16 addrspace(1)* %1
-  %2 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %3 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %2 to %System.Text.DecoderFallback addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %3)
-  %4 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %6 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %4, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %6, %System.Text.Encoding addrspace(1)* %5)
-  %7 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
-  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %7, i32 0, i32 1
-  store i8 1, i8 addrspace(1)* %8
+  %NullCheck = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %0, i32 0, i32 5
+  store i16 63, i16 addrspace(1)* %2
+  %3 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %4 = bitcast %System.Text.InternalDecoderBestFitFallback addrspace(1)* %3 to %System.Text.DecoderFallback addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.DecoderFallback addrspace(1)*)*)(%System.Text.DecoderFallback addrspace(1)* %4)
+  %5 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %6 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %5, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %8, %System.Text.Encoding addrspace(1)* %6)
+  %9 = load %System.Text.InternalDecoderBestFitFallback addrspace(1)*, %System.Text.InternalDecoderBestFitFallback addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %7
+  %11 = getelementptr inbounds %System.Text.InternalDecoderBestFitFallback, %System.Text.InternalDecoderBestFitFallback addrspace(1)* %9, i32 0, i32 1
+  store i8 1, i8 addrspace(1)* %11
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
@@ -7885,51 +11493,59 @@ entry:
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
   %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %20 = load i64, i64 addrspace(1)* %19
-  %21 = add i64 %20, 64
-  %22 = inttoptr i64 %21 to i64*
-  %23 = load i64, i64* %22
-  %24 = add i64 %23, 56
-  %25 = inttoptr i64 %24 to i64*
-  %26 = load i64, i64* %25
-  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
-  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
-  %29 = zext i8 %28 to i32
-  %30 = icmp ne i32 %29, 0
-  br i1 %30, label %35, label %31
+  %NullCheck = icmp ne i64 addrspace(1)* %19, null
+  br i1 %NullCheck, label %20, label %ThrowNullRef
 
-; <label>:31                                      ; preds = %17
-  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:20                                      ; preds = %17
+  %21 = load i64, i64 addrspace(1)* %19
+  %22 = add i64 %21, 64
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = add i64 %24, 56
+  %26 = inttoptr i64 %25 to i64*
+  %27 = load i64, i64* %26
+  %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
+  %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %36, label %32
+
+; <label>:32                                      ; preds = %20
+  %33 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %17
-  %36 = load i32, i32* %arg3
-  %37 = icmp sgt i32 %36, 0
-  br i1 %37, label %43, label %38
+; <label>:36                                      ; preds = %20
+  %37 = load i32, i32* %arg3
+  %38 = icmp sgt i32 %37, 0
+  br i1 %38, label %44, label %39
 
-; <label>:38                                      ; preds = %35
-  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+; <label>:39                                      ; preds = %36
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
-  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %42 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %41)
+  %43 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43, %System.String addrspace(1)* %40, %System.String addrspace(1)* %42)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %43) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
-  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %47 = load i32, i32* %arg3
-  %48 = load i8, i8* %arg4
-  %49 = zext i8 %48 to i32
-  %50 = trunc i32 %49 to i8
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+; <label>:44                                      ; preds = %36
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %46 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %47 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %48 = load i32, i32* %arg3
+  %49 = load i8, i8* %arg4
+  %50 = zext i8 %49 to i32
+  %51 = trunc i32 %50 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %45, %System.IO.Stream addrspace(1)* %46, %System.Text.Encoding addrspace(1)* %47, i32 %48, i8 %51)
   ret void
+
+ThrowNullRef:                                     ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::.ctor using LLILCJit
@@ -7942,11 +11558,19 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
-  %2 = load i8, i8 addrspace(1)* %1, align 8
-  %3 = zext i8 %2 to i32
-  %4 = trunc i32 %3 to i8
-  ret i8 %4
+  %NullCheck = icmp ne %System.IO.ConsoleStream addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %0, i32 0, i32 4
+  %3 = load i8, i8 addrspace(1)* %2, align 8
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::Init using LLILCJit
@@ -7966,116 +11590,244 @@ entry:
   store i8 %param4, i8* %arg4
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
   %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %2, %System.IO.Stream addrspace(1)* %1)
-  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %4 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %3, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %4)
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %8 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 4
-  %9 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.Encoding addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 96
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %19 = call %System.Text.Encoder addrspace(1)* %18(%System.Text.Encoding addrspace(1)* %9)
-  %20 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 5
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %20, %System.Text.Encoder addrspace(1)* %19)
-  %21 = load i32, i32* %arg3
-  %22 = icmp sge i32 %21, 128
-  br i1 %22, label %24, label %23
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:23                                      ; preds = %entry
-  store i32 128, i32* %arg3
-  br label %24
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)* addrspace(1)*, %System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* addrspace(1)* %3, %System.IO.Stream addrspace(1)* %1)
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %4, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
 
-; <label>:24                                      ; preds = %entry, %23
-  %25 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+; <label>:6                                       ; preds = %2
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %4, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %7, %System.Text.Encoding addrspace(1)* %5)
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %6
+  %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
+  %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 96
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %8, null
+  br i1 %NullCheck8, label %24, label %ThrowNullRef7
+
+; <label>:24                                      ; preds = %14
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)* addrspace(1)*, %System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* addrspace(1)* %25, %System.Text.Encoder addrspace(1)* %23)
   %26 = load i32, i32* %arg3
-  %27 = sext i32 %26 to i64
-  %28 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %27)
-  %29 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %25, i32 0, i32 7
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %29, %"System.Char[]" addrspace(1)* %28)
+  %27 = icmp sge i32 %26, 128
+  br i1 %27, label %29, label %28
+
+; <label>:28                                      ; preds = %24
+  store i32 128, i32* %arg3
+  br label %29
+
+; <label>:29                                      ; preds = %24, %28
   %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %32 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %31, i32 0, i32 4
-  %33 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %32, align 8
-  %34 = load i32, i32* %arg3
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %33 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 96
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 16
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %44 = call i32 %43(%System.Text.Encoding addrspace(1)* %33, i32 %34)
-  %45 = sext i32 %44 to i64
-  %46 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %45)
-  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 6
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %47, %"System.Byte[]" addrspace(1)* %46)
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %49 = load i32, i32* %arg3
-  %50 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 10
-  store i32 %49, i32 addrspace(1)* %50
-  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %52 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %51, i32 0, i32 3
-  %53 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %52, align 8
-  %54 = bitcast %System.IO.Stream addrspace(1)* %53 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 64
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 40
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i8 (%System.IO.Stream addrspace(1)*)*
-  %63 = call i8 %62(%System.IO.Stream addrspace(1)* %53)
-  %64 = zext i8 %63 to i32
-  %65 = icmp eq i32 %64, 0
-  br i1 %65, label %84, label %66
+  %31 = load i32, i32* %arg3
+  %32 = sext i32 %31 to i64
+  %33 = call %"System.Char[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Char[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %32)
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %30, null
+  br i1 %NullCheck10, label %34, label %ThrowNullRef9
 
-; <label>:66                                      ; preds = %24
-  %67 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %68 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %67, i32 0, i32 3
-  %69 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %68, align 8
-  %70 = bitcast %System.IO.Stream addrspace(1)* %69 to i64 addrspace(1)*
-  %71 = load i64, i64 addrspace(1)* %70
-  %72 = add i64 %71, 72
-  %73 = inttoptr i64 %72 to i64*
-  %74 = load i64, i64* %73
-  %75 = add i64 %74, 8
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
-  %78 = inttoptr i64 %77 to i64 (%System.IO.Stream addrspace(1)*)*
-  %79 = call i64 %78(%System.IO.Stream addrspace(1)* %69)
-  %80 = icmp sle i64 %79, 0
-  br i1 %80, label %84, label %81
+; <label>:34                                      ; preds = %29
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)* addrspace(1)*, %"System.Char[]" addrspace(1)*)*)(%"System.Char[]" addrspace(1)* addrspace(1)* %35, %"System.Char[]" addrspace(1)* %33)
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %37, null
+  br i1 %NullCheck12, label %38, label %ThrowNullRef11
 
-; <label>:81                                      ; preds = %66
-  %82 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %82, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %83
-  br label %84
+; <label>:38                                      ; preds = %34
+  %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
+  %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
+  %41 = load i32, i32* %arg3
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
+  %NullCheck14 = icmp ne i64 addrspace(1)* %42, null
+  br i1 %NullCheck14, label %43, label %ThrowNullRef13
 
-; <label>:84                                      ; preds = %24, %66, %81
-  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %86 = load i8, i8* %arg4
-  %87 = zext i8 %86 to i32
-  %88 = icmp eq i32 %87, 0
-  %89 = sext i1 %88 to i32
-  %90 = trunc i32 %89 to i8
-  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 13
-  store i8 %90, i8 addrspace(1)* %91
+; <label>:43                                      ; preds = %38
+  %44 = load i64, i64 addrspace(1)* %42
+  %45 = add i64 %44, 96
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = add i64 %47, 16
+  %49 = inttoptr i64 %48 to i64*
+  %50 = load i64, i64* %49
+  %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
+  %53 = sext i32 %52 to i64
+  %54 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 %53)
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck16, label %55, label %ThrowNullRef15
+
+; <label>:55                                      ; preds = %43
+  %56 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Byte[]" addrspace(1)* addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(%"System.Byte[]" addrspace(1)* addrspace(1)* %56, %"System.Byte[]" addrspace(1)* %54)
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = load i32, i32* %arg3
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck18, label %59, label %ThrowNullRef17
+
+; <label>:59                                      ; preds = %55
+  %60 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 10
+  store i32 %58, i32 addrspace(1)* %60
+  %61 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %61, null
+  br i1 %NullCheck20, label %62, label %ThrowNullRef19
+
+; <label>:62                                      ; preds = %59
+  %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
+  %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
+  %NullCheck22 = icmp ne i64 addrspace(1)* %65, null
+  br i1 %NullCheck22, label %66, label %ThrowNullRef21
+
+; <label>:66                                      ; preds = %62
+  %67 = load i64, i64 addrspace(1)* %65
+  %68 = add i64 %67, 64
+  %69 = inttoptr i64 %68 to i64*
+  %70 = load i64, i64* %69
+  %71 = add i64 %70, 40
+  %72 = inttoptr i64 %71 to i64*
+  %73 = load i64, i64* %72
+  %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
+  %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
+  %76 = zext i8 %75 to i32
+  %77 = icmp eq i32 %76, 0
+  br i1 %77, label %99, label %78
+
+; <label>:78                                      ; preds = %66
+  %79 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %79, null
+  br i1 %NullCheck24, label %80, label %ThrowNullRef23
+
+; <label>:80                                      ; preds = %78
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
+  %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
+  %NullCheck26 = icmp ne i64 addrspace(1)* %83, null
+  br i1 %NullCheck26, label %84, label %ThrowNullRef25
+
+; <label>:84                                      ; preds = %80
+  %85 = load i64, i64 addrspace(1)* %83
+  %86 = add i64 %85, 72
+  %87 = inttoptr i64 %86 to i64*
+  %88 = load i64, i64* %87
+  %89 = add i64 %88, 8
+  %90 = inttoptr i64 %89 to i64*
+  %91 = load i64, i64* %90
+  %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
+  %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
+  %94 = icmp sle i64 %93, 0
+  br i1 %94, label %99, label %95
+
+; <label>:95                                      ; preds = %84
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck28 = icmp ne %System.IO.StreamWriter addrspace(1)* %96, null
+  br i1 %NullCheck28, label %97, label %ThrowNullRef27
+
+; <label>:97                                      ; preds = %95
+  %98 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %98
+  br label %99
+
+; <label>:99                                      ; preds = %66, %84, %97
+  %100 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %101 = load i8, i8* %arg4
+  %102 = zext i8 %101 to i32
+  %103 = icmp eq i32 %102, 0
+  %104 = sext i1 %103 to i32
+  %105 = trunc i32 %104 to i8
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %100, null
+  br i1 %NullCheck30, label %106, label %ThrowNullRef29
+
+; <label>:106                                     ; preds = %99
+  %107 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %100, i32 0, i32 13
+  store i8 %105, i8 addrspace(1)* %107
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %29
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %55
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %59
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %62
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %78
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %95
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %99
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
@@ -8086,19 +11838,35 @@ entry:
   %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %4 = load i64, i64 addrspace(1)* %3
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
-  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
-  ret %System.Text.Encoder addrspace(1)* %12
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %4, null
+  br i1 %NullCheck2, label %5, label %ThrowNullRef1
+
+; <label>:5                                       ; preds = %1
+  %6 = load i64, i64 addrspace(1)* %4
+  %7 = add i64 %6, 96
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = add i64 %9, 8
+  %11 = inttoptr i64 %10 to i64*
+  %12 = load i64, i64* %11
+  %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
+  ret %System.Text.Encoder addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
@@ -8146,34 +11914,66 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
   %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
-  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
-  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
-  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
-  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
-  br i1 %NullCheck, label %9, label %ThrowNullRef
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %2, null
+  br i1 %NullCheck, label %4, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
-  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
-  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
-  %14 = load i64, i64 addrspace(1)* %13
-  %15 = add i64 %14, 64
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = add i64 %17, 32
-  %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
-  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
-  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
-  call void %22(%System.Text.Encoder addrspace(1)* %21)
+; <label>:4                                       ; preds = %entry
+  %5 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %5, %System.Text.Encoding addrspace(1)* %3)
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
+
+; <label>:8                                       ; preds = %4
+  %9 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %7, i32 0, i32 3
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %9, align 8
+  %NullCheck4 = icmp ne %System.Text.Encoding addrspace(1)* %10, null
+  br i1 %NullCheck4, label %11, label %ThrowNullRef3
+
+; <label>:11                                      ; preds = %8
+  %12 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %10)
+  %NullCheck6 = icmp ne %System.Text.EncoderNLS addrspace(1)* %6, null
+  br i1 %NullCheck6, label %13, label %ThrowNullRef5
+
+; <label>:13                                      ; preds = %11
+  %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
+  %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
+  %NullCheck8 = icmp ne i64 addrspace(1)* %16, null
+  br i1 %NullCheck8, label %17, label %ThrowNullRef7
+
+; <label>:17                                      ; preds = %13
+  %18 = load i64, i64 addrspace(1)* %16
+  %19 = add i64 %18, 64
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = add i64 %21, 32
+  %23 = inttoptr i64 %22 to i64*
+  %24 = load i64, i64* %23
+  %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
+  %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %26(%System.Text.Encoder addrspace(1)* %25)
   ret void
 
 ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %13
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8199,9 +11999,17 @@ entry:
   %this = alloca %System.Text.Encoding addrspace(1)*
   store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
   %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
@@ -8212,32 +12020,64 @@ entry:
   %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
   store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
   %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
-  store i32 0, i32 addrspace(1)* %1
-  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
-  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
-  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
-  br i1 %5, label %19, label %6
+  %NullCheck = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
-  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
-  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
-  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
-  %12 = add i64 %11, 72
-  %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
-  %15 = add i64 %14, 8
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
-  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
-  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
-  br label %19
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %2
+  %3 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck2 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
 
-; <label>:19                                      ; preds = %entry, %6
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %3, i32 0, i32 2
+  %6 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %5, align 8
+  %7 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %6, null
+  br i1 %7, label %23, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %NullCheck4 = icmp ne %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, null
+  br i1 %NullCheck4, label %10, label %ThrowNullRef3
+
+; <label>:10                                      ; preds = %8
+  %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
+  %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %13, null
+  br i1 %NullCheck6, label %14, label %ThrowNullRef5
+
+; <label>:14                                      ; preds = %10
+  %15 = load i64, i64 addrspace(1)* %13
+  %16 = add i64 %15, 72
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 8
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
+  br label %23
+
+; <label>:23                                      ; preds = %4, %14
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %10
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
@@ -8250,20 +12090,36 @@ entry:
   store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
   store i32 %param1, i32* %arg1
   %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
-  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
-  %3 = load i32, i32* %arg1
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
-  %5 = load i64, i64 addrspace(1)* %4
-  %6 = add i64 %5, 96
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = add i64 %8, 16
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
-  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
-  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
-  ret i32 %13
+  %NullCheck = icmp ne %System.Text.ConsoleEncoding addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %5, null
+  br i1 %NullCheck2, label %6, label %ThrowNullRef1
+
+; <label>:6                                       ; preds = %1
+  %7 = load i64, i64 addrspace(1)* %5
+  %8 = add i64 %7, 96
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
+  ret i32 %15
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
@@ -8298,59 +12154,75 @@ entry:
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
   %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %15 = load i64, i64 addrspace(1)* %14
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
-  %19 = add i64 %18, 40
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
-  %22 = inttoptr i64 %21 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %23 = call i32 %22(%System.Text.EncoderFallback addrspace(1)* %13)
-  %24 = icmp sle i32 %23, 1
-  br i1 %24, label %42, label %25
+  %NullCheck = icmp ne i64 addrspace(1)* %14, null
+  br i1 %NullCheck, label %15, label %ThrowNullRef
 
-; <label>:25                                      ; preds = %7
-  %26 = load i64, i64* %loc0
-  %27 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %28 = bitcast %System.Text.UTF8Encoding addrspace(1)* %27 to %System.Text.Encoding addrspace(1)*
-  %29 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %28)
-  %30 = bitcast %System.Text.EncoderFallback addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
-  %32 = add i64 %31, 64
-  %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
-  %35 = add i64 %34, 40
-  %36 = inttoptr i64 %35 to i64*
-  %37 = load i64, i64* %36
-  %38 = inttoptr i64 %37 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
-  %39 = call i32 %38(%System.Text.EncoderFallback addrspace(1)* %29)
-  %40 = sext i32 %39 to i64
-  %41 = mul i64 %26, %40
-  store i64 %41, i64* %loc0
-  br label %42
+; <label>:15                                      ; preds = %7
+  %16 = load i64, i64 addrspace(1)* %14
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 40
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
+  %25 = icmp sle i32 %24, 1
+  br i1 %25, label %44, label %26
 
-; <label>:42                                      ; preds = %7, %25
-  %43 = load i64, i64* %loc0
-  %44 = mul i64 %43, 3
-  store i64 %44, i64* %loc0
+; <label>:26                                      ; preds = %15
+  %27 = load i64, i64* %loc0
+  %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
+  %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %31, null
+  br i1 %NullCheck2, label %32, label %ThrowNullRef1
+
+; <label>:32                                      ; preds = %26
+  %33 = load i64, i64 addrspace(1)* %31
+  %34 = add i64 %33, 64
+  %35 = inttoptr i64 %34 to i64*
+  %36 = load i64, i64* %35
+  %37 = add i64 %36, 40
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
+  %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
+  %42 = sext i32 %41 to i64
+  %43 = mul i64 %27, %42
+  store i64 %43, i64* %loc0
+  br label %44
+
+; <label>:44                                      ; preds = %15, %32
   %45 = load i64, i64* %loc0
-  %46 = icmp sle i64 %45, 2147483647
-  br i1 %46, label %52, label %47
+  %46 = mul i64 %45, 3
+  store i64 %46, i64* %loc0
+  %47 = load i64, i64* %loc0
+  %48 = icmp sle i64 %47, 2147483647
+  br i1 %48, label %54, label %49
 
-; <label>:47                                      ; preds = %42
-  %48 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %50 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %49)
-  %51 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51, %System.String addrspace(1)* %48, %System.String addrspace(1)* %50)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %51) #0
+; <label>:49                                      ; preds = %44
+  %50 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %51 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %52 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %51)
+  %53 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53, %System.String addrspace(1)* %50, %System.String addrspace(1)* %52)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %53) #0
   unreachable
 
-; <label>:52                                      ; preds = %42
-  %53 = load i64, i64* %loc0
-  %54 = trunc i64 %53 to i32
-  ret i32 %54
+; <label>:54                                      ; preds = %44
+  %55 = load i64, i64* %loc0
+  %56 = trunc i64 %55 to i32
+  ret i32 %56
+
+ThrowNullRef:                                     ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %26
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
@@ -8361,11 +12233,27 @@ entry:
   %this = alloca %System.Text.EncoderReplacementFallback addrspace(1)*
   store %System.Text.EncoderReplacementFallback addrspace(1)* %param0, %System.Text.EncoderReplacementFallback addrspace(1)** %this
   %0 = load %System.Text.EncoderReplacementFallback addrspace(1)*, %System.Text.EncoderReplacementFallback addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %1, align 8
-  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
-  %4 = load i32, i32 addrspace(1)* %3
-  ret i32 %4
+  %NullCheck = icmp ne %System.Text.EncoderReplacementFallback addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.Text.EncoderReplacementFallback, %System.Text.EncoderReplacementFallback addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %3, null
+  br i1 %NullCheck2, label %4, label %ThrowNullRef1
+
+; <label>:4                                       ; preds = %1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %3, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  ret i32 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::get_CanSeek using LLILCJit
@@ -8393,20 +12281,28 @@ entry:
   %2 = load i8, i8* %arg1
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
-  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
-  store i8 %4, i8 addrspace(1)* %5
-  %6 = load i8, i8* %arg1
-  %7 = zext i8 %6 to i32
-  %8 = icmp eq i32 %7, 0
-  br i1 %8, label %11, label %9
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %1, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
-  br label %11
+; <label>:5                                       ; preds = %entry
+  %6 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %6
+  %7 = load i8, i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
 
-; <label>:11                                      ; preds = %entry, %9
+; <label>:10                                      ; preds = %5
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %11, i8 1, i8 0)
+  br label %12
+
+; <label>:12                                      ; preds = %5, %10
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
@@ -8418,36 +12314,44 @@ entry:
   %loc0 = alloca %System.Threading.Tasks.Task addrspace(1)*
   store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
-  %2 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Threading.Tasks.Task addrspace(1)* %2, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %3 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %4 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %3, null
-  br i1 %4, label %15, label %5
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:5                                       ; preds = %entry
-  %6 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
-  %NullCheck = icmp ne %System.Threading.Tasks.Task addrspace(1)* %6, null
-  br i1 %NullCheck, label %7, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 8
+  %3 = load volatile %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Threading.Tasks.Task addrspace(1)* %3, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %4 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %5 = icmp eq %System.Threading.Tasks.Task addrspace(1)* %4, null
+  br i1 %5, label %16, label %6
 
-; <label>:7                                       ; preds = %5
-  %8 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %6)
-  %9 = zext i8 %8 to i32
-  %10 = icmp ne i32 %9, 0
-  br i1 %10, label %15, label %11
+; <label>:6                                       ; preds = %1
+  %7 = load %System.Threading.Tasks.Task addrspace(1)*, %System.Threading.Tasks.Task addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.Threading.Tasks.Task addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:11                                      ; preds = %7
-  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
-  %14 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14, %System.String addrspace(1)* %13)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %14) #0
+; <label>:8                                       ; preds = %6
+  %9 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Threading.Tasks.Task addrspace(1)*)*)(%System.Threading.Tasks.Task addrspace(1)* %7)
+  %10 = zext i8 %9 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %13)
+  %15 = call %System.InvalidOperationException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.InvalidOperationException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*, %System.String addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15, %System.String addrspace(1)* %14)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.InvalidOperationException addrspace(1)*)*)(%System.InvalidOperationException addrspace(1)* %15) #0
   unreachable
 
-; <label>:15                                      ; preds = %entry, %7
+; <label>:16                                      ; preds = %1, %8
   ret void
 
-ThrowNullRef:                                     ; preds = %5
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8466,177 +12370,345 @@ entry:
   store i8 %param1, i8* %arg1
   store i8 %param2, i8* %arg2
   %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
-  br i1 %3, label %5, label %4
+  %NullCheck = icmp ne %System.IO.StreamWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IO.Stream addrspace(1)* %3, null
+  br i1 %4, label %6, label %5
+
+; <label>:5                                       ; preds = %1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
-  br label %5
+  br label %6
 
-; <label>:5                                       ; preds = %entry, %4
-  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
-  %8 = load i32, i32 addrspace(1)* %7, align 8
-  %9 = icmp ne i32 %8, 0
-  br i1 %9, label %23, label %10
+; <label>:6                                       ; preds = %1, %5
+  %7 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %7, null
+  br i1 %NullCheck2, label %8, label %ThrowNullRef1
 
-; <label>:10                                      ; preds = %5
-  %11 = load i8, i8* %arg1
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %18, label %14
+; <label>:8                                       ; preds = %6
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %7, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %25, label %12
 
-; <label>:14                                      ; preds = %10
-  %15 = load i8, i8* %arg2
-  %16 = zext i8 %15 to i32
-  %17 = icmp eq i32 %16, 0
-  br i1 %17, label %22, label %18
+; <label>:12                                      ; preds = %8
+  %13 = load i8, i8* %arg1
+  %14 = zext i8 %13 to i32
+  %15 = icmp ne i32 %14, 0
+  br i1 %15, label %20, label %16
 
-; <label>:18                                      ; preds = %10, %14
-  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %23, label %22
+; <label>:16                                      ; preds = %12
+  %17 = load i8, i8* %arg2
+  %18 = zext i8 %17 to i32
+  %19 = icmp eq i32 %18, 0
+  br i1 %19, label %24, label %20
 
-; <label>:22                                      ; preds = %14, %18
+; <label>:20                                      ; preds = %12, %16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %22 = zext i8 %21 to i32
+  %23 = icmp eq i32 %22, 0
+  br i1 %23, label %25, label %24
+
+; <label>:24                                      ; preds = %16, %20
   ret void
 
-; <label>:23                                      ; preds = %5, %18
-  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
-  %26 = load i8, i8 addrspace(1)* %25, align 8
-  %27 = zext i8 %26 to i32
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %70, label %29
+; <label>:25                                      ; preds = %8, %20
+  %26 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %26, null
+  br i1 %NullCheck4, label %27, label %ThrowNullRef3
 
-; <label>:29                                      ; preds = %23
-  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
-  store i8 1, i8 addrspace(1)* %31
-  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
-  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
-  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
-  %37 = add i64 %36, 64
-  %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
-  %40 = add i64 %39, 40
-  %41 = inttoptr i64 %40 to i64*
-  %42 = load i64, i64* %41
-  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
-  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
-  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
-  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
-  %47 = load i32, i32 addrspace(1)* %46
-  %48 = zext i32 %47 to i64
-  %49 = trunc i64 %48 to i32
-  %50 = icmp sle i32 %49, 0
-  br i1 %50, label %70, label %51
+; <label>:27                                      ; preds = %25
+  %28 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %26, i32 0, i32 12
+  %29 = load i8, i8 addrspace(1)* %28, align 8
+  %30 = zext i8 %29 to i32
+  %31 = icmp ne i32 %30, 0
+  br i1 %31, label %80, label %32
 
-; <label>:51                                      ; preds = %29
-  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
-  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
-  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
-  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
-  %58 = load i32, i32 addrspace(1)* %57
-  %59 = zext i32 %58 to i64
-  %60 = trunc i64 %59 to i32
-  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
-  %63 = add i64 %62, 88
-  %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
-  %66 = add i64 %65, 56
-  %67 = inttoptr i64 %66 to i64*
-  %68 = load i64, i64* %67
-  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
-  br label %70
+; <label>:32                                      ; preds = %27
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %33, null
+  br i1 %NullCheck6, label %34, label %ThrowNullRef5
 
-; <label>:70                                      ; preds = %23, %29, %51
-  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
-  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
-  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
-  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
-  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
-  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
-  %83 = load i8, i8* %arg2
-  %84 = zext i8 %83 to i32
-  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
-  %86 = load i64, i64 addrspace(1)* %85
-  %87 = add i64 %86, 64
-  %88 = inttoptr i64 %87 to i64*
-  %89 = load i64, i64* %88
-  %90 = add i64 %89, 56
-  %91 = inttoptr i64 %90 to i64*
-  %92 = load i64, i64* %91
-  %93 = trunc i32 %84 to i8
-  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
-  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
-  store i32 %95, i32* %loc1
-  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
-  store i32 0, i32 addrspace(1)* %97
-  %98 = load i32, i32* %loc1
-  %99 = icmp sle i32 %98, 0
-  br i1 %99, label %117, label %100
+; <label>:34                                      ; preds = %32
+  %35 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %35
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %36, null
+  br i1 %NullCheck8, label %37, label %ThrowNullRef7
 
-; <label>:100                                     ; preds = %70
-  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
-  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
-  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
-  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
-  %107 = load i32, i32* %loc1
-  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
-  %110 = add i64 %109, 88
-  %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
-  %113 = add i64 %112, 56
-  %114 = inttoptr i64 %113 to i64*
-  %115 = load i64, i64* %114
-  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
-  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
-  br label %117
+; <label>:37                                      ; preds = %34
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
+  %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
+  %NullCheck10 = icmp ne i64 addrspace(1)* %40, null
+  br i1 %NullCheck10, label %41, label %ThrowNullRef9
 
-; <label>:117                                     ; preds = %70, %100
-  %118 = load i8, i8* %arg1
-  %119 = zext i8 %118 to i32
-  %120 = icmp eq i32 %119, 0
-  br i1 %120, label %134, label %121
+; <label>:41                                      ; preds = %37
+  %42 = load i64, i64 addrspace(1)* %40
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 40
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
+  store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
+  %51 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck12 = icmp ne %"System.Byte[]" addrspace(1)* %51, null
+  br i1 %NullCheck12, label %52, label %ThrowNullRef11
 
-; <label>:121                                     ; preds = %117
-  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
-  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
-  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
-  %126 = load i64, i64 addrspace(1)* %125
-  %127 = add i64 %126, 80
-  %128 = inttoptr i64 %127 to i64*
-  %129 = load i64, i64* %128
-  %130 = add i64 %129, 24
-  %131 = inttoptr i64 %130 to i64*
-  %132 = load i64, i64* %131
-  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
-  call void %133(%System.IO.Stream addrspace(1)* %124)
-  br label %134
+; <label>:52                                      ; preds = %41
+  %53 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %51, i32 0, i32 1
+  %54 = load i32, i32 addrspace(1)* %53
+  %55 = zext i32 %54 to i64
+  %56 = trunc i64 %55 to i32
+  %57 = icmp sle i32 %56, 0
+  br i1 %57, label %80, label %58
 
-; <label>:134                                     ; preds = %117, %121
+; <label>:58                                      ; preds = %52
+  %59 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %59, null
+  br i1 %NullCheck14, label %60, label %ThrowNullRef13
+
+; <label>:60                                      ; preds = %58
+  %61 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %59, i32 0, i32 3
+  %62 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %61, align 8
+  %63 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %64 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %NullCheck16 = icmp ne %"System.Byte[]" addrspace(1)* %64, null
+  br i1 %NullCheck16, label %65, label %ThrowNullRef15
+
+; <label>:65                                      ; preds = %60
+  %66 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %64, i32 0, i32 1
+  %67 = load i32, i32 addrspace(1)* %66
+  %68 = zext i32 %67 to i64
+  %69 = trunc i64 %68 to i32
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
+  %NullCheck18 = icmp ne i64 addrspace(1)* %70, null
+  br i1 %NullCheck18, label %71, label %ThrowNullRef17
+
+; <label>:71                                      ; preds = %65
+  %72 = load i64, i64 addrspace(1)* %70
+  %73 = add i64 %72, 88
+  %74 = inttoptr i64 %73 to i64*
+  %75 = load i64, i64* %74
+  %76 = add i64 %75, 56
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
+  br label %80
+
+; <label>:80                                      ; preds = %27, %52, %71
+  %81 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck20 = icmp ne %System.IO.StreamWriter addrspace(1)* %81, null
+  br i1 %NullCheck20, label %82, label %ThrowNullRef19
+
+; <label>:82                                      ; preds = %80
+  %83 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %81, i32 0, i32 5
+  %84 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %83, align 8
+  %85 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck22 = icmp ne %System.IO.StreamWriter addrspace(1)* %85, null
+  br i1 %NullCheck22, label %86, label %ThrowNullRef21
+
+; <label>:86                                      ; preds = %82
+  %87 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %85, i32 0, i32 7
+  %88 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %87, align 8
+  %89 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck24 = icmp ne %System.IO.StreamWriter addrspace(1)* %89, null
+  br i1 %NullCheck24, label %90, label %ThrowNullRef23
+
+; <label>:90                                      ; preds = %86
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %89, i32 0, i32 9
+  %92 = load i32, i32 addrspace(1)* %91, align 8
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck26 = icmp ne %System.IO.StreamWriter addrspace(1)* %93, null
+  br i1 %NullCheck26, label %94, label %ThrowNullRef25
+
+; <label>:94                                      ; preds = %90
+  %95 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 6
+  %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
+  %97 = load i8, i8* %arg2
+  %98 = zext i8 %97 to i32
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
+  %NullCheck28 = icmp ne i64 addrspace(1)* %99, null
+  br i1 %NullCheck28, label %100, label %ThrowNullRef27
+
+; <label>:100                                     ; preds = %94
+  %101 = load i64, i64 addrspace(1)* %99
+  %102 = add i64 %101, 64
+  %103 = inttoptr i64 %102 to i64*
+  %104 = load i64, i64* %103
+  %105 = add i64 %104, 56
+  %106 = inttoptr i64 %105 to i64*
+  %107 = load i64, i64* %106
+  %108 = trunc i32 %98 to i8
+  %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
+  store i32 %110, i32* %loc1
+  %111 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck30 = icmp ne %System.IO.StreamWriter addrspace(1)* %111, null
+  br i1 %NullCheck30, label %112, label %ThrowNullRef29
+
+; <label>:112                                     ; preds = %100
+  %113 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %111, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %113
+  %114 = load i32, i32* %loc1
+  %115 = icmp sle i32 %114, 0
+  br i1 %115, label %136, label %116
+
+; <label>:116                                     ; preds = %112
+  %117 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck32 = icmp ne %System.IO.StreamWriter addrspace(1)* %117, null
+  br i1 %NullCheck32, label %118, label %ThrowNullRef31
+
+; <label>:118                                     ; preds = %116
+  %119 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %117, i32 0, i32 3
+  %120 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %119, align 8
+  %121 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck34 = icmp ne %System.IO.StreamWriter addrspace(1)* %121, null
+  br i1 %NullCheck34, label %122, label %ThrowNullRef33
+
+; <label>:122                                     ; preds = %118
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
+  %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
+  %125 = load i32, i32* %loc1
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
+  %NullCheck36 = icmp ne i64 addrspace(1)* %126, null
+  br i1 %NullCheck36, label %127, label %ThrowNullRef35
+
+; <label>:127                                     ; preds = %122
+  %128 = load i64, i64 addrspace(1)* %126
+  %129 = add i64 %128, 88
+  %130 = inttoptr i64 %129 to i64*
+  %131 = load i64, i64* %130
+  %132 = add i64 %131, 56
+  %133 = inttoptr i64 %132 to i64*
+  %134 = load i64, i64* %133
+  %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
+  br label %136
+
+; <label>:136                                     ; preds = %112, %127
+  %137 = load i8, i8* %arg1
+  %138 = zext i8 %137 to i32
+  %139 = icmp eq i32 %138, 0
+  br i1 %139, label %155, label %140
+
+; <label>:140                                     ; preds = %136
+  %141 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck38 = icmp ne %System.IO.StreamWriter addrspace(1)* %141, null
+  br i1 %NullCheck38, label %142, label %ThrowNullRef37
+
+; <label>:142                                     ; preds = %140
+  %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
+  %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
+  %NullCheck40 = icmp ne i64 addrspace(1)* %145, null
+  br i1 %NullCheck40, label %146, label %ThrowNullRef39
+
+; <label>:146                                     ; preds = %142
+  %147 = load i64, i64 addrspace(1)* %145
+  %148 = add i64 %147, 80
+  %149 = inttoptr i64 %148 to i64*
+  %150 = load i64, i64* %149
+  %151 = add i64 %150, 24
+  %152 = inttoptr i64 %151 to i64*
+  %153 = load i64, i64* %152
+  %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
+  call void %154(%System.IO.Stream addrspace(1)* %144)
+  br label %155
+
+; <label>:155                                     ; preds = %136, %146
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %32
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %34
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %41
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %58
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %60
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %65
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef19:                                   ; preds = %80
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef21:                                   ; preds = %82
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef23:                                   ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef25:                                   ; preds = %90
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef27:                                   ; preds = %94
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef29:                                   ; preds = %100
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef31:                                   ; preds = %116
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef33:                                   ; preds = %118
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef35:                                   ; preds = %122
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef37:                                   ; preds = %140
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef39:                                   ; preds = %142
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
@@ -8701,27 +12773,51 @@ entry:
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %1 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
-  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %2, %System.Object addrspace(1)* %1)
-  %3 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %4 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
-  %7 = add i64 %6, 64
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
-  %10 = add i64 %9, 32
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
-  %13 = inttoptr i64 %12 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
-  %14 = call %System.IFormatProvider addrspace(1)* %13(%System.IO.TextWriter addrspace(1)* %4)
-  %15 = bitcast %System.IO.SyncTextWriter addrspace(1)* %3 to %System.IO.TextWriter addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %15, %System.IFormatProvider addrspace(1)* %14)
-  %16 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %17 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %18 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %16, i32 0, i32 4
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %18, %System.IO.TextWriter addrspace(1)* %17)
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
+
+; <label>:2                                       ; preds = %entry
+  %3 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
+  %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
+  %NullCheck2 = icmp ne i64 addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %2
+  %8 = load i64, i64 addrspace(1)* %6
+  %9 = add i64 %8, 64
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 32
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
+  %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %17, %System.IFormatProvider addrspace(1)* %16)
+  %18 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %19 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %18, null
+  br i1 %NullCheck4, label %20, label %ThrowNullRef3
+
+; <label>:20                                      ; preds = %7
+  %21 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %18, i32 0, i32 4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)* addrspace(1)*, %System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* addrspace(1)* %21, %System.IO.TextWriter addrspace(1)* %19)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::get_FormatProvider using LLILCJit
@@ -8732,28 +12828,44 @@ entry:
   %this = alloca %System.IO.TextWriter addrspace(1)*
   store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %1, align 8
-  %3 = icmp ne %System.IFormatProvider addrspace(1)* %2, null
-  br i1 %3, label %9, label %4
+  %NullCheck = icmp ne %System.IO.TextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:4                                       ; preds = %entry
-  %5 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
-  %NullCheck = icmp ne %System.Threading.Thread addrspace(1)* %5, null
-  br i1 %NullCheck, label %6, label %ThrowNullRef
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %0, i32 0, i32 2
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %2, align 8
+  %4 = icmp ne %System.IFormatProvider addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
 
-; <label>:6                                       ; preds = %4
-  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %5)
-  %8 = bitcast %System.Globalization.CultureInfo addrspace(1)* %7 to %System.IFormatProvider addrspace(1)*
-  ret %System.IFormatProvider addrspace(1)* %8
+; <label>:5                                       ; preds = %1
+  %6 = call %System.Threading.Thread addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Threading.Thread addrspace(1)* ()*)()
+  %NullCheck2 = icmp ne %System.Threading.Thread addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
 
-; <label>:9                                       ; preds = %entry
-  %10 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %11 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %10, i32 0, i32 2
-  %12 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %11, align 8
-  ret %System.IFormatProvider addrspace(1)* %12
+; <label>:7                                       ; preds = %5
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %6)
+  %9 = bitcast %System.Globalization.CultureInfo addrspace(1)* %8 to %System.IFormatProvider addrspace(1)*
+  ret %System.IFormatProvider addrspace(1)* %9
 
-ThrowNullRef:                                     ; preds = %4
+; <label>:10                                      ; preds = %1
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.TextWriter addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %10
+  %13 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %11, i32 0, i32 2
+  %14 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)* addrspace(1)* %13, align 8
+  ret %System.IFormatProvider addrspace(1)* %14
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %10
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
@@ -8950,44 +13062,68 @@ entry:
   store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
   store i8 0, i8* %loc1
   %0 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %1 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
-  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %1, align 8
-  store %System.Object addrspace(1)* %2, %System.Object addrspace(1)** %loc0
-  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  %4 = addrspacecast i8* %loc1 to i8 addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %4)
-  %5 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
-  %6 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %5, i32 0, i32 4
-  %7 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %6, align 8
-  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %9 = bitcast %System.IO.TextWriter addrspace(1)* %7 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
-  %11 = add i64 %10, 104
-  %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
-  %14 = add i64 %13, 8
+  %NullCheck = icmp ne %System.IO.SyncTextWriter addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.Object addrspace(1)*, %System.Object addrspace(1)* addrspace(1)* %2, align 8
+  store %System.Object addrspace(1)* %3, %System.Object addrspace(1)** %loc0
+  %4 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  %5 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %4, i8 addrspace(1)* %5)
+  %6 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.SyncTextWriter addrspace(1)* %6, null
+  br i1 %NullCheck2, label %7, label %ThrowNullRef1
+
+; <label>:7                                       ; preds = %1
+  %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
+  %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
+  %NullCheck4 = icmp ne i64 addrspace(1)* %11, null
+  br i1 %NullCheck4, label %12, label %ThrowNullRef3
+
+; <label>:12                                      ; preds = %7
+  %13 = load i64, i64 addrspace(1)* %11
+  %14 = add i64 %13, 104
   %15 = inttoptr i64 %14 to i64*
   %16 = load i64, i64* %15
-  %17 = inttoptr i64 %16 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
-  call void %17(%System.IO.TextWriter addrspace(1)* %7, %System.String addrspace(1)* %8)
-  br label %18
+  %17 = add i64 %16, 8
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %9, %System.String addrspace(1)* %10)
+  br label %21
 
-; <label>:18                                      ; preds = %entry
-  %19 = load i8, i8* %loc1
-  %20 = zext i8 %19 to i32
-  %21 = icmp eq i32 %20, 0
-  br i1 %21, label %24, label %22
+; <label>:21                                      ; preds = %12
+  %22 = load i8, i8* %loc1
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %27, label %25
 
-; <label>:22                                      ; preds = %18
-  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
-  br label %24
+; <label>:25                                      ; preds = %21
+  %26 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %26)
+  br label %27
 
-; <label>:24                                      ; preds = %18, %22
-  br label %25
+; <label>:27                                      ; preds = %21, %25
+  br label %28
 
-; <label>:25                                      ; preds = %24
+; <label>:28                                      ; preds = %27
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %7
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
@@ -9051,116 +13187,196 @@ entry:
 
 ; <label>:23                                      ; preds = %15
   %24 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
-  %26 = load i32, i32 addrspace(1)* %25
-  %27 = zext i32 %26 to i64
-  %28 = trunc i64 %27 to i32
-  %29 = load i32, i32* %arg2
-  %30 = sub i32 %28, %29
-  %31 = load i32, i32* %arg3
-  %32 = icmp sge i32 %30, %31
-  br i1 %32, label %37, label %33
+  %NullCheck = icmp ne %"System.Char[]" addrspace(1)* %24, null
+  br i1 %NullCheck, label %25, label %ThrowNullRef
 
-; <label>:33                                      ; preds = %23
-  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
-  %35 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %34)
-  %36 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36, %System.String addrspace(1)* %35)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36) #0
+; <label>:25                                      ; preds = %23
+  %26 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = zext i32 %27 to i64
+  %29 = trunc i64 %28 to i32
+  %30 = load i32, i32* %arg2
+  %31 = sub i32 %29, %30
+  %32 = load i32, i32* %arg3
+  %33 = icmp sge i32 %31, %32
+  br i1 %33, label %38, label %34
+
+; <label>:34                                      ; preds = %25
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %37, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %37) #0
   unreachable
 
-; <label>:37                                      ; preds = %23
-  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %38)
-  br label %89
+; <label>:38                                      ; preds = %25
+  %39 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %39)
+  br label %98
 
-; <label>:39                                      ; preds = %89
-  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
-  %42 = load i32, i32 addrspace(1)* %41, align 8
-  %43 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %43, i32 0, i32 10
-  %45 = load i32, i32 addrspace(1)* %44, align 8
-  %46 = icmp ne i32 %42, %45
-  br i1 %46, label %49, label %47
+; <label>:40                                      ; preds = %98
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.IO.StreamWriter addrspace(1)* %41, null
+  br i1 %NullCheck4, label %42, label %ThrowNullRef3
 
-; <label>:47                                      ; preds = %39
-  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %48, i8 0, i8 0)
-  br label %49
+; <label>:42                                      ; preds = %40
+  %43 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck6 = icmp ne %System.IO.StreamWriter addrspace(1)* %45, null
+  br i1 %NullCheck6, label %46, label %ThrowNullRef5
 
-; <label>:49                                      ; preds = %39, %47
-  %50 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %51 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %50, i32 0, i32 10
-  %52 = load i32, i32 addrspace(1)* %51, align 8
+; <label>:46                                      ; preds = %42
+  %47 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %45, i32 0, i32 10
+  %48 = load i32, i32 addrspace(1)* %47, align 8
+  %49 = icmp ne i32 %44, %48
+  br i1 %49, label %52, label %50
+
+; <label>:50                                      ; preds = %46
+  %51 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %51, i8 0, i8 0)
+  br label %52
+
+; <label>:52                                      ; preds = %46, %50
   %53 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %54 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 9
-  %55 = load i32, i32 addrspace(1)* %54, align 8
-  %56 = sub i32 %52, %55
-  store i32 %56, i32* %loc0
-  %57 = load i32, i32* %loc0
-  %58 = load i32, i32* %arg3
-  %59 = icmp sle i32 %57, %58
-  br i1 %59, label %62, label %60
+  %NullCheck8 = icmp ne %System.IO.StreamWriter addrspace(1)* %53, null
+  br i1 %NullCheck8, label %54, label %ThrowNullRef7
 
-; <label>:60                                      ; preds = %49
-  %61 = load i32, i32* %arg3
+; <label>:54                                      ; preds = %52
+  %55 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 10
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck10 = icmp ne %System.IO.StreamWriter addrspace(1)* %57, null
+  br i1 %NullCheck10, label %58, label %ThrowNullRef9
+
+; <label>:58                                      ; preds = %54
+  %59 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 9
+  %60 = load i32, i32 addrspace(1)* %59, align 8
+  %61 = sub i32 %56, %60
   store i32 %61, i32* %loc0
-  br label %62
+  %62 = load i32, i32* %loc0
+  %63 = load i32, i32* %arg3
+  %64 = icmp sle i32 %62, %63
+  br i1 %64, label %67, label %65
 
-; <label>:62                                      ; preds = %49, %60
-  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
-  %64 = load i32, i32* %arg2
-  %65 = mul i32 %64, 2
-  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %67 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 7
-  %68 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %67, align 8
-  %69 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %70 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %69, i32 0, i32 9
-  %71 = load i32, i32 addrspace(1)* %70, align 8
-  %72 = mul i32 %71, 2
-  %73 = load i32, i32* %loc0
-  %74 = mul i32 %73, 2
-  %75 = bitcast %"System.Char[]" addrspace(1)* %63 to %System.Array addrspace(1)*
-  %76 = bitcast %"System.Char[]" addrspace(1)* %68 to %System.Array addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %75, i32 %65, %System.Array addrspace(1)* %76, i32 %72, i32 %74)
-  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  %79 = load i32, i32 addrspace(1)* %78, align 8
+; <label>:65                                      ; preds = %58
+  %66 = load i32, i32* %arg3
+  store i32 %66, i32* %loc0
+  br label %67
+
+; <label>:67                                      ; preds = %58, %65
+  %68 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %69 = load i32, i32* %arg2
+  %70 = mul i32 %69, 2
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck12 = icmp ne %System.IO.StreamWriter addrspace(1)* %71, null
+  br i1 %NullCheck12, label %72, label %ThrowNullRef11
+
+; <label>:72                                      ; preds = %67
+  %73 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 7
+  %74 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %73, align 8
+  %75 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck14 = icmp ne %System.IO.StreamWriter addrspace(1)* %75, null
+  br i1 %NullCheck14, label %76, label %ThrowNullRef13
+
+; <label>:76                                      ; preds = %72
+  %77 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %75, i32 0, i32 9
+  %78 = load i32, i32 addrspace(1)* %77, align 8
+  %79 = mul i32 %78, 2
   %80 = load i32, i32* %loc0
-  %81 = add i32 %79, %80
-  %82 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
-  store i32 %81, i32 addrspace(1)* %82
-  %83 = load i32, i32* %arg2
-  %84 = load i32, i32* %loc0
-  %85 = add i32 %83, %84
-  store i32 %85, i32* %arg2
-  %86 = load i32, i32* %arg3
-  %87 = load i32, i32* %loc0
-  %88 = sub i32 %86, %87
-  store i32 %88, i32* %arg3
-  br label %89
+  %81 = mul i32 %80, 2
+  %82 = bitcast %"System.Char[]" addrspace(1)* %68 to %System.Array addrspace(1)*
+  %83 = bitcast %"System.Char[]" addrspace(1)* %74 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %82, i32 %70, %System.Array addrspace(1)* %83, i32 %79, i32 %81)
+  %84 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck16 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck16, label %85, label %ThrowNullRef15
 
-; <label>:89                                      ; preds = %37, %62
-  %90 = load i32, i32* %arg3
-  %91 = icmp sgt i32 %90, 0
-  br i1 %91, label %39, label %92
+; <label>:85                                      ; preds = %76
+  %86 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
+  %87 = load i32, i32 addrspace(1)* %86, align 8
+  %88 = load i32, i32* %loc0
+  %89 = add i32 %87, %88
+  %NullCheck18 = icmp ne %System.IO.StreamWriter addrspace(1)* %84, null
+  br i1 %NullCheck18, label %90, label %ThrowNullRef17
 
-; <label>:92                                      ; preds = %89
-  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  %94 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 11
-  %95 = load i8, i8 addrspace(1)* %94, align 8
-  %96 = zext i8 %95 to i32
-  %97 = icmp eq i32 %96, 0
-  br i1 %97, label %100, label %98
+; <label>:90                                      ; preds = %85
+  %91 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %84, i32 0, i32 9
+  store i32 %89, i32 addrspace(1)* %91
+  %92 = load i32, i32* %arg2
+  %93 = load i32, i32* %loc0
+  %94 = add i32 %92, %93
+  store i32 %94, i32* %arg2
+  %95 = load i32, i32* %arg3
+  %96 = load i32, i32* %loc0
+  %97 = sub i32 %95, %96
+  store i32 %97, i32* %arg3
+  br label %98
 
-; <label>:98                                      ; preds = %92
-  %99 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %99, i8 1, i8 0)
-  br label %100
+; <label>:98                                      ; preds = %38, %90
+  %99 = load i32, i32* %arg3
+  %100 = icmp sgt i32 %99, 0
+  br i1 %100, label %40, label %101
 
-; <label>:100                                     ; preds = %92, %98
+; <label>:101                                     ; preds = %98
+  %102 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.StreamWriter addrspace(1)* %102, null
+  br i1 %NullCheck2, label %103, label %ThrowNullRef1
+
+; <label>:103                                     ; preds = %101
+  %104 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %102, i32 0, i32 11
+  %105 = load i8, i8 addrspace(1)* %104, align 8
+  %106 = zext i8 %105 to i32
+  %107 = icmp eq i32 %106, 0
+  br i1 %107, label %110, label %108
+
+; <label>:108                                     ; preds = %103
+  %109 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %109, i8 1, i8 0)
+  br label %110
+
+; <label>:110                                     ; preds = %103, %108
   ret void
+
+ThrowNullRef:                                     ; preds = %23
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %101
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %40
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %42
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %52
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef9:                                    ; preds = %54
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef11:                                   ; preds = %67
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef13:                                   ; preds = %72
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef15:                                   ; preds = %76
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef17:                                   ; preds = %85
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
@@ -9288,30 +13504,62 @@ entry:
   %40 = load i8, i8* %arg5
   %41 = zext i8 %40 to i32
   %42 = trunc i32 %41 to i8
-  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
-  store i8 %42, i8 addrspace(1)* %43
-  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
-  store i8 1, i8 addrspace(1)* %45
-  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
-  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
-  %49 = load i16*, i16** %arg1
-  %50 = load i32, i32* %arg2
-  %51 = load i8*, i8** %arg3
-  %52 = load i32, i32* %arg4
-  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
-  %55 = load i64, i64 addrspace(1)* %54
-  %56 = add i64 %55, 80
-  %57 = inttoptr i64 %56 to i64*
-  %58 = load i64, i64* %57
-  %59 = add i64 %58, 32
-  %60 = inttoptr i64 %59 to i64*
-  %61 = load i64, i64* %60
-  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
-  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
-  ret i32 %63
+  %NullCheck = icmp ne %System.Text.EncoderNLS addrspace(1)* %39, null
+  br i1 %NullCheck, label %43, label %ThrowNullRef
+
+; <label>:43                                      ; preds = %38
+  %44 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %44
+  %45 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.Text.EncoderNLS addrspace(1)* %45, null
+  br i1 %NullCheck2, label %46, label %ThrowNullRef1
+
+; <label>:46                                      ; preds = %43
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %45, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %47
+  %48 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %NullCheck4 = icmp ne %System.Text.EncoderNLS addrspace(1)* %48, null
+  br i1 %NullCheck4, label %49, label %ThrowNullRef3
+
+; <label>:49                                      ; preds = %46
+  %50 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %48, i32 0, i32 3
+  %51 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %50, align 8
+  %52 = load i16*, i16** %arg1
+  %53 = load i32, i32* %arg2
+  %54 = load i8*, i8** %arg3
+  %55 = load i32, i32* %arg4
+  %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
+  %NullCheck6 = icmp ne i64 addrspace(1)* %57, null
+  br i1 %NullCheck6, label %58, label %ThrowNullRef5
+
+; <label>:58                                      ; preds = %49
+  %59 = load i64, i64 addrspace(1)* %57
+  %60 = add i64 %59, 80
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = add i64 %62, 32
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
+  ret i32 %67
+
+ThrowNullRef:                                     ; preds = %38
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %43
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %46
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %49
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
@@ -9337,25 +13585,33 @@ entry:
   %4 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0 to %System.IO.ConsoleStream addrspace(1)*
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*)(%System.IO.ConsoleStream addrspace(1)* %4, %"System.Byte[]" addrspace(1)* %1, i32 %2, i32 %3)
   %5 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %6 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
-  %7 = load i64, i64 addrspace(1)* %6, align 8
-  %8 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %9 = load i32, i32* %arg2
-  %10 = load i32, i32* %arg3
-  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %7, %"System.Byte[]" addrspace(1)* %8, i32 %9, i32 %10)
-  store i32 %11, i32* %loc0
-  %12 = load i32, i32* %loc0
-  %13 = icmp eq i32 %12, 0
-  br i1 %13, label %17, label %14
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = load i32, i32* %loc0
-  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %15)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
+; <label>:6                                       ; preds = %entry
+  %7 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %5, i32 0, i32 7
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
+  %10 = load i32, i32* %arg2
+  %11 = load i32, i32* %arg3
+  %12 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, %"System.Byte[]" addrspace(1)*, i32, i32)*)(i64 %8, %"System.Byte[]" addrspace(1)* %9, i32 %10, i32 %11)
+  store i32 %12, i32* %loc0
+  %13 = load i32, i32* %loc0
+  %14 = icmp eq i32 %13, 0
+  br i1 %14, label %18, label %15
+
+; <label>:15                                      ; preds = %6
+  %16 = load i32, i32* %loc0
+  %17 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* (i32)*)(i32 %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %17) #0
   unreachable
 
-; <label>:17                                      ; preds = %entry
+; <label>:18                                      ; preds = %6
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::ValidateWrite using LLILCJit
@@ -9415,38 +13671,54 @@ entry:
 
 ; <label>:22                                      ; preds = %8
   %23 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %arg1
-  %24 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
-  %25 = load i32, i32 addrspace(1)* %24
-  %26 = zext i32 %25 to i64
-  %27 = trunc i64 %26 to i32
-  %28 = load i32, i32* %arg2
-  %29 = sub i32 %27, %28
-  %30 = load i32, i32* %arg3
-  %31 = icmp sge i32 %29, %30
-  br i1 %31, label %35, label %32
+  %NullCheck = icmp ne %"System.Byte[]" addrspace(1)* %23, null
+  br i1 %NullCheck, label %24, label %ThrowNullRef
 
-; <label>:32                                      ; preds = %22
-  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
-  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+; <label>:24                                      ; preds = %22
+  %25 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %23, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %36, label %33
+
+; <label>:33                                      ; preds = %24
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  %35 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %35) #0
   unreachable
 
-; <label>:35                                      ; preds = %22
-  %36 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %36, i32 0, i32 4
-  %38 = load i8, i8 addrspace(1)* %37, align 8
-  %39 = zext i8 %38 to i32
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %43, label %41
+; <label>:36                                      ; preds = %24
+  %37 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %NullCheck2 = icmp ne %System.IO.ConsoleStream addrspace(1)* %37, null
+  br i1 %NullCheck2, label %38, label %ThrowNullRef1
 
-; <label>:41                                      ; preds = %35
-  %42 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %42) #0
+; <label>:38                                      ; preds = %36
+  %39 = getelementptr inbounds %System.IO.ConsoleStream, %System.IO.ConsoleStream addrspace(1)* %37, i32 0, i32 4
+  %40 = load i8, i8 addrspace(1)* %39, align 8
+  %41 = zext i8 %40 to i32
+  %42 = icmp ne i32 %41, 0
+  br i1 %42, label %45, label %43
+
+; <label>:43                                      ; preds = %38
+  %44 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %44) #0
   unreachable
 
-; <label>:43                                      ; preds = %35
+; <label>:45                                      ; preds = %38
   ret void
+
+ThrowNullRef:                                     ; preds = %22
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %36
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
@@ -9459,23 +13731,31 @@ entry:
   %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
   store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
   %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
-  %2 = load i64, i64 addrspace(1)* %1, align 8
-  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
-  %4 = zext i8 %3 to i32
-  %5 = icmp eq i32 %4, 0
-  br i1 %5, label %8, label %6
+  %NullCheck = icmp ne %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, null
+  br i1 %NullCheck, label %1, label %ThrowNullRef
 
-; <label>:6                                       ; preds = %entry
-  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %3 = load i64, i64 addrspace(1)* %2, align 8
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %3, i64 0)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %1
+  %8 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %8) #0
   unreachable
 
-; <label>:8                                       ; preds = %entry
-  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
-  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+; <label>:9                                       ; preds = %1
+  %10 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %11 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %10 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %11)
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 INFO:  jitting method ConsoleStream::Flush using LLILCJit
@@ -9487,27 +13767,35 @@ entry:
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
   %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %2 = load i64, i64 addrspace(1)* %1
-  %3 = add i64 %2, 64
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load i64, i64* %4
-  %6 = add i64 %5, 56
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
-  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
-  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
-  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
-  %12 = zext i8 %11 to i32
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %16, label %14
+  %NullCheck = icmp ne i64 addrspace(1)* %1, null
+  br i1 %NullCheck, label %2, label %ThrowNullRef
 
-; <label>:14                                      ; preds = %entry
-  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
-  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+; <label>:2                                       ; preds = %entry
+  %3 = load i64, i64 addrspace(1)* %1
+  %4 = add i64 %3, 64
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
+  %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
+  %13 = zext i8 %12 to i32
+  %14 = icmp ne i32 %13, 0
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %2
+  %16 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %16) #0
   unreachable
 
-; <label>:16                                      ; preds = %entry
+; <label>:17                                      ; preds = %2
   ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
 }
 
 


### PR DESCRIPTION
Generate explicit compare+branch+throw sequences to check for null derefrence on loads and stores.  LLVM IR does not support annotating loads/stores as exception-bearing, and additionally this approach may simplify runtime porting to other targets since we'll generate explicit machine code for these tests and the runtime won't need to mess with machine traps.  The llilc-jit-eh.md document contains more information about the approach/rationale.

Introduce a mock configuration flag, UseExplicitNullChecks, on the Reader object (this leaves the old codepaths accessible to facilitate future experiments).
Extend the existing makeStore wrapper around LLVMBuilder::CreateStore, and add a similar makeLoad wrapper around LLVMBuilder::CreateLoad.  These wrappers take an AddressMayBeNull parameter, and generate the null check when the address may be null and UseExplicitNullChecks is true (which it always is).
Transitively propagate the AddressMayBeNull parameter up through any callers that are sometimes invoked to generate loads/stores for known-non-null pointers and sometimes for maybe-null pointers.
For each method that now takes an AddressMayBeNull parameter, default that parameter to true and add a -NonNull sibling method that passes false; this makes the callsites more readable.

Null checks are always emitted as an exact equality comparison against 0. For operations such as ldfld/stfld/ldlen, the check is performed against the base pointer (before adding the field offset), which will catch any null object references.
This test may not exactly match the Windows machine trap behavior when unsafe code is involved (though it does conform to the ECMA spec); in particular, ldind/ldfld/stind/stfld with a managed pointer base that is nonzero but in the guard page would raise a NullReferenceException from the machine trap but will not be caught by the checks inserted here.  This is a deliberate decision made after consultation with the CoreCLR team; the approach does guarantee that null dereferences from verifiable code will raise NullReferenceException (verifiable code cannot produce a nonzero managed pointer pointing into the guard page), and if unsafe code is used to construct not-quite-zero addresses which are subsequently dereferenced, it is acceptable for such dereferences to FailFast/SegFault/CoreDump/etc rather than raise NullReferenceException.

I've verified that there are no diffs if I recompile with the UseExplicitNullChecks flag set to false.

There are of course numerous diffs with the flag true; they look reasonable to me.

Closes #203
Resolves #204
Closes #63
